### PR TITLE
don't wait for DOMContentLoaded if it's already fired

### DIFF
--- a/lib/contracts/code_templates/define-when-env-loaded.js.ejs
+++ b/lib/contracts/code_templates/define-when-env-loaded.js.ejs
@@ -1,5 +1,5 @@
 var whenEnvIsLoaded = function(cb) {
-  if (typeof document !== 'undefined' && document !== null) {
+  if (typeof document !== 'undefined' && document !== null && !/comp|inter|loaded/.test(document.readyState)) {
       document.addEventListener('DOMContentLoaded', cb);
   } else {
     cb();


### PR DESCRIPTION
This pull request should improve the check for when the environment is loaded. In the situation of a browser plugin, for instance, it's possible the 'DOMContentLoaded' event has already fired so waiting for it will be fruitless.

test document.readyState and only add the DOMContentLoaded event listener if that event hasn't already fired.