### PR TITLE
Support multiple contexts at once

### DIFF
--- a/lib/constants.json
+++ b/lib/constants.json
@@ -3,6 +3,13 @@
   "contexts": {
     "simulator": "simulator",
     "blockchain": "blockchain",
+    "templateGeneration": "templateGeneration",
+    "run": "run",
+    "upload": "upload",
+    "build": "build",
+    "graph": "graph",
+    "test": "test",
+    "reset": "reset",
     "any": "any"
   },
   "events": {

--- a/lib/core/config.js
+++ b/lib/core/config.js
@@ -20,6 +20,7 @@ var Config = function(options) {
   this.logger = options.logger;
   this.events = options.events;
   this.embarkConfig = {};
+  this.context = options.context || [constants.contexts.any];
 };
 
 Config.prototype.loadConfigFiles = function(options) {
@@ -36,7 +37,7 @@ Config.prototype.loadConfigFiles = function(options) {
   this.embarkConfig = fs.readJSONSync(options.embarkConfig);
   this.embarkConfig.plugins = this.embarkConfig.plugins || {};
 
-  this.plugins = new Plugins({plugins: this.embarkConfig.plugins, logger: this.logger, interceptLogs: interceptLogs, events: this.events, config: this});
+  this.plugins = new Plugins({plugins: this.embarkConfig.plugins, logger: this.logger, interceptLogs: interceptLogs, events: this.events, config: this, context: this.context});
   this.plugins.loadPlugins();
 
   this.loadEmbarkConfigFile();

--- a/lib/core/engine.js
+++ b/lib/core/engine.js
@@ -9,7 +9,6 @@ let ServicesMonitor = require('./services_monitor.js');
 let Pipeline = require('../pipeline/pipeline.js');
 let Watch = require('../pipeline/watch.js');
 let LibraryManager = require('../versions/library_manager.js');
-const constants = require('../constants');
 
 class Engine {
   constructor(options) {
@@ -20,7 +19,7 @@ class Engine {
     this.logFile = options.logFile;
     this.logLevel = options.logLevel;
     this.events = options.events;
-    this.context = constants.contexts.simulator; // Will change to blockchain once we can connect to the blockchain
+    this.context = options.context;
   }
 
   init(_options) {
@@ -28,7 +27,7 @@ class Engine {
     let options = _options || {};
     this.events = options.events || this.events || new Events();
     this.logger = options.logger || new Logger({logLevel: options.logLevel || this.logLevel || 'debug', events: this.events, logFile: this.logFile});
-    this.config = new Config({env: this.env, logger: this.logger, events: this.events});
+    this.config = new Config({env: this.env, logger: this.logger, events: this.events, context: this.context});
     this.config.loadConfigFiles({embarkConfig: this.embarkConfig, interceptLogs: this.interceptLogs});
     this.plugins = this.config.plugins;
 
@@ -228,15 +227,6 @@ class Engine {
             return cb({name: version, status: 'on'});
           }
           let nodeName = version.split("/")[0];
-          const oldContext = self.context;
-          if (nodeName === 'Geth' || nodeName.toLowerCase().indexOf('test') < 0) {
-            self.context = constants.contexts.blockchain;
-          } else {
-            self.context = constants.contexts.simulator;
-          }
-          if (oldContext !== self.context) {
-            self.events.emit(constants.events.contextChange, self.context);
-          }
           let versionNumber = version.split("/")[1].split("-")[0];
           let name = nodeName + " " + versionNumber + " (Ethereum)";
 

--- a/lib/core/plugin.js
+++ b/lib/core/plugin.js
@@ -49,6 +49,10 @@ Plugin.prototype.isContextValid = function() {
   });
 };
 
+Plugin.prototype.hasContext = function(context) {
+  return this.currentContext.includes(context);
+};
+
 Plugin.prototype.loadPlugin = function() {
   if (!this.isContextValid())  {
     console.log(this.acceptedContext);

--- a/lib/core/plugin.js
+++ b/lib/core/plugin.js
@@ -29,19 +29,33 @@ var Plugin = function(options) {
   this.events = options.events;
   this.config = options.config;
   this.loaded = false;
-  this.context = options.pluginConfig.context || constants.contexts.any;
+  this.currentContext = options.context;
+  this.acceptedContext = options.pluginConfig.context || [constants.contexts.any];
+
+  if (!Array.isArray(this.currentContext)) {
+    this.currentContext = [this.currentContext];
+  }
+  if (!Array.isArray(this.acceptedContext)) {
+    this.acceptedContext = [this.acceptedContext];
+  }
 };
 
-Plugin.prototype.loadPlugin = function(currentContext) {
-  if (this.context !== constants.contexts.any && this.context !== currentContext) {
-    if (currentContext) {
-      this.logger.warn(`Plugin ${this.name} can only be loaded in the context of the ${this.context}`);
-    }
-    return this.events.on(constants.events.contextChange, this.loadPlugin.bind(this));
+Plugin.prototype.isContextValid = function() {
+  if (this.currentContext.includes(constants.contexts.any) || this.acceptedContext.includes(constants.contexts.any)) {
+    return true;
+  }
+  return this.acceptedContext.some(context => {
+    return this.currentContext.includes(context);
+  });
+};
+
+Plugin.prototype.loadPlugin = function() {
+  if (!this.isContextValid())  {
+    console.log(this.acceptedContext);
+    this.logger.warn(`Plugin ${this.name} can only be loaded in the context of "${this.acceptedContext.join(', ')}"`);
+    return false;
   }
   this.loaded = true;
-  this.logger.info(`Loaded plugin ${this.name}`);
-  this.events.removeListener(constants.events.contextChange, this.loadPlugin.bind(this));
   if (this.shouldInterceptLogs) {
     this.interceptLogs(this.pluginModule);
   }

--- a/lib/core/plugins.js
+++ b/lib/core/plugins.js
@@ -9,6 +9,7 @@ var Plugins = function(options) {
   this.logger = options.logger;
   this.events = options.events;
   this.config = options.config;
+  this.context = options.context;
 };
 
 Plugins.prototype.loadPlugins = function() {
@@ -33,7 +34,18 @@ Plugins.prototype.listPlugins = function() {
 Plugins.prototype.createPlugin = function(pluginName, pluginConfig) {
   let plugin = {};
   let pluginPath = false;
-  var pluginWrapper = new Plugin({name: pluginName, pluginModule: plugin, pluginConfig: pluginConfig, logger: this.logger, pluginPath: pluginPath, interceptLogs: this.interceptLogs, events: this.events, config: this.config, isInternal: true});
+  var pluginWrapper = new Plugin({
+    name: pluginName,
+    pluginModule: plugin,
+    pluginConfig: pluginConfig,
+    logger: this.logger,
+    pluginPath: pluginPath,
+    interceptLogs: this.interceptLogs,
+    events: this.events,
+    config: this.config,
+    isInternal: true,
+    context: this.context
+  });
   this.plugins.push(pluginWrapper);
   return pluginWrapper;
 };
@@ -42,7 +54,18 @@ Plugins.prototype.loadInternalPlugin = function(pluginName, pluginConfig) {
   var pluginPath = utils.joinPath('../modules/', pluginName, 'index.js');
   var plugin = require(pluginPath);
 
-  var pluginWrapper = new Plugin({name: pluginName, pluginModule: plugin, pluginConfig: pluginConfig, logger: this.logger, pluginPath: pluginPath, interceptLogs: this.interceptLogs, events: this.events, config: this.config, isInternal: true});
+  var pluginWrapper = new Plugin({
+    name: pluginName,
+    pluginModule: plugin,
+    pluginConfig: pluginConfig,
+    logger: this.logger,
+    pluginPath: pluginPath,
+    interceptLogs: this.interceptLogs,
+    events: this.events,
+    config: this.config,
+    isInternal: true,
+    context: this.context
+  });
   pluginWrapper.loadInternalPlugin();
   this.plugins.push(pluginWrapper);
 };
@@ -51,7 +74,18 @@ Plugins.prototype.loadPlugin = function(pluginName, pluginConfig) {
   var pluginPath = utils.joinPath(utils.pwd(), 'node_modules', pluginName);
   var plugin = require(pluginPath);
 
-  var pluginWrapper = new Plugin({name: pluginName, pluginModule: plugin, pluginConfig: pluginConfig, logger: this.logger, pluginPath: pluginPath, interceptLogs: this.interceptLogs, events: this.events, config: this.config, isInternal: false});
+  var pluginWrapper = new Plugin({
+    name: pluginName,
+    pluginModule: plugin,
+    pluginConfig: pluginConfig,
+    logger: this.logger,
+    pluginPath: pluginPath,
+    interceptLogs: this.interceptLogs,
+    events: this.events,
+    config: this.config,
+    isInternal: false,
+    context: this.context
+  });
   pluginWrapper.loadPlugin();
   this.plugins.push(pluginWrapper);
 };

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,4 +1,5 @@
 let async = require('async');
+const constants = require('./constants');
 // require("./utils/debug_util.js")(__filename, async);
 
 require('colors');
@@ -31,22 +32,25 @@ class Embark {
     this.events = new Events();
     this.logger = new Logger({logLevel: 'debug', events: this.events});
 
-    this.config = new Config({env: env, logger: this.logger, events: this.events});
+    this.config = new Config({env: env, logger: this.logger, events: this.events, context: this.context});
     this.config.loadConfigFiles(options);
     this.plugins = this.config.plugins;
   }
 
   blockchain(env, client) {
+    this.context = [constants.contexts.blockchain];
     return require('./cmds/blockchain/blockchain.js')(this.config.blockchainConfig, client, env).run();
   }
 
   simulator(options) {
+    this.context = options.context || [constants.contexts.simulator, constants.contexts.blockchain];
     let Simulator = require('./cmds/simulator.js');
     let simulator = new Simulator({blockchainConfig: this.config.blockchainConfig});
     simulator.run(options);
   }
 
   generateTemplate(templateName, destinationFolder, name) {
+    this.context = [constants.contexts.templateGeneration];
     let TemplateGenerator = require('./cmds/template_generator.js');
     let templateGenerator = new TemplateGenerator(templateName);
     templateGenerator.generate(destinationFolder, name);
@@ -54,6 +58,7 @@ class Embark {
 
   run(options) {
     let self = this;
+    self.context = options.context || [constants.contexts.run, constants.contexts.build];
     let Dashboard = require('./dashboard/dashboard.js');
     let windowSize = require('window-size');
 
@@ -62,7 +67,8 @@ class Embark {
       version: this.version,
       embarkConfig: options.embarkConfig || 'embark.json',
       logFile: options.logFile,
-      logLevel: options.logLevel
+      logLevel: options.logLevel,
+      context: self.context
     });
     engine.init();
 
@@ -152,6 +158,7 @@ class Embark {
   }
 
   build(options, continueProcessing) {
+    this.context = options.context || [constants.contexts.build];
     let engine = new Engine({
       env: options.env,
       version: this.version,
@@ -162,7 +169,8 @@ class Embark {
       events: options.events,
       logger: options.logger,
       config: options.config,
-      plugins: options.plugins
+      plugins: options.plugins,
+      context: this.context
     });
     engine.init();
 
@@ -201,18 +209,22 @@ class Embark {
   }
 
   initTests(options) {
+    this.context = options.context || [constants.contexts.test];
     let Test = require('./tests/test.js');
+    options.context = this.context;
     return new Test(options);
   }
 
   graph(options) {
+    this.context = options.context || [constants.contexts.graph];
     options.onlyCompile = true;
     
     let engine = new Engine({
       env: options.env,
       version: this.version,
       embarkConfig: options.embarkConfig || 'embark.json',
-      logFile: options.logFile
+      logFile: options.logFile,
+      context: this.context
     });
     engine.init();
 
@@ -253,11 +265,13 @@ class Embark {
   }
 
   reset() {
+    this.context = [constants.contexts.reset];
     let resetCmd = require('./cmds/reset.js');
     resetCmd();
   }
 
   upload(platform, options) {
+    this.context = options.context || [constants.contexts.upload, constants.contexts.build];
     
     // populate options that were instantiated with initConfig to pass around
     options.buildDir = 'dist/';
@@ -318,6 +332,7 @@ class Embark {
   }
 
   runTests(file) {
+    this.context = [constants.contexts.test];
     let RunTests = require('./tests/run_tests.js');
     RunTests.run(file);
   }
@@ -327,6 +342,7 @@ class Embark {
 // temporary until next refactor
 Embark.initTests = function(options) {
   let Test = require('./tests/test.js');
+  options.context = [constants.contexts.test];
   return new Test(options);
 };
 


### PR DESCRIPTION
- Enables multiple contexts at once (eg: `embark run` is ['run', 'build']
- Enables plugins to use the function `hasContext(context)` to test if the current running context contains one specific context.