### PR TITLE
Removed annoying [Object object] from the log that was appearing duri…

### DIFF
--- a/lib/modules/solidity/index.js
+++ b/lib/modules/solidity/index.js
@@ -75,7 +75,6 @@ class Solidity {
                 return callback(new Error("Solidity errors: " + output.errors[i].formattedMessage).message);
               }
             }
-            self.logger.warn(output.errors.join('\n'));
           }
           callback(null, output);
         });


### PR DESCRIPTION
…ng contract compilation.

The warnings in object that were attempted to be logged were already being logged in a previous loop, so this was simply removed.