### PR TITLE
 Support setting log level as an argument

### DIFF
--- a/lib/cmd.js
+++ b/lib/cmd.js
@@ -87,9 +87,14 @@ class Cmd {
   build() {
     program
       .command('build [environment]')
+      .option('--logfile [logfile]', 'filename to output logs (default: none)')
+      .option('--loglevel [loglevel]', 'level of logging to display ["error", "warn", "info", "debug", "trace"] (default: debug)')
       .description('deploy and build dapp at dist/ (default: development)')
       .action(function (env, _options) {
-        embark.build({env: env || 'development'});
+        _options.env = env || 'development';
+        _options.logFile = _options.logfile; // fix casing
+        _options.logLevel = _options.loglevel; // fix casing
+        embark.build(_options);
       });
   }
 
@@ -102,7 +107,7 @@ class Cmd {
       .option('--nodashboard', 'simple mode, disables the dashboard')
       .option('--no-color', 'no colors in case it\'s needed for compatbility purposes')
       .option('--logfile [logfile]', 'filename to output logs (default: none)')
-      .option('--logLevel [logLevel]', 'level of logging to display ["error", "warn", "info", "debug", "trace"] (default: debug)')
+      .option('--loglevel [loglevel]', 'level of logging to display ["error", "warn", "info", "debug", "trace"] (default: debug)',)
       .description('run dapp (default: development)')
       .action(function (env, options) {
         embark.run({
@@ -111,8 +116,8 @@ class Cmd {
           serverHost: options.host,
           runWebserver: !options.noserver,
           useDashboard: !options.nodashboard,
-          logfile: options.logfile,
-          logLevel: options.logLevel
+          logFile: options.logfile,
+          logLevel: options.loglevel
         });
       });
   }
@@ -171,15 +176,18 @@ class Cmd {
 
   upload() {
     program
-      .command('upload [platform] [environment]')
+      .command('upload <platform> [environment]')
       .option('--logfile [logfile]', 'filename to output logs (default: none)')
-      .description('upload your dapp to a decentralized storage (e.g embark upload ipfs)')
+      .option('--loglevel [loglevel]', 'level of logging to display ["error", "warn", "info", "debug", "trace"]', /^(error|warn|info|debug|trace)$/i, 'debug')
+      .description('Upload your dapp to a decentralized storage (e.g embark upload ipfs).')
       .action(function (platform, env, _options) {
         let environment = env || 'development';
         embark.initConfig(environment, {
           embarkConfig: 'embark.json', interceptLogs: false
         });
         _options.env = environment;
+        _options.logFile = _options.logfile; // fix casing
+        _options.logLevel = _options.loglevel; // fix casing
         embark.upload(platform, _options);
       });
   }
@@ -191,7 +199,7 @@ class Cmd {
       .action(function (env, options) {
         embark.graph({
           env: env || 'development',
-          logfile: options.logfile
+          logFile: options.logfile
         });
       });
   }

--- a/lib/cmd.js
+++ b/lib/cmd.js
@@ -88,7 +88,7 @@ class Cmd {
     program
       .command('build [environment]')
       .option('--logfile [logfile]', 'filename to output logs (default: none)')
-      .option('--loglevel [loglevel]', 'level of logging to display ["error", "warn", "info", "debug", "trace"] (default: debug)')
+      .option('--loglevel [loglevel]', 'level of logging to display ["error", "warn", "info", "debug", "trace"]', /^(error|warn|info|debug|trace)$/i, 'debug')
       .description('deploy and build dapp at dist/ (default: development)')
       .action(function (env, _options) {
         _options.env = env || 'development';
@@ -107,7 +107,7 @@ class Cmd {
       .option('--nodashboard', 'simple mode, disables the dashboard')
       .option('--no-color', 'no colors in case it\'s needed for compatbility purposes')
       .option('--logfile [logfile]', 'filename to output logs (default: none)')
-      .option('--loglevel [loglevel]', 'level of logging to display ["error", "warn", "info", "debug", "trace"] (default: debug)',)
+      .option('--loglevel [loglevel]', 'level of logging to display ["error", "warn", "info", "debug", "trace"]', /^(error|warn|info|debug|trace)$/i, 'debug')
       .description('run dapp (default: development)')
       .action(function (env, options) {
         embark.run({

--- a/lib/cmd.js
+++ b/lib/cmd.js
@@ -102,6 +102,7 @@ class Cmd {
       .option('--nodashboard', 'simple mode, disables the dashboard')
       .option('--no-color', 'no colors in case it\'s needed for compatbility purposes')
       .option('--logfile [logfile]', 'filename to output logs (default: none)')
+      .option('--logLevel [logLevel]', 'level of logging to display ["error", "warn", "info", "debug", "trace"] (default: debug)')
       .description('run dapp (default: development)')
       .action(function (env, options) {
         embark.run({
@@ -110,7 +111,8 @@ class Cmd {
           serverHost: options.host,
           runWebserver: !options.noserver,
           useDashboard: !options.nodashboard,
-          logfile: options.logfile
+          logfile: options.logfile,
+          logLevel: options.logLevel
         });
       });
   }

--- a/lib/core/engine.js
+++ b/lib/core/engine.js
@@ -16,15 +16,16 @@ class Engine {
     this.embarkConfig = options.embarkConfig;
     this.interceptLogs = options.interceptLogs;
     this.version = options.version;
-    this.logfile = options.logfile;
+    this.logFile = options.logFile;
     this.logLevel = options.logLevel;
+    this.events = options.events;
   }
 
   init(_options) {
     let self = this;
     let options = _options || {};
-    this.events = new Events();
-    this.logger = options.logger || new Logger({logLevel: options.logLevel || this.logLevel || 'debug', events: this.events, logfile: this.logfile});
+    this.events = options.events || this.events || new Events();
+    this.logger = options.logger || new Logger({logLevel: options.logLevel || this.logLevel || 'debug', events: this.events, logFile: this.logFile});
     this.config = new Config({env: this.env, logger: this.logger, events: this.events});
     this.config.loadConfigFiles({embarkConfig: this.embarkConfig, interceptLogs: this.interceptLogs});
     this.plugins = this.config.plugins;

--- a/lib/core/engine.js
+++ b/lib/core/engine.js
@@ -17,13 +17,14 @@ class Engine {
     this.interceptLogs = options.interceptLogs;
     this.version = options.version;
     this.logfile = options.logfile;
+    this.logLevel = options.logLevel;
   }
 
   init(_options) {
     let self = this;
     let options = _options || {};
     this.events = new Events();
-    this.logger = options.logger || new Logger({logLevel: options.logLevel || 'debug', events: this.events, logfile: this.logfile});
+    this.logger = options.logger || new Logger({logLevel: options.logLevel || this.logLevel || 'debug', events: this.events, logfile: this.logfile});
     this.config = new Config({env: this.env, logger: this.logger, events: this.events});
     this.config.loadConfigFiles({embarkConfig: this.embarkConfig, interceptLogs: this.interceptLogs});
     this.plugins = this.config.plugins;

--- a/lib/core/logger.js
+++ b/lib/core/logger.js
@@ -7,16 +7,16 @@ class Logger {
     this.logLevels = ['error', 'warn', 'info', 'debug', 'trace'];
     this.logLevel = options.logLevel || 'info';
     this.logFunction = options.logFunction || console.log;
-    this.logfile = options.logfile;
+    this.logFile = options.logFile;
   }
 }
 
 Logger.prototype.writeToFile = function (txt) {
-  if (!this.logfile) {
+  if (!this.logFile) {
     return;
   }
 
-  fs.appendFileSync(this.logfile, "\n" + txt);
+  fs.appendFileSync(this.logFile, "\n" + txt);
 };
 
 Logger.prototype.error = function (txt) {

--- a/lib/index.js
+++ b/lib/index.js
@@ -61,7 +61,9 @@ class Embark {
       env: options.env,
       version: this.version,
       embarkConfig: options.embarkConfig || 'embark.json',
-      logfile: options.logfile
+      logfile: options.logfile,
+      logLevel: options.logLevel,
+      interceptLogs: true
     });
     engine.init();
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -61,9 +61,8 @@ class Embark {
       env: options.env,
       version: this.version,
       embarkConfig: options.embarkConfig || 'embark.json',
-      logfile: options.logfile,
-      logLevel: options.logLevel,
-      interceptLogs: true
+      logFile: options.logFile,
+      logLevel: options.logLevel
     });
     engine.init();
 
@@ -149,16 +148,20 @@ class Embark {
     });
   }
 
-  build(options, engine, continueProcessing) {
-    if(!engine){
-      engine = new Engine({
-        env: options.env,
-        version: this.version,
-        embarkConfig: 'embark.json',
-        interceptLogs: false
-      });
-      engine.init();
-    }
+  build(options, continueProcessing) {
+    let engine = new Engine({
+      env: options.env,
+      version: this.version,
+      embarkConfig: 'embark.json',
+      interceptLogs: false,
+      logFile: options.logFile,
+      logLevel: options.logLevel,
+      events: options.events,
+      logger: options.logger,
+      config: options.config,
+      plugins: options.plugins
+    });
+    engine.init();
 
     async.waterfall([
       function startServices(callback) {
@@ -206,7 +209,7 @@ class Embark {
       env: options.env,
       version: this.version,
       embarkConfig: options.embarkConfig || 'embark.json',
-      logfile: options.logfile
+      logFile: options.logFile
     });
     engine.init();
 
@@ -254,29 +257,26 @@ class Embark {
   // TODO: should deploy if it hasn't already
   upload(platform, options) {
     
+    // populate options that were instantiated with initConfig to pass around
     options.buildDir = 'dist/';
     options.storageConfig = this.config.storageConfig;
-
-    // initialise embark engine
-    let engine = new Engine({
-      env: options.env,
-      version: this.version,
-      embarkConfig: options.embarkConfig || 'embark.json',
-      logfile: options.logfile
-    });
-    engine.init();
+    options.events = this.events;
+    options.logger = this.logger;
+    options.config = this.config;
 
     // load plugins
     this.plugins.loadInternalPlugin('ipfs', options);
     this.plugins.loadInternalPlugin('swarm', options);
 
-    let plugins = this.plugins;
+    // upddate our options with loaded plugins
+    options.plugins = this.plugins;
+
     let cmdPlugin;
     let self = this;
     async.waterfall([
       function setupStoragePlugin(callback){
         // check use has input existing storage plugin
-        let cmdPlugins = plugins.getPluginsFor('uploadCmds');
+        let cmdPlugins = self.plugins.getPluginsFor('uploadCmds');
         
         if (cmdPlugins.length > 0) {
           cmdPlugin = cmdPlugins.find((pluginCmd) => {
@@ -284,7 +284,7 @@ class Embark {
           });
         }
         if (!cmdPlugin) {
-          engine.logger.info('try "embark upload ipfs" or "embark upload swarm"'.green);
+          self.logger.info('try "embark upload ipfs" or "embark upload swarm"'.green);
           callback({message: 'unknown platform: ' + platform});
         } else {
           callback();
@@ -292,8 +292,7 @@ class Embark {
       },
       function buildAndDeployContracts(callback){
         // 2. upload to storage (outputDone event triggered after webpack finished)
-        engine.events.on('outputDone', function () {
-          engine.logger.info('deploying to ' + platform + '...');
+        self.events.on('outputDone', function () {
           cmdPlugin.uploadCmds[0].cb()
           .then((success) => {
             callback(null, success);
@@ -301,14 +300,14 @@ class Embark {
           .catch(callback);
         });
         // 1. build the contracts and dapp webpack
-        self.build(options, engine, true);
+        self.build(options, true);
       }
     ], function (err, _result) {
       if (err) {
-        engine.logger.error(err.message);
-        engine.logger.debug(err.stack);
+        self.logger.error(err.message);
+        self.logger.debug(err.stack);
       } else {
-        engine.logger.info("finished building dapp and deploying to " + platform.underline);
+        self.logger.info("finished building dapp and deploying to " + platform.underline);
       }
 
       // needed due to child processes

--- a/lib/modules/ipfs/upload.js
+++ b/lib/modules/ipfs/upload.js
@@ -13,7 +13,7 @@ class IPFS {
 
   deploy() {
     return new Promise((resolve, reject) => {
-      console.log("deploying!");
+      console.log("deploying to ipfs!");
       let self = this;
       async.waterfall([
         function findBinary(callback) {
@@ -29,8 +29,9 @@ class IPFS {
         function runCommand(ipfs_bin, callback) {
           let cmd = `"${ipfs_bin}" add -r ${self.buildDir}`;
           console.log(("=== adding " + self.buildDir + " to ipfs").green);
-          console.log(cmd.green);
-          shelljs.exec(cmd, function(code, stdout, stderr){
+          console.trace(cmd);
+          shelljs.exec(cmd, {silent:true}, function(code, stdout, stderr){ // {silent:true}: don't echo cmd output so it can be controlled via logLevel
+            console.log(stdout.green);
             callback(stderr, stdout);
           });
         },

--- a/lib/modules/swarm/upload.js
+++ b/lib/modules/swarm/upload.js
@@ -10,6 +10,7 @@ class Swarm {
 
   deploy() {
     return new Promise((resolve, reject) => {
+      console.log("deploying to swarm!");
       let self = this;
       async.waterfall([
         function findBinary(callback) {
@@ -25,8 +26,9 @@ class Swarm {
         function runCommand(swarm_bin, callback) {
           let cmd = `"${swarm_bin}" --defaultpath ${self.buildDir} index.html --recursive up ${self.buildDir}`;
           console.log(("=== adding " + self.buildDir + " to swarm").green);
-          console.log(cmd.green);
-          shelljs.exec(cmd, function(code, stdout, stderr){
+          console.trace(cmd);
+          shelljs.exec(cmd, {silent:true}, function(code, stdout, stderr){ // {silent:true}: don't echo cmd output so it can be controlled via logLevel
+            console.log(stdout.green);
             callback(stderr, {code: code, output: stdout});
           });
         },


### PR DESCRIPTION
* Add loglevel and logfile switch to `embark build`
* Support existing `loglevel` and `logfile` switch for `embark run/upload`
* make casing consistent for `loglevel` and `logfile`
* remove passing engine to `build()` and instead pass needed objects in options.
* prevent duplicate plugin initiation (above point)
* allow `Events` object to be passed to `Engine` constructor and `init()`
* prevent echo of upload commands to allow interception and control via logging