### PR TITLE
Fix console.dir messing up the console

### DIFF
--- a/lib/core/logger.js
+++ b/lib/core/logger.js
@@ -64,6 +64,16 @@ Logger.prototype.trace = function (txt) {
   this.writeToFile("[trace]: " + txt);
 };
 
+Logger.prototype.dir = function (txt) {
+  if (!txt || !(this.shouldLog('info'))) {
+    return;
+  }
+  this.events.emit("log", "dir", txt);
+  this.logFunction(txt);
+  this.writeToFile("[dir]: ");
+  this.writeToFile(txt);
+};
+
 Logger.prototype.shouldLog = function (level) {
   return (this.logLevels.indexOf(level) <= this.logLevels.indexOf(this.logLevel));
 };

--- a/lib/core/plugin.js
+++ b/lib/core/plugin.js
@@ -77,6 +77,9 @@ Plugin.prototype.interceptLogs = function(context) {
   context.console.trace  = function(txt) {
     self.logger.trace(self.name + " > " + txt);
   };
+  context.console.dir  = function(txt) {
+    self.logger.dir(txt);
+  };
 };
 
 // TODO: add deploy provider


### PR DESCRIPTION
Using console.dir in the embark console was being printed and overriding the console itself, it needed to be added to console logs overrides and passed to the logger instead.

It was not an issue with async console logs as previously thought