### PR TITLE
Fix weird characters in IPFS get by using ipfsConnection.get

### DIFF
--- a/lib/modules/ipfs/embarkjs.js
+++ b/lib/modules/ipfs/embarkjs.js
@@ -37,7 +37,7 @@ __embarkIPFS.saveText = function(text) {
       var connectionError = new Error('No IPFS connection. Please ensure to call Embark.Storage.setProvider()');
       reject(connectionError);
     }
-    self.ipfsConnection.add((new self.ipfsConnection.Buffer(text)), function(err, result) {
+    self.ipfsConnection.add(self.ipfsConnection.Buffer.from(text), function(err, result) {
       if (err) {
         reject(err);
       } else {
@@ -58,10 +58,11 @@ __embarkIPFS.get = function(hash) {
       var connectionError = new Error('No IPFS connection. Please ensure to call Embark.Storage.setProvider()');
       reject(connectionError);
     }
-    self.ipfsConnection.object.get(hash).then(function(node) {
-      resolve(node.data.toString());
-    }).catch(function(err) {
-      reject(err);
+    self.ipfsConnection.get(hash, function (err, files) {
+      if (err) {
+        return reject(err);
+      }
+      resolve(files[0].content.toString());
     });
   });
 


### PR DESCRIPTION
There was a bug in Windows (or my version of IPFS), where the result of `ipfsConnection.object.get` was something like this: test
Fixed by using `ipfsConnection.get` instead.
Please test on Linux or OsX to confirm it still works. Thanks.