### PR TITLE
Add Vyper contract support

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,12 +160,17 @@ Solidity/Serpent files in the contracts directory will automatically be deployed
 Libraries and languages available
 ======
 
-Embark can build and deploy contracts coded in Solidity. It will make them available on the client side using EmbarkJS and Web3.js.
+Embark can build and deploy contracts coded in Solidity and now also in Vyper. It will make them available on the client side using EmbarkJS and Web3.js.
 
 Further documentation for these can be found below:
 
-* Smart Contracts: [Solidity](https://solidity.readthedocs.io/en/develop/) and [Serpent](https://github.com/ethereum/wiki/wiki/Serpent)
+* Smart Contracts:
+    * [Solidity](https://solidity.readthedocs.io/en/develop/)
+    * [Vyper](https://vyper.readthedocs.io/en/latest/index.html)
+    * [Serpent](https://github.com/ethereum/wiki/wiki/Serpent)
 * Client Side: [Web3.js](https://github.com/ethereum/wiki/wiki/JavaScript-API) and [EmbarkJS](#embarkjs)
+
+However, to use Vyper, you need to have Vyper installed on you computer beforehand. Meaning that doing `vyper contract.v.py` is possible.
 
 Using Contracts
 ======

--- a/lib/contracts/compiler.js
+++ b/lib/contracts/compiler.js
@@ -7,9 +7,10 @@ class Compiler {
   }
 
   compile_contracts(contractFiles, cb) {
+    const self = this;
     let available_compilers = {};
 
-    let pluginCompilers = this.plugins.getPluginsProperty('compilers', 'compilers');
+    let pluginCompilers = self.plugins.getPluginsProperty('compilers', 'compilers');
     pluginCompilers.forEach(function (compilerObject) {
       available_compilers[compilerObject.extension] = compilerObject.cb;
     });
@@ -18,10 +19,13 @@ class Compiler {
 
     async.eachObject(available_compilers,
       function (extension, compiler, callback) {
-        // TODO: warn about files it doesn't know how to compile
         let matchingFiles = contractFiles.filter(function (file) {
           let fileMatch = file.filename.match(/\.[0-9a-z]+$/);
-          return (fileMatch && (fileMatch[0] === extension));
+          if (fileMatch && (fileMatch[0] === extension)) {
+            file.compiled = true;
+            return true;
+          }
+          return false;
         });
 
         compiler.call(compiler, matchingFiles || [], function (err, compileResult) {
@@ -30,6 +34,12 @@ class Compiler {
         });
       },
       function (err) {
+        contractFiles.forEach(file => {
+          if (!file.compiled) {
+              self.logger.warn(`${file.filename} doesn't have a compatible contract compiler. Maybe a plugin exists for it.`);
+          }
+        });
+
         cb(err, compiledObject);
       }
     );

--- a/lib/contracts/deploy.js
+++ b/lib/contracts/deploy.js
@@ -305,7 +305,8 @@ class Deploy {
         let contractObject = new self.web3.eth.Contract(contract.abiDefinition);
 
         try {
-          deployObject = contractObject.deploy({arguments: contractParams, data: "0x" + contractCode});
+          const dataCode = contractCode.startsWith('0x') ? contractCode : "0x" + contractCode;
+          deployObject = contractObject.deploy({arguments: contractParams, data: dataCode});
         } catch(e) {
           if (e.message.indexOf('Invalid number of parameters for "undefined"') >= 0) {
             return next(new Error("attempted to deploy " + contract.className + " without specifying parameters"));

--- a/lib/core/engine.js
+++ b/lib/core/engine.js
@@ -137,6 +137,9 @@ class Engine {
     this.registerModule('solidity', {
       contractDirectories: self.config.contractDirectories
     });
+    this.registerModule('vyper', {
+      contractDirectories: self.config.contractDirectories
+    });
 
     this.contractsManager = new ContractsManager({
       contractFiles: this.config.contractsFiles,

--- a/lib/modules/solidity/index.js
+++ b/lib/modules/solidity/index.js
@@ -49,7 +49,7 @@ class Solidity {
         });
       },
       function compileContracts(callback) {
-        self.logger.info("compiling contracts...");
+        self.logger.info("compiling solidity contracts...");
         let jsonObj =  {
           language: 'Solidity',
           sources: input,

--- a/lib/modules/vyper/index.js
+++ b/lib/modules/vyper/index.js
@@ -20,31 +20,34 @@ class Vyper {
         const compiled_object = {};
         async.each(contractFiles,
           function (file, fileCb) {
-            const fileNameOnly = path.basename(file.filename);
-            compiled_object[fileNameOnly] = {};
+            const className = path.basename(file.filename).split('.')[0];
+            compiled_object[className] = {};
             async.parallel([
               function getByteCode(paraCb) {
-                shelljs.exec(`vyper ${file.filename}`, { silent: true }, (code, stdout, stderr) => {
+                shelljs.exec(`vyper ${file.filename}`, {silent: true}, (code, stdout, stderr) => {
                   if (stderr) {
                     return paraCb(stderr);
                   }
                   if (code !== 0) {
-                    return paraCb(`Vyper exited with error code ${code}`)
+                    return paraCb(`Vyper exited with error code ${code}`);
                   }
                   if (!stdout) {
                     return paraCb('Execution returned no bytecode');
                   }
-                  compiled_object[fileNameOnly].code = stdout.replace(/\n/g, '');
+                  const byteCode = stdout.replace(/\n/g, '');
+                  compiled_object[className].runtimeBytecode = byteCode;
+                  compiled_object[className].realRuntimeBytecode = byteCode;
+                  compiled_object[className].code = byteCode;
                   paraCb();
                 });
               },
               function getABI(paraCb) {
-                shelljs.exec(`vyper -f json ${file.filename}`, { silent: true }, (code, stdout, stderr) => {
+                shelljs.exec(`vyper -f json ${file.filename}`, {silent: true}, (code, stdout, stderr) => {
                   if (stderr) {
                     return paraCb(stderr);
                   }
                   if (code !== 0) {
-                    return paraCb(`Vyper exited with error code ${code}`)
+                    return paraCb(`Vyper exited with error code ${code}`);
                   }
                   if (!stdout) {
                     return paraCb('Execution returned no ABI');
@@ -55,7 +58,7 @@ class Vyper {
                   } catch (e) {
                     return paraCb('ABI is not valid JSON');
                   }
-                  compiled_object[fileNameOnly].abiDefinition = ABI;
+                  compiled_object[className].abiDefinition = ABI;
                   paraCb();
                 });
               }

--- a/lib/modules/vyper/index.js
+++ b/lib/modules/vyper/index.js
@@ -1,0 +1,75 @@
+let async = require('../../utils/async_extend.js');
+const shelljs = require('shelljs');
+
+class Vyper {
+
+  constructor(embark, options) {
+    this.logger = embark.logger;
+    this.events = embark.events;
+    this.contractDirectories = options.contractDirectories;
+
+    console.log('Construct VYPER');
+    embark.registerCompiler(".py", this.compile_vyper.bind(this));
+  }
+
+  compile_vyper(contractFiles, cb) {
+    let self = this;
+    async.waterfall([
+      function compileContracts(callback) {
+        self.logger.info("compiling vyper contracts...");
+        async.each(contractFiles,
+            function(file, fileCb) {
+                shelljs.exec(`vyper ${file.filename}`, (code, stdout, stderr) => {
+                  console.log('Code', code);
+                  console.log('Stdout', stdout);
+                  console.log('Stderr', stderr);
+                  fileCb();
+                });
+            },
+            function (err) {
+              process.exit(); // TODO remove me
+              callback(err);
+            });
+      },
+      function createCompiledObject(output, callback) {
+        let json = output.contracts;
+
+        if (!output || !output.contracts) {
+          return callback(new Error("error compiling for unknown reasons"));
+        }
+
+        if (Object.keys(output.contracts).length === 0 && output.sourceList.length > 0) {
+          return callback(new Error("error compiling. There are sources available but no code could be compiled, likely due to fatal errors in the solidity code").message);
+        }
+
+        let compiled_object = {};
+
+        for (let contractFile in json) {
+          for (let contractName in json[contractFile]) {
+            let contract = json[contractFile][contractName];
+
+            const className = contractName;
+            const filename = contractFile;
+
+            compiled_object[className] = {};
+            compiled_object[className].code = contract.evm.bytecode.object;
+            compiled_object[className].runtimeBytecode = contract.evm.deployedBytecode.object;
+            compiled_object[className].realRuntimeBytecode = contract.evm.deployedBytecode.object.slice(0, -68);
+            compiled_object[className].swarmHash = contract.evm.deployedBytecode.object.slice(-68).slice(0, 64);
+            compiled_object[className].gasEstimates = contract.evm.gasEstimates;
+            compiled_object[className].functionHashes = contract.evm.methodIdentifiers;
+            compiled_object[className].abiDefinition = contract.abi;
+            compiled_object[className].filename = filename;
+          }
+        }
+
+        callback(null, compiled_object);
+      }
+    ], function (err, result) {
+      cb(err, result);
+    });
+  }
+
+}
+
+module.exports = Vyper;

--- a/lib/modules/vyper/index.js
+++ b/lib/modules/vyper/index.js
@@ -1,5 +1,6 @@
 let async = require('../../utils/async_extend.js');
 const shelljs = require('shelljs');
+const path = require('path');
 
 class Vyper {
 
@@ -8,7 +9,6 @@ class Vyper {
     this.events = embark.events;
     this.contractDirectories = options.contractDirectories;
 
-    console.log('Construct VYPER');
     embark.registerCompiler(".py", this.compile_vyper.bind(this));
   }
 
@@ -17,53 +17,53 @@ class Vyper {
     async.waterfall([
       function compileContracts(callback) {
         self.logger.info("compiling vyper contracts...");
+        const compiled_object = {};
         async.each(contractFiles,
-            function(file, fileCb) {
-                shelljs.exec(`vyper ${file.filename}`, (code, stdout, stderr) => {
-                  console.log('Code', code);
-                  console.log('Stdout', stdout);
-                  console.log('Stderr', stderr);
-                  fileCb();
+          function (file, fileCb) {
+            const fileNameOnly = path.basename(file.filename);
+            compiled_object[fileNameOnly] = {};
+            async.parallel([
+              function getByteCode(paraCb) {
+                shelljs.exec(`vyper ${file.filename}`, { silent: true }, (code, stdout, stderr) => {
+                  if (stderr) {
+                    return paraCb(stderr);
+                  }
+                  if (code !== 0) {
+                    return paraCb(`Vyper exited with error code ${code}`)
+                  }
+                  if (!stdout) {
+                    return paraCb('Execution returned no bytecode');
+                  }
+                  compiled_object[fileNameOnly].code = stdout.replace(/\n/g, '');
+                  paraCb();
                 });
-            },
-            function (err) {
-              process.exit(); // TODO remove me
-              callback(err);
-            });
-      },
-      function createCompiledObject(output, callback) {
-        let json = output.contracts;
-
-        if (!output || !output.contracts) {
-          return callback(new Error("error compiling for unknown reasons"));
-        }
-
-        if (Object.keys(output.contracts).length === 0 && output.sourceList.length > 0) {
-          return callback(new Error("error compiling. There are sources available but no code could be compiled, likely due to fatal errors in the solidity code").message);
-        }
-
-        let compiled_object = {};
-
-        for (let contractFile in json) {
-          for (let contractName in json[contractFile]) {
-            let contract = json[contractFile][contractName];
-
-            const className = contractName;
-            const filename = contractFile;
-
-            compiled_object[className] = {};
-            compiled_object[className].code = contract.evm.bytecode.object;
-            compiled_object[className].runtimeBytecode = contract.evm.deployedBytecode.object;
-            compiled_object[className].realRuntimeBytecode = contract.evm.deployedBytecode.object.slice(0, -68);
-            compiled_object[className].swarmHash = contract.evm.deployedBytecode.object.slice(-68).slice(0, 64);
-            compiled_object[className].gasEstimates = contract.evm.gasEstimates;
-            compiled_object[className].functionHashes = contract.evm.methodIdentifiers;
-            compiled_object[className].abiDefinition = contract.abi;
-            compiled_object[className].filename = filename;
-          }
-        }
-
-        callback(null, compiled_object);
+              },
+              function getABI(paraCb) {
+                shelljs.exec(`vyper -f json ${file.filename}`, { silent: true }, (code, stdout, stderr) => {
+                  if (stderr) {
+                    return paraCb(stderr);
+                  }
+                  if (code !== 0) {
+                    return paraCb(`Vyper exited with error code ${code}`)
+                  }
+                  if (!stdout) {
+                    return paraCb('Execution returned no ABI');
+                  }
+                  let ABI = [];
+                  try {
+                    ABI = JSON.parse(stdout.replace(/\n/g, ''));
+                  } catch (e) {
+                    return paraCb('ABI is not valid JSON');
+                  }
+                  compiled_object[fileNameOnly].abiDefinition = ABI;
+                  paraCb();
+                });
+              }
+            ], fileCb);
+          },
+          function (err) {
+            callback(err, compiled_object);
+          });
       }
     ], function (err, result) {
       cb(err, result);


### PR DESCRIPTION
Can now compile and deploy contracts in Vyper. Need to have Vyper installed.

Do we want tests in Test_app for that, @iurimatias ? It wouldn't work for Windows though and we would need to install Vyper on the test machines, so it might be complicated.