### PR TITLE
Fix Windows Build due to PWD not existing

### DIFF
--- a/lib/contracts/code_generator.js
+++ b/lib/contracts/code_generator.js
@@ -289,6 +289,7 @@ class CodeGenerator {
         });
       },
       function getImports(web3Location, next) {
+        web3Location = web3Location.replace(/\\/g, '/'); // Import paths must always have forward slashes
         code += "\nimport Web3 from '" + web3Location + "';\n";
         code += "\nimport web3 from 'Embark/web3';\n";
         next();

--- a/lib/index.js
+++ b/lib/index.js
@@ -3,6 +3,15 @@ let async = require('async');
 
 require('colors');
 
+// Override process.chdir so that we have a partial-implementation PWD for Windows
+const realChdir = process.chdir;
+process.chdir = (...args) => {
+    if (!process.env.PWD) {
+        process.env.PWD = process.cwd();
+    }
+    realChdir(...args);
+};
+
 let Engine = require('./core/engine.js');
 
 let version = require('../package.json').version;

--- a/lib/pipeline/pipeline.js
+++ b/lib/pipeline/pipeline.js
@@ -26,6 +26,23 @@ class Pipeline {
 
     self.buildWeb3JS(function() {
 
+      let importsList = {};
+
+      importsList["Embark/EmbarkJS"] = fs.dappPath(".embark", 'embark.js');
+      importsList["Embark/web3"] = fs.dappPath(".embark", 'web3_instance.js');
+
+      self.plugins.getPluginsProperty('imports', 'imports').forEach(function (importObject) {
+          let [importName, importLocation] = importObject;
+          importsList[importName] = importLocation;
+      });
+
+      for (let contractName in contractsJSON) {
+          let contractCode = self.buildContractJS(contractName);
+          let filePath = fs.dappPath(".embark", contractName + '.js');
+          fs.writeFileSync(filePath, contractCode);
+          importsList["Embark/contracts/" + contractName] = filePath;
+      }
+
       // limit:1 due to issues when downloading required files such as web3.js
       async.eachOfLimit(self.assetFiles, 1, function (files, targetFile, cb) {
         // limit:1 due to issues when downloading required files such as web3.js
@@ -34,22 +51,6 @@ class Pipeline {
             self.logger.trace("reading " + file.filename);
 
             if (file.filename.indexOf('.js') >= 0) {
-              let importsList = {};
-
-              importsList["Embark/EmbarkJS"] = fs.dappPath(".embark", 'embark.js');
-              importsList["Embark/web3"] = fs.dappPath(".embark", 'web3_instance.js');
-
-              self.plugins.getPluginsProperty('imports', 'imports').forEach(function (importObject) {
-                let [importName, importLocation] = importObject;
-                importsList[importName] = importLocation;
-              });
-
-              for (let contractName in contractsJSON) {
-                let contractCode = self.buildContractJS(contractName);
-                let filePath = fs.dappPath(".embark", contractName + '.js');
-                fs.writeFileSync(filePath, contractCode);
-                importsList["Embark/contracts/" + contractName] = filePath;
-              }
 
               let realCwd;
 

--- a/lib/pipeline/pipeline.js
+++ b/lib/pipeline/pipeline.js
@@ -288,6 +288,7 @@ class Pipeline {
         });
       },
       function getImports(web3Location, next) {
+        web3Location = web3Location.replace(/\\/g, '/'); // Import paths must always have forward slashes
         code += "\nimport Web3 from '" + web3Location + "';\n";
 
         code += "\n if (typeof web3 !== 'undefined') {";


### PR DESCRIPTION
Since PWD doesn't exist on Windows, the paths to build were not correct. 
I fixed by overiding `chdir` so that when `process.env.pwd` doesn't exist, it sets it to CWD. That way, the first time `chdir` is called, PWD is set to the real current directory.

After fixing that, another issue appeared where the paths created by `path.join` used backslashes and where imported `web3\1.0.0-beta.27` failed because node thought that `\1` was an octal.

Finally, while looking at the code to find the original bug, I saw that we re-create the import list with every loop of files, so I moved it up.

I think everything works. Sadly, my PC currently sucks so I can't run a VM with Linux to check if I didn't break the Linux build. Could someone please check that out.