### PR TITLE
Add context to limit plugins that should not run in the simulator

### DIFF
--- a/lib/constants.json
+++ b/lib/constants.json
@@ -1,3 +1,11 @@
 {
-  "httpContractsDirectory": ".embark/contracts/"
+  "httpContractsDirectory": ".embark/contracts/",
+  "contexts": {
+    "simulator": "simulator",
+    "blockchain": "blockchain",
+    "any": "any"
+  },
+  "events": {
+    "contextChange": "contextChange"
+  }
 }

--- a/lib/core/engine.js
+++ b/lib/core/engine.js
@@ -9,6 +9,7 @@ let ServicesMonitor = require('./services_monitor.js');
 let Pipeline = require('../pipeline/pipeline.js');
 let Watch = require('../pipeline/watch.js');
 let LibraryManager = require('../versions/library_manager.js');
+const constants = require('../constants');
 
 class Engine {
   constructor(options) {
@@ -19,6 +20,7 @@ class Engine {
     this.logFile = options.logFile;
     this.logLevel = options.logLevel;
     this.events = options.events;
+    this.context = constants.contexts.simulator; // Will change to blockchain once we can connect to the blockchain
   }
 
   init(_options) {
@@ -226,6 +228,16 @@ class Engine {
             return cb({name: version, status: 'on'});
           }
           let nodeName = version.split("/")[0];
+          const oldContext = self.context;
+          if (nodeName === 'Geth' || nodeName.toLowerCase().indexOf('test') < 0) {
+            self.context = constants.contexts.blockchain;
+          } else {
+            self.context = constants.contexts.simulator;
+          }
+          if (oldContext !== self.context) {
+            console.log('Emiting context change');
+            self.events.emit(constants.events.contextChange, self.context);
+          }
           let versionNumber = version.split("/")[1].split("-")[0];
           let name = nodeName + " " + versionNumber + " (Ethereum)";
 

--- a/lib/core/engine.js
+++ b/lib/core/engine.js
@@ -235,7 +235,6 @@ class Engine {
             self.context = constants.contexts.simulator;
           }
           if (oldContext !== self.context) {
-            console.log('Emiting context change');
             self.events.emit(constants.events.contextChange, self.context);
           }
           let versionNumber = version.split("/")[1].split("-")[0];

--- a/lib/core/plugin.js
+++ b/lib/core/plugin.js
@@ -28,14 +28,19 @@ var Plugin = function(options) {
   this.logger = options.logger;
   this.events = options.events;
   this.config = options.config;
+  this.loaded = false;
   this.context = options.pluginConfig.context || constants.contexts.any;
 };
 
 Plugin.prototype.loadPlugin = function(currentContext) {
   if (this.context !== constants.contexts.any && this.context !== currentContext) {
-    this.events.on(constants.events.contextChange, this.loadPlugin.bind(this));
-    return;
+    if (currentContext) {
+      this.logger.warn(`Plugin ${this.name} can only be loaded in the context of the ${this.context}`);
+    }
+    return this.events.on(constants.events.contextChange, this.loadPlugin.bind(this));
   }
+  this.loaded = true;
+  this.logger.info(`Loaded plugin ${this.name}`);
   this.events.removeListener(constants.events.contextChange, this.loadPlugin.bind(this));
   if (this.shouldInterceptLogs) {
     this.interceptLogs(this.pluginModule);

--- a/lib/core/plugin.js
+++ b/lib/core/plugin.js
@@ -1,5 +1,6 @@
-var fs = require('./fs.js');
-var utils = require('../utils/utils.js');
+const fs = require('./fs.js');
+const utils = require('../utils/utils.js');
+const constants = require('../constants');
 
 // TODO: pass other params like blockchainConfig, contract files, etc..
 var Plugin = function(options) {
@@ -27,9 +28,15 @@ var Plugin = function(options) {
   this.logger = options.logger;
   this.events = options.events;
   this.config = options.config;
+  this.context = options.pluginConfig.context || constants.contexts.any;
 };
 
-Plugin.prototype.loadPlugin = function() {
+Plugin.prototype.loadPlugin = function(currentContext) {
+  if (this.context !== constants.contexts.any && this.context !== currentContext) {
+    this.events.on(constants.events.contextChange, this.loadPlugin.bind(this));
+    return;
+  }
+  this.events.removeListener(constants.events.contextChange, this.loadPlugin.bind(this));
   if (this.shouldInterceptLogs) {
     this.interceptLogs(this.pluginModule);
   }

--- a/lib/core/plugins.js
+++ b/lib/core/plugins.js
@@ -20,10 +20,12 @@ Plugins.prototype.loadPlugins = function() {
 };
 
 Plugins.prototype.listPlugins = function() {
-  var list = [];
-  for (var className in this.pluginList) {
-    list.push(className);
-  }
+  const list = [];
+  this.plugins.forEach(plugin => {
+    if (plugin.loaded) {
+      list.push(plugin.name);
+    }
+  });
   return list;
 };
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -67,9 +67,9 @@ class Embark {
     engine.init();
 
     if (!options.useDashboard) {
-      console.log('========================'.bold.green);
-      console.log(('Welcome to Embark ' + this.version).yellow.bold);
-      console.log('========================'.bold.green);
+      engine.logger.info('========================'.bold.green);
+      engine.logger.info(('Welcome to Embark ' + this.version).yellow.bold);
+      engine.logger.info('========================'.bold.green);
     }
 
     async.parallel([


### PR DESCRIPTION
Adds 3 contexts (others can be added):
- blockchain
- simulator
- any

When we connect to the node, we check which of the context we are in. Plugins that have a specific environment condition won't load until the context changes to the one needed.

Designed to be completely backwards compatible, meaning that plugins not specifying a context will default to `any`. To tell embark that a plugin only works with the blockchain, just need to add the field  `"context": "blockchain"` in embark.json. 