### PR TITLE
Fix versions with spaces and add warning

### DIFF
--- a/lib/versions/library_manager.js
+++ b/lib/versions/library_manager.js
@@ -27,6 +27,14 @@ class LibraryManager {
     this.versions['solc'] = solcVersionInConfig;
     this.versions['web3'] = web3VersionInConfig;
     this.versions['ipfs-api'] = ipfsApiVersion;
+
+    Object.keys(this.versions).forEach(versionKey => {
+      const newVersion = this.versions[versionKey].trim();
+      if (newVersion !== this.versions[versionKey]) {
+        this.embark.logger.warn(`There a a space in the version of ${versionKey}. We corrected it for you ("${this.versions[versionKey]}" => "${newVersion}").`);
+        this.versions[versionKey] = newVersion;
+      }
+    });
   }
 
   registerCommands() {


### PR DESCRIPTION
When you put by accident a space in your version (ex: `"solc": "0.4.17  ",`), it still created the directory with that space, making it impossible to change, remove or move it (at least on Windows).
Fixed it and put a warning for users to know they made that mistake.