### PR TITLE
Fix issues with missing web3 dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,9 +8,59 @@
       "version": "2.0.0",
       "resolved": "http://registry.npmjs.org/@sinonjs/formatio/-/formatio-2.0.0.tgz",
       "integrity": "sha512-ls6CAMA6/5gG+O/IdsBcblvnd8qcO/l1TYoNeAzp3wcISOxlPXQEus0mLcdwazEkWjaBdaJ3TaxmNgCLWwvWzg==",
+      "dev": true,
       "requires": {
         "samsam": "1.3.0"
       }
+    },
+    "@types/debug": {
+      "version": "0.0.30",
+      "resolved": "https://registry.npmjs.org/@types/debug/-/debug-0.0.30.tgz",
+      "integrity": "sha512-orGL5LXERPYsLov6CWs3Fh6203+dXzJkR7OnddIr2514Hsecwc8xRpzCapshBbKFImCsvS/mk6+FWiN5LyZJAQ=="
+    },
+    "@types/fs-extra": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/@types/fs-extra/-/fs-extra-5.0.2.tgz",
+      "integrity": "sha512-Q3FWsbdmkQd1ib11A4XNWQvRD//5KpPoGawA8aB2DR7pWKoW9XQv3+dGxD/Z1eVFze23Okdo27ZQytVFlweKvQ==",
+      "requires": {
+        "@types/node": "9.6.6"
+      }
+    },
+    "@types/lockfile": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@types/lockfile/-/lockfile-1.0.0.tgz",
+      "integrity": "sha512-pD6JuijPmrfi84qF3/TzGQ7zi0QIX+d7ZdetD6jUA6cp+IsCzAquXZfi5viesew+pfpOTIdAVKuh1SHA7KeKzg=="
+    },
+    "@types/node": {
+      "version": "9.6.6",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-9.6.6.tgz",
+      "integrity": "sha512-SJe0g5cZeGNDP5sD8mIX3scb+eq8LQQZ60FXiKZHipYSeEFZ5EKml+NNMiO76F74TY4PoMWlNxF/YRY40FOvZQ=="
+    },
+    "@types/node-fetch": {
+      "version": "1.6.9",
+      "resolved": "https://registry.npmjs.org/@types/node-fetch/-/node-fetch-1.6.9.tgz",
+      "integrity": "sha512-n2r6WLoY7+uuPT7pnEtKJCmPUGyJ+cbyBR8Avnu4+m1nzz7DwBVuyIvvlBzCZ/nrpC7rIgb3D6pNavL7rFEa9g==",
+      "requires": {
+        "@types/node": "9.6.6"
+      }
+    },
+    "@types/semver": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/@types/semver/-/semver-5.5.0.tgz",
+      "integrity": "sha512-41qEJgBH/TWgo5NFSvBCJ1qkoi3Q6ONSF2avrHq1LVEZfYpdHmj0y9SuTK+u9ZhG1sYQKBL1AWXKyLWP4RaUoQ=="
+    },
+    "@types/tar": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@types/tar/-/tar-4.0.0.tgz",
+      "integrity": "sha512-YybbEHNngcHlIWVCYsoj7Oo1JU9JqONuAlt1LlTH/lmL8BMhbzdFUgReY87a05rY1j8mfK47Del+TCkaLAXwLw==",
+      "requires": {
+        "@types/node": "9.6.6"
+      }
+    },
+    "@types/url-join": {
+      "version": "0.8.2",
+      "resolved": "https://registry.npmjs.org/@types/url-join/-/url-join-0.8.2.tgz",
+      "integrity": "sha1-EYHsvh2XtwNODqHjXmLobMJrQi0="
     },
     "abbrev": {
       "version": "1.1.1",
@@ -97,7 +147,7 @@
     "ansi-escapes": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-3.1.0.tgz",
-      "integrity": "sha1-9zIHu4EgfXX9bIPxJa8m7qN4yjA=",
+      "integrity": "sha512-UgAb8H9D41AQnu/PbWlCofQVcnV4Gs2bBJi9eZPxfU/hgglFh3SMDMENRIqdr7H6XFnXdoknctFByVsCOotTVw==",
       "dev": true
     },
     "ansi-regex": {
@@ -236,7 +286,7 @@
     "async-limiter": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/async-limiter/-/async-limiter-1.0.0.tgz",
-      "integrity": "sha1-ePrtjD0HSrgfIrTphdeehzj3IPg="
+      "integrity": "sha512-jp/uFnooOiO+L211eZOoSyzpOITMXx1rBITauYykG3BRYPu8h0UcxsPNB04RR5vo4Tyz3+ay17tR6JVf9qzYWg=="
     },
     "asynckit": {
       "version": "0.4.0",
@@ -1082,7 +1132,7 @@
     "bluebird": {
       "version": "3.5.1",
       "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.1.tgz",
-      "integrity": "sha1-2VUfnemPH82h5oPRfukaBgLuLrk="
+      "integrity": "sha512-MKiLiV+I1AA596t9w1sQJ8jkiSr5+ZKi0WKrYGUn6d1Fx+Ij4tIj+m2WMQSGczs5jZVxV339chE8iwk6F64wjA=="
     },
     "bn.js": {
       "version": "4.11.8",
@@ -1447,7 +1497,7 @@
     "circular-json": {
       "version": "0.3.3",
       "resolved": "https://registry.npmjs.org/circular-json/-/circular-json-0.3.3.tgz",
-      "integrity": "sha1-gVyZ6oT2gJUp0vRXkb34JxE1LWY=",
+      "integrity": "sha512-UZK3NBx2Mca+b5LsG7bY183pHWt5Y1xts4P3Pz7ENTwGVnJOUWbRb3ocjvX7hx9tq/yTAdclXm9sZ38gNuem4A==",
       "dev": true
     },
     "clap": {
@@ -1655,7 +1705,7 @@
     "commander": {
       "version": "2.15.1",
       "resolved": "https://registry.npmjs.org/commander/-/commander-2.15.1.tgz",
-      "integrity": "sha1-30boZ9D8Kuxmo0ZitAapzK//Ww8="
+      "integrity": "sha512-VlfT9F3V0v+jr4yxPc5gg9s62/fIVWsd2Bk2iD435um1NlGMYdVCq+MjcXnhYq2icNOizHr1kK+5TI6H0Hy0ag=="
     },
     "commondir": {
       "version": "1.0.1",
@@ -1703,7 +1753,7 @@
     "content-type": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.4.tgz",
-      "integrity": "sha1-4TjMdeBAxyexlm/l5fjJruJW/js="
+      "integrity": "sha512-hIP3EEPs8tB9AT1L+NUqtwOAps4mk2Zob89MWXMHjHWg9milF/j4osnnQLXBCBFBk/tvIG/tUc9mOUJiPBhPXA=="
     },
     "convert-source-map": {
       "version": "1.5.1",
@@ -1803,7 +1853,7 @@
         "boom": {
           "version": "5.2.0",
           "resolved": "https://registry.npmjs.org/boom/-/boom-5.2.0.tgz",
-          "integrity": "sha1-XdnabuOl8wIHdDYpDLcX0/SlTgI=",
+          "integrity": "sha512-Z5BTk6ZRe4tXXQlkqftmsAUANpXmuwlsF5Oov8ThoMbQRzdGTA1ngYRW160GexgOgjsFOKJz0LYhoNi+2AMBUw==",
           "requires": {
             "hoek": "4.2.1"
           }
@@ -1836,7 +1886,7 @@
     "css-loader": {
       "version": "0.28.11",
       "resolved": "https://registry.npmjs.org/css-loader/-/css-loader-0.28.11.tgz",
-      "integrity": "sha1-w/mGSnAL4nEbtaJGKyOJsaOS2rc=",
+      "integrity": "sha512-wovHgjAx8ZIMGSL8pTys7edA1ClmzxHeY6n/d97gg5odgsxEgKjULPR0viqyC+FWMCL9sfqoC/QCUBo62tLvPg==",
       "requires": {
         "babel-code-frame": "6.26.0",
         "css-selector-tokenizer": "0.7.0",
@@ -2020,7 +2070,7 @@
     "decompress-tar": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/decompress-tar/-/decompress-tar-4.1.1.tgz",
-      "integrity": "sha1-cYy9P8sWIJcW5womuE57pFkuWvE=",
+      "integrity": "sha512-JdJMaCrGpB5fESVyxwpCx4Jdj2AagLmv3y58Qy4GE6HMVjWz1FeVQk1Ct4Kye7PftcdOo/7U7UKzYBJgqnGeUQ==",
       "requires": {
         "file-type": "5.2.0",
         "is-stream": "1.1.0",
@@ -2030,7 +2080,7 @@
     "decompress-tarbz2": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/decompress-tarbz2/-/decompress-tarbz2-4.1.1.tgz",
-      "integrity": "sha1-MIKluIDqQEOBY0nzeLVsUWvho5s=",
+      "integrity": "sha512-s88xLzf1r81ICXLAVQVzaN6ZmX4A6U4z2nMbOwobxkLoIIfjVMBg7TeguTUXkKeXni795B6y5rnvDw7rxhAq9A==",
       "requires": {
         "decompress-tar": "4.1.1",
         "file-type": "6.2.0",
@@ -2042,14 +2092,14 @@
         "file-type": {
           "version": "6.2.0",
           "resolved": "https://registry.npmjs.org/file-type/-/file-type-6.2.0.tgz",
-          "integrity": "sha1-5QzXXTVv/tTjBtxPW89Sp5kDqRk="
+          "integrity": "sha512-YPcTBDV+2Tm0VqjybVd32MHdlEGAtuxS3VAYsumFokDSMG+ROT5wawGlnHDoz7bfMcMDt9hxuXvXwoKUx2fkOg=="
         }
       }
     },
     "decompress-targz": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/decompress-targz/-/decompress-targz-4.1.1.tgz",
-      "integrity": "sha1-wJvDXE0R894J8tLaU+neI+fOHu4=",
+      "integrity": "sha512-4z81Znfr6chWnRDNfFNqLwPvm4db3WuZkqV+UgXQzSngG3CEKdBkw5jrv3axjjL96glyiiKjsxJG3X6WBZwX3w==",
       "requires": {
         "decompress-tar": "4.1.1",
         "file-type": "5.2.0",
@@ -2197,7 +2247,7 @@
     "doctrine": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-2.1.0.tgz",
-      "integrity": "sha1-XNAfwQFiG0LEzX9dGmYkNxbT850=",
+      "integrity": "sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==",
       "dev": true,
       "requires": {
         "esutils": "2.0.2"
@@ -2253,7 +2303,7 @@
     "ejs": {
       "version": "2.5.8",
       "resolved": "https://registry.npmjs.org/ejs/-/ejs-2.5.8.tgz",
-      "integrity": "sha1-KraVRhnyJeYZO3rF98OcSP7+Q4A="
+      "integrity": "sha512-QIDZL54fyV8MDcAsO91BMH1ft2qGGaHIJsJIA/+t+7uvXol1dm413fPcUgUb4k8F/9457rx4/KFE4XfDifrQxQ=="
     },
     "electron-to-chromium": {
       "version": "1.3.37",
@@ -2432,7 +2482,7 @@
     "eslint": {
       "version": "4.13.1",
       "resolved": "https://registry.npmjs.org/eslint/-/eslint-4.13.1.tgz",
-      "integrity": "sha1-AFXgAURkx+t4eMr1Se8pQZkrRE8=",
+      "integrity": "sha512-UCJVV50RtLHYzBp1DZ8CMPtRSg4iVZvjgO9IJHIKyWU/AnJVjtdRikoUPLB29n5pzMB7TnsLQWf0V6VUJfoPfw==",
       "dev": true,
       "requires": {
         "ajv": "5.5.2",
@@ -2495,7 +2545,7 @@
         "ansi-styles": {
           "version": "3.2.1",
           "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-          "integrity": "sha1-QfuyAkPlCxK+DwS43tvwdSDOhB0=",
+          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
           "dev": true,
           "requires": {
             "color-convert": "1.9.1"
@@ -2504,7 +2554,7 @@
         "chalk": {
           "version": "2.3.2",
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.2.tgz",
-          "integrity": "sha1-JQ3JawdJG/1gHmSNZt319gx6XGU=",
+          "integrity": "sha512-ZM4j2/ld/YZDc3Ma8PgN7gyAk+kHMMMyzLNryCPGhWrsfAuDVeuid5bpRFTDgMH9JBK2lA4dyyAkkZYF/WcqDQ==",
           "dev": true,
           "requires": {
             "ansi-styles": "3.2.1",
@@ -2515,7 +2565,7 @@
         "debug": {
           "version": "3.1.0",
           "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
-          "integrity": "sha1-W7WgZyYotkFJVmuhaBnmFRjGcmE=",
+          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
           "dev": true,
           "requires": {
             "ms": "2.0.0"
@@ -2524,13 +2574,13 @@
         "esprima": {
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.0.tgz",
-          "integrity": "sha1-RJnt3NERDgshi6zy+n9/WfVcqAQ=",
+          "integrity": "sha512-oftTcaMu/EGrEIu904mWteKIv8vMuOgGYo7EhVJJN00R/EED9DCua/xxHRdYnKtcECzVg7xOWhflvJMnqcFZjw==",
           "dev": true
         },
         "globals": {
           "version": "11.4.0",
           "resolved": "https://registry.npmjs.org/globals/-/globals-11.4.0.tgz",
-          "integrity": "sha1-uFx5M0lWHBYHajwTVJI4onlF8bw=",
+          "integrity": "sha512-Dyzmifil8n/TmSqYDEXbm+C8yitzJQqQIlJQLNRMwa+BOUJpRC19pyVeN12JAjt61xonvXjtff+hJruTRXn5HA==",
           "dev": true
         },
         "has-flag": {
@@ -2542,7 +2592,7 @@
         "js-yaml": {
           "version": "3.11.0",
           "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.11.0.tgz",
-          "integrity": "sha1-WXwai9VxUvJtYizkEXhRpR9euu8=",
+          "integrity": "sha512-saJstZWv7oNeOyBh3+Dx1qWzhW0+e6/8eDzo7p5rDFqxntSztloLtuKu+Ejhtq82jsilwOIZYsCz+lIjthg1Hw==",
           "dev": true,
           "requires": {
             "argparse": "1.0.10",
@@ -2561,7 +2611,7 @@
         "supports-color": {
           "version": "5.3.0",
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.3.0.tgz",
-          "integrity": "sha1-WySsFduA+pJ89SJ6SjP9PEx2dsA=",
+          "integrity": "sha512-0aP01LLIskjKs3lq52EC0aGBAJhLq7B2Rd8HC/DR/PtNNpcLilNmHC12O+hu0usQpo7wtHNRqtrhBwtDb0+dNg==",
           "dev": true,
           "requires": {
             "has-flag": "3.0.0"
@@ -2582,7 +2632,7 @@
     "espree": {
       "version": "3.5.4",
       "resolved": "https://registry.npmjs.org/espree/-/espree-3.5.4.tgz",
-      "integrity": "sha1-sPRHGHyKi+2US4FaZgvd9d610ac=",
+      "integrity": "sha512-yAcIQxtmMiB/jL32dzEp2enBeidsB7xWPLNiw3IIkpVds1P+h7qF9YwJq1yUNzp2OKXgAprs4F61ih66UsoD1A==",
       "dev": true,
       "requires": {
         "acorn": "5.5.3",
@@ -2629,7 +2679,7 @@
     "eth-lib": {
       "version": "0.1.27",
       "resolved": "https://registry.npmjs.org/eth-lib/-/eth-lib-0.1.27.tgz",
-      "integrity": "sha1-8LD9FE+GXS1r+CV6QABPLnXKHdY=",
+      "integrity": "sha512-B8czsfkJYzn2UIEMwjc7Mbj+Cy72V+/OXH/tb44LV8jhrjizQJJ325xMOMyk3+ETa6r6oi0jsUY14+om8mQMWA==",
       "requires": {
         "bn.js": "4.11.8",
         "elliptic": "6.4.0",
@@ -2944,7 +2994,7 @@
     "finalhandler": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.1.1.tgz",
-      "integrity": "sha1-7r9O2EAHnIP0JJA4ydcDAIMBsQU=",
+      "integrity": "sha512-Y1GUDo39ez4aHAw7MysnUD5JzYX+WaIj8I57kO3aEPT1fFRL4sr7mjei97FgnwhAyyzRYmQZaTHb2+9uZ1dPtg==",
       "requires": {
         "debug": "2.6.9",
         "encodeurl": "1.0.2",
@@ -3110,6 +3160,14 @@
       "requires": {
         "graceful-fs": "4.1.11",
         "jsonfile": "2.4.0"
+      }
+    },
+    "fs-minipass": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-1.2.5.tgz",
+      "integrity": "sha512-JhBl0skXjUPCFH7x6x61gQxrKyXsxB5gcgePLZCwfyCGGsTISMoIeObbrvVeP6Xmyaudw4TT43qV2Gz+iyd2oQ==",
+      "requires": {
+        "minipass": "2.2.1"
       }
     },
     "fs-promise": {
@@ -4204,7 +4262,7 @@
     "got": {
       "version": "7.1.0",
       "resolved": "https://registry.npmjs.org/got/-/got-7.1.0.tgz",
-      "integrity": "sha1-BUUP2ECU5rvqVvRRpDqcKJFmOFo=",
+      "integrity": "sha512-Y5WMo7xKKq1muPsxD+KmrR8DH5auG7fBdDVueZwETwV6VytKyU9OX/ddpq2/1hp1vIPvVb4T81dKQz3BivkNLw==",
       "requires": {
         "decompress-response": "3.3.0",
         "duplexer3": "0.1.4",
@@ -4551,12 +4609,12 @@
     "has-symbol-support-x": {
       "version": "1.4.2",
       "resolved": "https://registry.npmjs.org/has-symbol-support-x/-/has-symbol-support-x-1.4.2.tgz",
-      "integrity": "sha1-FAn5i8ACR9pF2mfO4KNvKC/yZFU="
+      "integrity": "sha512-3ToOva++HaW+eCpgqZrCfN51IPB+7bJNVT6CUATzueB5Heb8o6Nam0V3HG5dlDvZU1Gn5QLcbahiKw/XVk5JJw=="
     },
     "has-to-string-tag-x": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/has-to-string-tag-x/-/has-to-string-tag-x-1.4.1.tgz",
-      "integrity": "sha1-oEWrOD17SyASoAFIqwql8pAETU0=",
+      "integrity": "sha512-vdbKfmw+3LoOYVr+mtxHaX5a96+0f3DljYd8JOqvOLsf5mw2Otda2qCDT9qRqLAhrjyQ0h7ual5nOiASpsGNFw==",
       "requires": {
         "has-symbol-support-x": "1.4.2"
       }
@@ -4640,7 +4698,7 @@
     "hawk": {
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/hawk/-/hawk-6.0.2.tgz",
-      "integrity": "sha1-r02RTrBl+bXOTZ0RwcshJu7MMDg=",
+      "integrity": "sha512-miowhl2+U7Qle4vdLqDdPt9m09K6yZhkLDTWGoUiUzrQCn+mHHSmfJgAyGaLRZbPmTqfFFjRV1QWCW0VWUJBbQ==",
       "requires": {
         "boom": "4.3.1",
         "cryptiles": "3.1.2",
@@ -4661,7 +4719,7 @@
     "hoek": {
       "version": "4.2.1",
       "resolved": "https://registry.npmjs.org/hoek/-/hoek-4.2.1.tgz",
-      "integrity": "sha1-ljRQKqEsRF3Vp8VzS1cruHOKrLs="
+      "integrity": "sha512-QLg82fGkfnJ/4iy1xZ81/9SIJiq1NGFUMGs6ParyjBZr6jW2Ufj/snDqTHixNlHdPNwN2RLVD0Pi3igeK9+JfA=="
     },
     "home-or-tmp": {
       "version": "2.0.0",
@@ -4818,7 +4876,7 @@
     "ignore": {
       "version": "3.3.7",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-3.3.7.tgz",
-      "integrity": "sha1-YSKJv7PCIOGGpYEYYY1b6MG6sCE=",
+      "integrity": "sha512-YGG3ejvBNHRqu0559EOxxNFihD0AjpvHlC/pdGKd3X3ofe+CoJkYazwNJYTNebqpPKN+VVQbh4ZFn1DivMNuHA==",
       "dev": true
     },
     "imurmurhash": {
@@ -4863,7 +4921,7 @@
     "inquirer": {
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-3.3.0.tgz",
-      "integrity": "sha1-ndLyrXZdyrH/BEO0kUQqILoifck=",
+      "integrity": "sha512-h+xtnyk4EwKvFWHrUYsWErEVR+igKtLdchu+o0Z1RL7VU/jVMFbYir2bp6bAj8efFNxWqHX0dIss6fJQ+/+qeQ==",
       "dev": true,
       "requires": {
         "ansi-escapes": "3.1.0",
@@ -4891,7 +4949,7 @@
         "ansi-styles": {
           "version": "3.2.1",
           "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-          "integrity": "sha1-QfuyAkPlCxK+DwS43tvwdSDOhB0=",
+          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
           "dev": true,
           "requires": {
             "color-convert": "1.9.1"
@@ -4900,7 +4958,7 @@
         "chalk": {
           "version": "2.3.2",
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.2.tgz",
-          "integrity": "sha1-JQ3JawdJG/1gHmSNZt319gx6XGU=",
+          "integrity": "sha512-ZM4j2/ld/YZDc3Ma8PgN7gyAk+kHMMMyzLNryCPGhWrsfAuDVeuid5bpRFTDgMH9JBK2lA4dyyAkkZYF/WcqDQ==",
           "dev": true,
           "requires": {
             "ansi-styles": "3.2.1",
@@ -4926,7 +4984,7 @@
         "supports-color": {
           "version": "5.3.0",
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.3.0.tgz",
-          "integrity": "sha1-WySsFduA+pJ89SJ6SjP9PEx2dsA=",
+          "integrity": "sha512-0aP01LLIskjKs3lq52EC0aGBAJhLq7B2Rd8HC/DR/PtNNpcLilNmHC12O+hu0usQpo7wtHNRqtrhBwtDb0+dNg==",
           "dev": true,
           "requires": {
             "has-flag": "3.0.0"
@@ -5230,7 +5288,7 @@
     "is-path-in-cwd": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/is-path-in-cwd/-/is-path-in-cwd-1.0.1.tgz",
-      "integrity": "sha1-WsSLNF72dTOb1sekipEhELJBz1I=",
+      "integrity": "sha512-FjV1RTW48E7CWM7eE/J2NJvAEEVektecDBVBE5Hh3nM1Jd0kvhHtX68Pr3xsDf857xt3Y4AkwVULK1Vku62aaQ==",
       "dev": true,
       "requires": {
         "is-path-inside": "1.0.1"
@@ -5288,7 +5346,7 @@
     "is-resolvable": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/is-resolvable/-/is-resolvable-1.1.0.tgz",
-      "integrity": "sha1-+xj4fOH+uSUWnJpAfBkxijIG7Yg=",
+      "integrity": "sha512-qgDYXFSR5WvEfuS5dMj6oTMEbrrSaM0CrFk2Yiq/gXnBvD9pMa2jGXxyhGLfvhZpuMZe18CJpFxAt3CRs42NMg==",
       "dev": true
     },
     "is-retry-allowed": {
@@ -5350,7 +5408,7 @@
     "isurl": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/isurl/-/isurl-1.0.0.tgz",
-      "integrity": "sha1-sn9PSfPNqj6kSgpbfzRi5u3DnWc=",
+      "integrity": "sha512-1P/yWsxPlDtn7QeRD+ULKQPaIaN6yF368GZ2vDfv0AL0NwpStafjWCDDdn0k8wgFMWpVAqG7oJhxHnlud42i9w==",
       "requires": {
         "has-to-string-tag-x": "1.4.1",
         "is-object": "1.0.1"
@@ -5470,7 +5528,8 @@
     "just-extend": {
       "version": "1.1.27",
       "resolved": "https://registry.npmjs.org/just-extend/-/just-extend-1.1.27.tgz",
-      "integrity": "sha512-mJVp13Ix6gFo3SBAy9U/kL+oeZqzlYYYLQBwXVBlVzIsZwBqGREnOro24oC/8s8aox+rJhtZ2DiQof++IrkA+g=="
+      "integrity": "sha512-mJVp13Ix6gFo3SBAy9U/kL+oeZqzlYYYLQBwXVBlVzIsZwBqGREnOro24oC/8s8aox+rJhtZ2DiQof++IrkA+g==",
+      "dev": true
     },
     "keccakjs": {
       "version": "0.2.1",
@@ -5630,6 +5689,81 @@
         }
       }
     },
+    "live-plugin-manager": {
+      "version": "git+https://github.com/iurimatias/live-plugin-manager.git#b494a103a84733611c7d921bd0e8c6d699b33c5a",
+      "requires": {
+        "@types/debug": "0.0.30",
+        "@types/fs-extra": "5.0.2",
+        "@types/lockfile": "1.0.0",
+        "@types/node-fetch": "1.6.9",
+        "@types/semver": "5.5.0",
+        "@types/tar": "4.0.0",
+        "@types/url-join": "0.8.2",
+        "debug": "3.1.0",
+        "fs-extra": "5.0.0",
+        "lockfile": "1.0.4",
+        "node-fetch": "2.1.2",
+        "semver": "5.5.0",
+        "tar": "4.4.1",
+        "url-join": "4.0.0"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "fs-extra": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-5.0.0.tgz",
+          "integrity": "sha512-66Pm4RYbjzdyeuqudYqhFiNBbCIuI9kgRqLPSHIlXHidW8NIQtVdkM1yeZ4lXwuhbTETv3EUGMNHAAw6hiundQ==",
+          "requires": {
+            "graceful-fs": "4.1.11",
+            "jsonfile": "4.0.0",
+            "universalify": "0.1.1"
+          }
+        },
+        "jsonfile": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
+          "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
+          "requires": {
+            "graceful-fs": "4.1.11"
+          }
+        },
+        "minipass": {
+          "version": "2.2.4",
+          "resolved": "https://registry.npmjs.org/minipass/-/minipass-2.2.4.tgz",
+          "integrity": "sha512-hzXIWWet/BzWhYs2b+u7dRHlruXhwdgvlTMDKC6Cb1U7ps6Ac6yQlR39xsbjWJE377YTCtKwIXIpJ5oP+j5y8g==",
+          "requires": {
+            "safe-buffer": "5.1.1",
+            "yallist": "3.0.2"
+          }
+        },
+        "tar": {
+          "version": "4.4.1",
+          "resolved": "https://registry.npmjs.org/tar/-/tar-4.4.1.tgz",
+          "integrity": "sha512-O+v1r9yN4tOsvl90p5HAP4AEqbYhx4036AGMm075fH9F8Qwi3oJ+v4u50FkT/KkvywNGtwkk0zRI+8eYm1X/xg==",
+          "requires": {
+            "chownr": "1.0.1",
+            "fs-minipass": "1.2.5",
+            "minipass": "2.2.4",
+            "minizlib": "1.1.0",
+            "mkdirp": "0.5.1",
+            "safe-buffer": "5.1.1",
+            "yallist": "3.0.2"
+          }
+        },
+        "yallist": {
+          "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.0.2.tgz",
+          "integrity": "sha1-hFK0u36Dx8GI2AQcGoN8dz1ti7k="
+        }
+      }
+    },
     "load-json-file": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-2.0.0.tgz",
@@ -5685,6 +5819,14 @@
       "resolved": "https://registry.npmjs.org/lock/-/lock-0.1.4.tgz",
       "integrity": "sha1-/sfervF+fDoKVeHaBCgD4l2RdF0="
     },
+    "lockfile": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/lockfile/-/lockfile-1.0.4.tgz",
+      "integrity": "sha512-cvbTwETRfsFh4nHsL1eGWapU1XFi5Ot9E85sWAwia7Y7EgB7vfqcZhTKZ+l7hCGxSPoushMv5GKhT5PdLv03WA==",
+      "requires": {
+        "signal-exit": "3.0.2"
+      }
+    },
     "lodash": {
       "version": "4.17.5",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.5.tgz",
@@ -5708,7 +5850,8 @@
     "lodash.get": {
       "version": "4.4.2",
       "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
-      "integrity": "sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk="
+      "integrity": "sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk=",
+      "dev": true
     },
     "lodash.map": {
       "version": "4.6.0",
@@ -5748,7 +5891,8 @@
     "lolex": {
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/lolex/-/lolex-2.3.2.tgz",
-      "integrity": "sha512-A5pN2tkFj7H0dGIAM6MFvHKMJcPnjZsOMvR7ujCjfgW5TbV6H9vb1PgxLtHvjqNZTHsUolz+6/WEO0N1xNx2ng=="
+      "integrity": "sha512-A5pN2tkFj7H0dGIAM6MFvHKMJcPnjZsOMvR7ujCjfgW5TbV6H9vb1PgxLtHvjqNZTHsUolz+6/WEO0N1xNx2ng==",
+      "dev": true
     },
     "longest": {
       "version": "1.0.1",
@@ -5781,7 +5925,7 @@
     "lowercase-keys": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-1.0.1.tgz",
-      "integrity": "sha1-b54wtHCE2XGnyCD/FabFFnt0wm8="
+      "integrity": "sha512-G2Lj61tXDnVFFOi8VZds+SoQjtQC3dgokKdDG2mTm1tx4m50NUHBOZSBwQQHyy0V12A0JTG4icfZQH+xPyh8VA=="
     },
     "lru-cache": {
       "version": "4.1.2",
@@ -6078,12 +6222,12 @@
     "mime-db": {
       "version": "1.33.0",
       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.33.0.tgz",
-      "integrity": "sha1-o0kgUKXLm2NFBUHjnZeI0icng9s="
+      "integrity": "sha512-BHJ/EKruNIqJf/QahvxwQZXKygOQ256myeN/Ew+THcAa5q+PjyTTMMeNQC4DZw5AwfvelsUrA6B67NKMqXDbzQ=="
     },
     "mime-types": {
       "version": "2.1.18",
       "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.18.tgz",
-      "integrity": "sha1-bzI/YKg9ERRvgx/xH9ZuL+VQO7g=",
+      "integrity": "sha512-lc/aahn+t4/SWV/qcmumYjymLsWfN3ELhpmVuUFjgsORruuZPVSwAQryq+HHGvO/SI2KVX26bx+En+zhM8g8hQ==",
       "requires": {
         "mime-db": "1.33.0"
       }
@@ -6266,7 +6410,7 @@
     "mock-fs": {
       "version": "4.4.2",
       "resolved": "https://registry.npmjs.org/mock-fs/-/mock-fs-4.4.2.tgz",
-      "integrity": "sha1-Cd7FMT+XCVpFC+aqKtirZzjWPWs="
+      "integrity": "sha512-dF+yxZSojSiI8AXGoxj5qdFWpucndc54Ug+TwlpHFaV7j22MGG+OML2+FVa6xAZtjb/OFFQhOC37Jegx2GbEwA=="
     },
     "mout": {
       "version": "0.11.1",
@@ -6342,7 +6486,7 @@
     "mz": {
       "version": "2.7.0",
       "resolved": "https://registry.npmjs.org/mz/-/mz-2.7.0.tgz",
-      "integrity": "sha1-lQCAV6Vsr63CvGPd5/n/aVWUjjI=",
+      "integrity": "sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==",
       "requires": {
         "any-promise": "1.3.0",
         "object-assign": "4.1.1",
@@ -6433,6 +6577,7 @@
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/nise/-/nise-1.3.3.tgz",
       "integrity": "sha512-v1J/FLUB9PfGqZLGDBhQqODkbLotP0WtLo9R4EJY2PPu5f5Xg4o0rA8FDlmrjFSv9vBBKcfnOSpfYYuu5RTHqg==",
+      "dev": true,
       "requires": {
         "@sinonjs/formatio": "2.0.0",
         "just-extend": "1.1.27",
@@ -6444,17 +6589,24 @@
         "isarray": {
           "version": "0.0.1",
           "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
+          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
+          "dev": true
         },
         "path-to-regexp": {
           "version": "1.7.0",
           "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.7.0.tgz",
           "integrity": "sha1-Wf3g9DW62suhA6hOnTvGTpa5k30=",
+          "dev": true,
           "requires": {
             "isarray": "0.0.1"
           }
         }
       }
+    },
+    "node-fetch": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.1.2.tgz",
+      "integrity": "sha1-q4hOjn5X44qUR1POxwb3iNF2i7U="
     },
     "node-forge": {
       "version": "0.7.4",
@@ -6495,6 +6647,7 @@
       "version": "1.0.35",
       "resolved": "https://registry.npmjs.org/node-webcrypto-ossl/-/node-webcrypto-ossl-1.0.35.tgz",
       "integrity": "sha1-FCJVeb0J9dY7CtbO4LqAD4xqBg0=",
+      "optional": true,
       "requires": {
         "mkdirp": "0.5.1",
         "nan": "2.9.2",
@@ -6912,7 +7065,7 @@
     "p-cancelable": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/p-cancelable/-/p-cancelable-0.3.0.tgz",
-      "integrity": "sha1-ueEjgAvOu3rBOkeb4ZW1B7mNMPo="
+      "integrity": "sha512-RVbZPLso8+jFeq1MfNvgXtCRED2raz/dKpacfTNxsx6pLEpEomM7gah6VeHSYV3+vo0OAi4MkArtQcWWXuQoyw=="
     },
     "p-finally": {
       "version": "1.0.0",
@@ -7168,7 +7321,7 @@
     "pluralize": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/pluralize/-/pluralize-7.0.0.tgz",
-      "integrity": "sha1-KYuJ34uTsCIdv0Ia0rGx6iP8Z3c=",
+      "integrity": "sha512-ARhBOdzS3e41FbkW/XWrTEtukqqLoK5+Z/4UeDaLuSW+39JPeFgs4gCGqsrJHVZX0fUrx//4OF0K1CUGwlIFow==",
       "dev": true
     },
     "posix-character-classes": {
@@ -7777,7 +7930,7 @@
     "proxy-addr": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.3.tgz",
-      "integrity": "sha1-NV8mJQWmIWRrMTCnKOtkfiIFU0E=",
+      "integrity": "sha512-jQTChiCJteusULxjBp8+jftSQE5Obdl3k4cnmLA6WXtK6XFuWRnvVL7aCiBqaLPM8c4ph0S4tKna8XvmIwEnXQ==",
       "requires": {
         "forwarded": "0.1.2",
         "ipaddr.js": "1.6.0"
@@ -8202,7 +8355,7 @@
     "request": {
       "version": "2.85.0",
       "resolved": "https://registry.npmjs.org/request/-/request-2.85.0.tgz",
-      "integrity": "sha1-WgNhWkfGFCCz65m326IE+DYD4fo=",
+      "integrity": "sha512-8H7Ehijd4js+s6wuVPLjwORxD4zeuyjYugprdOXlPSqaApmL/QOy+EB/beICHVCHkGMKNh5rvihb5ov+IDw4mg==",
       "requires": {
         "aws-sign2": "0.7.0",
         "aws4": "1.6.0",
@@ -8384,7 +8537,8 @@
     "samsam": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/samsam/-/samsam-1.3.0.tgz",
-      "integrity": "sha512-1HwIYD/8UlOtFS3QO3w7ey+SdSDFE4HRNLZoZRYVQefrOY3l17epswImeB1ijgJFQJodIaHcwkp3r/myBjFVbg=="
+      "integrity": "sha512-1HwIYD/8UlOtFS3QO3w7ey+SdSDFE4HRNLZoZRYVQefrOY3l17epswImeB1ijgJFQJodIaHcwkp3r/myBjFVbg==",
+      "dev": true
     },
     "sax": {
       "version": "1.2.4",
@@ -8504,7 +8658,7 @@
     "servify": {
       "version": "0.1.12",
       "resolved": "https://registry.npmjs.org/servify/-/servify-0.1.12.tgz",
-      "integrity": "sha1-FCq3vuHx0DO2bQcHCGCFsXwG25U=",
+      "integrity": "sha512-/xE6GvsKKqyo1BAY+KxOWXcLpPsUUyji7Qg3bVD7hh1eRze5bR1uYiuDA/k3Gof1s9BTzQZEJK8sNcNGFIzeWw==",
       "requires": {
         "body-parser": "1.18.2",
         "cors": "2.8.4",
@@ -8620,7 +8774,7 @@
     "simple-get": {
       "version": "2.7.0",
       "resolved": "https://registry.npmjs.org/simple-get/-/simple-get-2.7.0.tgz",
-      "integrity": "sha1-rTf5JtCBKSN/8IxPLt/W8Q4DgLU=",
+      "integrity": "sha512-RkE9rGPHcxYZ/baYmgJtOSM63vH0Vyq+ma5TijBcLla41SWlh8t6XYIGMR/oeZcmr+/G8k+zrClkkVrtnQ0esg==",
       "requires": {
         "decompress-response": "3.3.0",
         "once": "1.4.0",
@@ -8631,6 +8785,7 @@
       "version": "4.5.0",
       "resolved": "https://registry.npmjs.org/sinon/-/sinon-4.5.0.tgz",
       "integrity": "sha512-trdx+mB0VBBgoYucy6a9L7/jfQOmvGeaKZT4OOJ+lPAtI8623xyGr8wLiE4eojzBS8G9yXbhx42GHUOVLr4X2w==",
+      "dev": true,
       "requires": {
         "@sinonjs/formatio": "2.0.0",
         "diff": "3.5.0",
@@ -8644,17 +8799,20 @@
         "diff": {
           "version": "3.5.0",
           "resolved": "https://registry.npmjs.org/diff/-/diff-3.5.0.tgz",
-          "integrity": "sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA=="
+          "integrity": "sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA==",
+          "dev": true
         },
         "has-flag": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-          "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
+          "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+          "dev": true
         },
         "supports-color": {
           "version": "5.4.0",
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
           "integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
+          "dev": true,
           "requires": {
             "has-flag": "3.0.0"
           }
@@ -8669,7 +8827,7 @@
     "slice-ansi": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-1.0.0.tgz",
-      "integrity": "sha1-BE8aSdiEL/MHqta1Be0Xi9lQE00=",
+      "integrity": "sha512-POqxBK6Lb3q6s047D/XsDVNPnF9Dl8JSaqe9h9lURl0OdNqy/ujDrOiIHtsqXMGbWWTIomRzAMaTyawAU//Reg==",
       "dev": true,
       "requires": {
         "is-fullwidth-code-point": "2.0.0"
@@ -8803,7 +8961,7 @@
     "sntp": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/sntp/-/sntp-2.1.0.tgz",
-      "integrity": "sha1-LGzsFP7cIiJznK+bXD2F0cxaLMg=",
+      "integrity": "sha512-FL1b58BDrqS3A11lJ0zEdnJ3UOKqVxawAkF3k7F0CVN7VQ34aZrV+G8BZ1WC9ZL7NyrwsW0oviwsWDgRuVYtJg==",
       "requires": {
         "hoek": "4.2.1"
       }
@@ -9314,7 +9472,7 @@
     "strip-dirs": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/strip-dirs/-/strip-dirs-2.1.0.tgz",
-      "integrity": "sha1-SYdzYmT8NEzyD2w0rKnRPR1O1sU=",
+      "integrity": "sha512-JOCxOeKLm2CAS73y/U4ZeZPTkE+gNVCzKt7Eox84Iej1LT/2pTWYpZKJuxwQpvX1LiZb1xokNR7RLfuBAa7T3g==",
       "requires": {
         "is-natural-number": "4.0.1"
       }
@@ -9406,7 +9564,7 @@
     "swarm-js": {
       "version": "0.1.37",
       "resolved": "https://registry.npmjs.org/swarm-js/-/swarm-js-0.1.37.tgz",
-      "integrity": "sha1-J9SFMXo0C77sQCkq94PMEKz6RmM=",
+      "integrity": "sha512-G8gi5fcXP/2upwiuOShJ258sIufBVztekgobr3cVgYXObZwJ5AXLqZn52AI+/ffft29pJexF9WNdUxjlkVehoQ==",
       "requires": {
         "bluebird": "3.5.1",
         "buffer": "5.1.0",
@@ -9426,7 +9584,7 @@
         "buffer": {
           "version": "5.1.0",
           "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.1.0.tgz",
-          "integrity": "sha1-yRPkNnjHy3yL0Wr7zdtsVQXo+f4=",
+          "integrity": "sha512-YkIRgwsZwJWTnyQrsBTWefizHh+8GYj3kbL1BTiAQ/9pwpino0G7B2gp5tx/FUBqUlvtxV85KNR3mwfAtv15Yw==",
           "requires": {
             "base64-js": "1.2.3",
             "ieee754": "1.1.8"
@@ -9541,7 +9699,7 @@
     "tar.gz": {
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/tar.gz/-/tar.gz-1.0.7.tgz",
-      "integrity": "sha1-V37yxZX6qnNFLvBBX+1BETISJXs=",
+      "integrity": "sha512-uhGatJvds/3diZrETqMj4RxBR779LKlIE74SsMcn5JProZsfs9j0QBwWO1RW+IWNJxS2x8Zzra1+AW6OQHWphg==",
       "requires": {
         "bluebird": "2.11.0",
         "commander": "2.15.1",
@@ -9570,7 +9728,8 @@
     "text-encoding": {
       "version": "0.6.4",
       "resolved": "https://registry.npmjs.org/text-encoding/-/text-encoding-0.6.4.tgz",
-      "integrity": "sha1-45mpgiV6J22uQou5KEXLcb3CbRk="
+      "integrity": "sha1-45mpgiV6J22uQou5KEXLcb3CbRk=",
+      "dev": true
     },
     "text-table": {
       "version": "0.2.0",
@@ -9632,7 +9791,7 @@
     "tmp": {
       "version": "0.0.33",
       "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
-      "integrity": "sha1-bTQzWIl2jSGyvNoKonfO07G/rfk=",
+      "integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
       "dev": true,
       "requires": {
         "os-tmpdir": "1.0.2"
@@ -9699,7 +9858,7 @@
     "tough-cookie": {
       "version": "2.3.4",
       "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.4.tgz",
-      "integrity": "sha1-7GDO44rGdQY//JelwYlwV47oNlU=",
+      "integrity": "sha512-TZ6TTfI5NtZnuyy/Kecv+CnoROnyXn2DN97LontgQpCwsX2XyLYCC0ENhYkehSOwAp8rTQKc/NUIF7BkQ5rKLA==",
       "requires": {
         "punycode": "1.4.1"
       }
@@ -9754,12 +9913,13 @@
     "type-detect": {
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
-      "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g=="
+      "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
+      "dev": true
     },
     "type-is": {
       "version": "1.6.16",
       "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.16.tgz",
-      "integrity": "sha1-+JzjQVQcZysl7nrjxz3uOyvlAZQ=",
+      "integrity": "sha512-HRkVv/5qY2G6I8iab9cI7v1bOIdhm94dVjQCPFElW9W+3GeDOSHmy2EBYe4VTApuzolPcmgFTN3ftVJRKR2J9Q==",
       "requires": {
         "media-typer": "0.3.0",
         "mime-types": "2.1.18"
@@ -9825,12 +9985,12 @@
     "ultron": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/ultron/-/ultron-1.1.1.tgz",
-      "integrity": "sha1-n+FTahCmZKZSZqHjzPhf02MCvJw="
+      "integrity": "sha512-UIEXBNeYmKptWH6z8ZnqTeS8fV74zG0/eRU9VGkpzz+LIJNs8W/zM/L+7ctCkRrgbNnnR0xxw4bKOr0cW0N0Og=="
     },
     "unbzip2-stream": {
       "version": "1.2.5",
       "resolved": "https://registry.npmjs.org/unbzip2-stream/-/unbzip2-stream-1.2.5.tgz",
-      "integrity": "sha1-c6AzpWe7veWWVLGTxE1Ip+T0PEc=",
+      "integrity": "sha512-izD3jxT8xkzwtXRUZjtmRwKnZoeECrfZ8ra/ketwOcusbZEp4mjULMnJOCfTDZBgGQAAY1AJ/IgxcwkavcX9Og==",
       "requires": {
         "buffer": "3.6.0",
         "through": "2.3.8"
@@ -9917,6 +10077,11 @@
       "resolved": "https://registry.npmjs.org/uniqs/-/uniqs-2.0.0.tgz",
       "integrity": "sha1-/+3ks2slKQaW5uFl1KWe25mOawI="
     },
+    "universalify": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.1.tgz",
+      "integrity": "sha1-+nG63UQ3r0wUiEHjs7Fl+enlkLc="
+    },
     "unpipe": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
@@ -9994,6 +10159,11 @@
           "integrity": "sha1-llOgNvt8HuQjQvIyXM7v6jkmxI0="
         }
       }
+    },
+    "url-join": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/url-join/-/url-join-4.0.0.tgz",
+      "integrity": "sha1-TTNA6AfTdzvamZH4MFrNzCpmXSo="
     },
     "url-loader": {
       "version": "0.6.2",
@@ -10092,7 +10262,7 @@
     "uuid": {
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.2.1.tgz",
-      "integrity": "sha1-EsUou51Y0LkmXZovbw/ovhf/HxQ="
+      "integrity": "sha512-jZnMwlb9Iku/O3smGWvZhauCf6cvvpKi4BKRiliS3cxnI+Gz9j5MEpTz2UFuXiKPJocb7gnsLHwiS05ige5BEA=="
     },
     "validate-npm-package-license": {
       "version": "3.0.3",
@@ -10131,7 +10301,7 @@
     "viz.js": {
       "version": "1.8.1",
       "resolved": "https://registry.npmjs.org/viz.js/-/viz.js-1.8.1.tgz",
-      "integrity": "sha1-J3qzz0NnxgipWygadHIIPD4u5s8="
+      "integrity": "sha512-KrSNgnIxec+JCAqDPliO6xYA69ToH2WTYB2Kbt8Bp/XRUvm23rTyfffFi4rvQLFkIRNUz/xCnnqhh/gChhsgGA=="
     },
     "vlq": {
       "version": "0.2.3",
@@ -10462,250 +10632,264 @@
         "web3-net": "1.0.0-beta.34",
         "web3-shh": "1.0.0-beta.34",
         "web3-utils": "1.0.0-beta.34"
+      }
+    },
+    "web3-bzz": {
+      "version": "1.0.0-beta.34",
+      "resolved": "https://registry.npmjs.org/web3-bzz/-/web3-bzz-1.0.0-beta.34.tgz",
+      "integrity": "sha1-Bo03d3q2Xlxg+OyLmlDP5FJ3kpw=",
+      "requires": {
+        "got": "7.1.0",
+        "swarm-js": "0.1.37",
+        "underscore": "1.8.3"
+      }
+    },
+    "web3-core": {
+      "version": "1.0.0-beta.34",
+      "resolved": "https://registry.npmjs.org/web3-core/-/web3-core-1.0.0-beta.34.tgz",
+      "integrity": "sha1-EhvoVV6fsA0sXQXd0zgdDJ5GmH4=",
+      "requires": {
+        "web3-core-helpers": "1.0.0-beta.34",
+        "web3-core-method": "1.0.0-beta.34",
+        "web3-core-requestmanager": "1.0.0-beta.34",
+        "web3-utils": "1.0.0-beta.34"
+      }
+    },
+    "web3-core-helpers": {
+      "version": "1.0.0-beta.34",
+      "resolved": "https://registry.npmjs.org/web3-core-helpers/-/web3-core-helpers-1.0.0-beta.34.tgz",
+      "integrity": "sha1-sWjaANPhnhVrwVriAyA91N/uLQM=",
+      "requires": {
+        "underscore": "1.8.3",
+        "web3-eth-iban": "1.0.0-beta.34",
+        "web3-utils": "1.0.0-beta.34"
+      }
+    },
+    "web3-core-method": {
+      "version": "1.0.0-beta.34",
+      "resolved": "https://registry.npmjs.org/web3-core-method/-/web3-core-method-1.0.0-beta.34.tgz",
+      "integrity": "sha1-7BY8iixJD6AqfsFVWfpzB/x8xt0=",
+      "requires": {
+        "underscore": "1.8.3",
+        "web3-core-helpers": "1.0.0-beta.34",
+        "web3-core-promievent": "1.0.0-beta.34",
+        "web3-core-subscriptions": "1.0.0-beta.34",
+        "web3-utils": "1.0.0-beta.34"
+      }
+    },
+    "web3-core-promievent": {
+      "version": "1.0.0-beta.34",
+      "resolved": "https://registry.npmjs.org/web3-core-promievent/-/web3-core-promievent-1.0.0-beta.34.tgz",
+      "integrity": "sha1-pPT6Z4S7KT6CxglgrltWqUzQPtw=",
+      "requires": {
+        "any-promise": "1.3.0",
+        "eventemitter3": "1.1.1"
+      }
+    },
+    "web3-core-requestmanager": {
+      "version": "1.0.0-beta.34",
+      "resolved": "https://registry.npmjs.org/web3-core-requestmanager/-/web3-core-requestmanager-1.0.0-beta.34.tgz",
+      "integrity": "sha1-Afj2zyrmtvC3DDi64e90G1urIVw=",
+      "requires": {
+        "underscore": "1.8.3",
+        "web3-core-helpers": "1.0.0-beta.34",
+        "web3-providers-http": "1.0.0-beta.34",
+        "web3-providers-ipc": "1.0.0-beta.34",
+        "web3-providers-ws": "1.0.0-beta.34"
+      }
+    },
+    "web3-core-subscriptions": {
+      "version": "1.0.0-beta.34",
+      "resolved": "https://registry.npmjs.org/web3-core-subscriptions/-/web3-core-subscriptions-1.0.0-beta.34.tgz",
+      "integrity": "sha1-n+0UQDPyIcPPIQYDAv/a9e8t4t4=",
+      "requires": {
+        "eventemitter3": "1.1.1",
+        "underscore": "1.8.3",
+        "web3-core-helpers": "1.0.0-beta.34"
+      }
+    },
+    "web3-eth": {
+      "version": "1.0.0-beta.34",
+      "resolved": "https://registry.npmjs.org/web3-eth/-/web3-eth-1.0.0-beta.34.tgz",
+      "integrity": "sha1-dAhgAIUMb+b1Ne9Jg31tS7YRMmg=",
+      "requires": {
+        "underscore": "1.8.3",
+        "web3-core": "1.0.0-beta.34",
+        "web3-core-helpers": "1.0.0-beta.34",
+        "web3-core-method": "1.0.0-beta.34",
+        "web3-core-subscriptions": "1.0.0-beta.34",
+        "web3-eth-abi": "1.0.0-beta.34",
+        "web3-eth-accounts": "1.0.0-beta.34",
+        "web3-eth-contract": "1.0.0-beta.34",
+        "web3-eth-iban": "1.0.0-beta.34",
+        "web3-eth-personal": "1.0.0-beta.34",
+        "web3-net": "1.0.0-beta.34",
+        "web3-utils": "1.0.0-beta.34"
+      }
+    },
+    "web3-eth-abi": {
+      "version": "1.0.0-beta.34",
+      "resolved": "https://registry.npmjs.org/web3-eth-abi/-/web3-eth-abi-1.0.0-beta.34.tgz",
+      "integrity": "sha1-A0Uz46ovfln/MXk+rqaFwO1a9no=",
+      "requires": {
+        "bn.js": "4.11.6",
+        "underscore": "1.8.3",
+        "web3-core-helpers": "1.0.0-beta.34",
+        "web3-utils": "1.0.0-beta.34"
       },
       "dependencies": {
         "bn.js": {
           "version": "4.11.6",
           "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.6.tgz",
           "integrity": "sha1-UzRK2xRhehP26N0s4okF0cC6MhU="
+        }
+      }
+    },
+    "web3-eth-accounts": {
+      "version": "1.0.0-beta.34",
+      "resolved": "https://registry.npmjs.org/web3-eth-accounts/-/web3-eth-accounts-1.0.0-beta.34.tgz",
+      "integrity": "sha1-4JFC7uzHl6w0WbdemyOUbTaV8zM=",
+      "requires": {
+        "any-promise": "1.3.0",
+        "crypto-browserify": "3.12.0",
+        "eth-lib": "0.2.7",
+        "scrypt.js": "0.2.0",
+        "underscore": "1.8.3",
+        "uuid": "2.0.1",
+        "web3-core": "1.0.0-beta.34",
+        "web3-core-helpers": "1.0.0-beta.34",
+        "web3-core-method": "1.0.0-beta.34",
+        "web3-utils": "1.0.0-beta.34"
+      },
+      "dependencies": {
+        "eth-lib": {
+          "version": "0.2.7",
+          "resolved": "https://registry.npmjs.org/eth-lib/-/eth-lib-0.2.7.tgz",
+          "integrity": "sha1-L5Pxex4jrsN1nNSj/iDBKGo/wco=",
+          "requires": {
+            "bn.js": "4.11.8",
+            "elliptic": "6.4.0",
+            "xhr-request-promise": "0.1.2"
+          }
         },
         "uuid": {
           "version": "2.0.1",
           "resolved": "https://registry.npmjs.org/uuid/-/uuid-2.0.1.tgz",
           "integrity": "sha1-wqMN7bPlNdcsz4LjQ5QaULqFM6w="
-        },
-        "web3-bzz": {
-          "version": "1.0.0-beta.34",
-          "resolved": "https://registry.npmjs.org/web3-bzz/-/web3-bzz-1.0.0-beta.34.tgz",
-          "integrity": "sha1-Bo03d3q2Xlxg+OyLmlDP5FJ3kpw=",
-          "requires": {
-            "got": "7.1.0",
-            "swarm-js": "0.1.37",
-            "underscore": "1.8.3"
-          }
-        },
-        "web3-core": {
-          "version": "1.0.0-beta.34",
-          "resolved": "https://registry.npmjs.org/web3-core/-/web3-core-1.0.0-beta.34.tgz",
-          "integrity": "sha1-EhvoVV6fsA0sXQXd0zgdDJ5GmH4=",
-          "requires": {
-            "web3-core-helpers": "1.0.0-beta.34",
-            "web3-core-method": "1.0.0-beta.34",
-            "web3-core-requestmanager": "1.0.0-beta.34",
-            "web3-utils": "1.0.0-beta.34"
-          }
-        },
-        "web3-core-helpers": {
-          "version": "1.0.0-beta.34",
-          "resolved": "https://registry.npmjs.org/web3-core-helpers/-/web3-core-helpers-1.0.0-beta.34.tgz",
-          "integrity": "sha1-sWjaANPhnhVrwVriAyA91N/uLQM=",
-          "requires": {
-            "underscore": "1.8.3",
-            "web3-eth-iban": "1.0.0-beta.34",
-            "web3-utils": "1.0.0-beta.34"
-          }
-        },
-        "web3-core-method": {
-          "version": "1.0.0-beta.34",
-          "resolved": "https://registry.npmjs.org/web3-core-method/-/web3-core-method-1.0.0-beta.34.tgz",
-          "integrity": "sha1-7BY8iixJD6AqfsFVWfpzB/x8xt0=",
-          "requires": {
-            "underscore": "1.8.3",
-            "web3-core-helpers": "1.0.0-beta.34",
-            "web3-core-promievent": "1.0.0-beta.34",
-            "web3-core-subscriptions": "1.0.0-beta.34",
-            "web3-utils": "1.0.0-beta.34"
-          }
-        },
-        "web3-core-promievent": {
-          "version": "1.0.0-beta.34",
-          "resolved": "https://registry.npmjs.org/web3-core-promievent/-/web3-core-promievent-1.0.0-beta.34.tgz",
-          "integrity": "sha1-pPT6Z4S7KT6CxglgrltWqUzQPtw=",
-          "requires": {
-            "any-promise": "1.3.0",
-            "eventemitter3": "1.1.1"
-          }
-        },
-        "web3-core-requestmanager": {
-          "version": "1.0.0-beta.34",
-          "resolved": "https://registry.npmjs.org/web3-core-requestmanager/-/web3-core-requestmanager-1.0.0-beta.34.tgz",
-          "integrity": "sha1-Afj2zyrmtvC3DDi64e90G1urIVw=",
-          "requires": {
-            "underscore": "1.8.3",
-            "web3-core-helpers": "1.0.0-beta.34",
-            "web3-providers-http": "1.0.0-beta.34",
-            "web3-providers-ipc": "1.0.0-beta.34",
-            "web3-providers-ws": "1.0.0-beta.34"
-          }
-        },
-        "web3-core-subscriptions": {
-          "version": "1.0.0-beta.34",
-          "resolved": "https://registry.npmjs.org/web3-core-subscriptions/-/web3-core-subscriptions-1.0.0-beta.34.tgz",
-          "integrity": "sha1-n+0UQDPyIcPPIQYDAv/a9e8t4t4=",
-          "requires": {
-            "eventemitter3": "1.1.1",
-            "underscore": "1.8.3",
-            "web3-core-helpers": "1.0.0-beta.34"
-          }
-        },
-        "web3-eth": {
-          "version": "1.0.0-beta.34",
-          "resolved": "https://registry.npmjs.org/web3-eth/-/web3-eth-1.0.0-beta.34.tgz",
-          "integrity": "sha1-dAhgAIUMb+b1Ne9Jg31tS7YRMmg=",
-          "requires": {
-            "underscore": "1.8.3",
-            "web3-core": "1.0.0-beta.34",
-            "web3-core-helpers": "1.0.0-beta.34",
-            "web3-core-method": "1.0.0-beta.34",
-            "web3-core-subscriptions": "1.0.0-beta.34",
-            "web3-eth-abi": "1.0.0-beta.34",
-            "web3-eth-accounts": "1.0.0-beta.34",
-            "web3-eth-contract": "1.0.0-beta.34",
-            "web3-eth-iban": "1.0.0-beta.34",
-            "web3-eth-personal": "1.0.0-beta.34",
-            "web3-net": "1.0.0-beta.34",
-            "web3-utils": "1.0.0-beta.34"
-          }
-        },
-        "web3-eth-abi": {
-          "version": "1.0.0-beta.34",
-          "resolved": "https://registry.npmjs.org/web3-eth-abi/-/web3-eth-abi-1.0.0-beta.34.tgz",
-          "integrity": "sha1-A0Uz46ovfln/MXk+rqaFwO1a9no=",
-          "requires": {
-            "bn.js": "4.11.6",
-            "underscore": "1.8.3",
-            "web3-core-helpers": "1.0.0-beta.34",
-            "web3-utils": "1.0.0-beta.34"
-          }
-        },
-        "web3-eth-accounts": {
-          "version": "1.0.0-beta.34",
-          "resolved": "https://registry.npmjs.org/web3-eth-accounts/-/web3-eth-accounts-1.0.0-beta.34.tgz",
-          "integrity": "sha1-4JFC7uzHl6w0WbdemyOUbTaV8zM=",
-          "requires": {
-            "any-promise": "1.3.0",
-            "crypto-browserify": "3.12.0",
-            "eth-lib": "0.2.7",
-            "scrypt.js": "0.2.0",
-            "underscore": "1.8.3",
-            "uuid": "2.0.1",
-            "web3-core": "1.0.0-beta.34",
-            "web3-core-helpers": "1.0.0-beta.34",
-            "web3-core-method": "1.0.0-beta.34",
-            "web3-utils": "1.0.0-beta.34"
-          },
-          "dependencies": {
-            "eth-lib": {
-              "version": "0.2.7",
-              "resolved": "https://registry.npmjs.org/eth-lib/-/eth-lib-0.2.7.tgz",
-              "integrity": "sha1-L5Pxex4jrsN1nNSj/iDBKGo/wco=",
-              "requires": {
-                "bn.js": "4.11.6",
-                "elliptic": "6.4.0",
-                "xhr-request-promise": "0.1.2"
-              }
-            }
-          }
-        },
-        "web3-eth-contract": {
-          "version": "1.0.0-beta.34",
-          "resolved": "https://registry.npmjs.org/web3-eth-contract/-/web3-eth-contract-1.0.0-beta.34.tgz",
-          "integrity": "sha1-nbs4+udkOoCEJ6IBgEcOx0FckeY=",
-          "requires": {
-            "underscore": "1.8.3",
-            "web3-core": "1.0.0-beta.34",
-            "web3-core-helpers": "1.0.0-beta.34",
-            "web3-core-method": "1.0.0-beta.34",
-            "web3-core-promievent": "1.0.0-beta.34",
-            "web3-core-subscriptions": "1.0.0-beta.34",
-            "web3-eth-abi": "1.0.0-beta.34",
-            "web3-utils": "1.0.0-beta.34"
-          }
-        },
-        "web3-eth-iban": {
-          "version": "1.0.0-beta.34",
-          "resolved": "https://registry.npmjs.org/web3-eth-iban/-/web3-eth-iban-1.0.0-beta.34.tgz",
-          "integrity": "sha1-mvRYYFhnzPdOqXmq8yazi6alugw=",
-          "requires": {
-            "bn.js": "4.11.6",
-            "web3-utils": "1.0.0-beta.34"
-          }
-        },
-        "web3-eth-personal": {
-          "version": "1.0.0-beta.34",
-          "resolved": "https://registry.npmjs.org/web3-eth-personal/-/web3-eth-personal-1.0.0-beta.34.tgz",
-          "integrity": "sha1-mvuhZzQuveVCC81YlcP2w0OI8gU=",
-          "requires": {
-            "web3-core": "1.0.0-beta.34",
-            "web3-core-helpers": "1.0.0-beta.34",
-            "web3-core-method": "1.0.0-beta.34",
-            "web3-net": "1.0.0-beta.34",
-            "web3-utils": "1.0.0-beta.34"
-          }
-        },
-        "web3-net": {
-          "version": "1.0.0-beta.34",
-          "resolved": "https://registry.npmjs.org/web3-net/-/web3-net-1.0.0-beta.34.tgz",
-          "integrity": "sha1-QnzqL0MYgUScjjjVIykPFz+f9j0=",
-          "requires": {
-            "web3-core": "1.0.0-beta.34",
-            "web3-core-method": "1.0.0-beta.34",
-            "web3-utils": "1.0.0-beta.34"
-          }
-        },
-        "web3-providers-http": {
-          "version": "1.0.0-beta.34",
-          "resolved": "https://registry.npmjs.org/web3-providers-http/-/web3-providers-http-1.0.0-beta.34.tgz",
-          "integrity": "sha1-5WG1K7tDdmKCAH1AKFv+NVDCfno=",
-          "requires": {
-            "web3-core-helpers": "1.0.0-beta.34",
-            "xhr2": "0.1.4"
-          }
-        },
-        "web3-providers-ipc": {
-          "version": "1.0.0-beta.34",
-          "resolved": "https://registry.npmjs.org/web3-providers-ipc/-/web3-providers-ipc-1.0.0-beta.34.tgz",
-          "integrity": "sha1-obd/GjBtc2SanAOQUuQMtxMo0Ao=",
-          "requires": {
-            "oboe": "2.1.3",
-            "underscore": "1.8.3",
-            "web3-core-helpers": "1.0.0-beta.34"
-          }
-        },
-        "web3-providers-ws": {
-          "version": "1.0.0-beta.34",
-          "resolved": "https://registry.npmjs.org/web3-providers-ws/-/web3-providers-ws-1.0.0-beta.34.tgz",
-          "integrity": "sha1-fecPG4Py3jZHZ3IVa+z+9uNRbrM=",
-          "requires": {
-            "underscore": "1.8.3",
-            "web3-core-helpers": "1.0.0-beta.34",
-            "websocket": "git://github.com/frozeman/WebSocket-Node.git#7004c39c42ac98875ab61126e5b4a925430f592c"
-          }
-        },
-        "web3-shh": {
-          "version": "1.0.0-beta.34",
-          "resolved": "https://registry.npmjs.org/web3-shh/-/web3-shh-1.0.0-beta.34.tgz",
-          "integrity": "sha1-l1Bh1x6uxCzO5Xb3vY9w8DhEr+A=",
-          "requires": {
-            "web3-core": "1.0.0-beta.34",
-            "web3-core-method": "1.0.0-beta.34",
-            "web3-core-subscriptions": "1.0.0-beta.34",
-            "web3-net": "1.0.0-beta.34"
-          }
-        },
-        "web3-utils": {
-          "version": "1.0.0-beta.34",
-          "resolved": "https://registry.npmjs.org/web3-utils/-/web3-utils-1.0.0-beta.34.tgz",
-          "integrity": "sha1-lBH8OarvOcpOBhafdiKX2f8CCXA=",
-          "requires": {
-            "bn.js": "4.11.6",
-            "eth-lib": "0.1.27",
-            "ethjs-unit": "0.1.6",
-            "number-to-bn": "1.7.0",
-            "randomhex": "0.1.5",
-            "underscore": "1.8.3",
-            "utf8": "2.1.1"
-          }
+        }
+      }
+    },
+    "web3-eth-contract": {
+      "version": "1.0.0-beta.34",
+      "resolved": "https://registry.npmjs.org/web3-eth-contract/-/web3-eth-contract-1.0.0-beta.34.tgz",
+      "integrity": "sha1-nbs4+udkOoCEJ6IBgEcOx0FckeY=",
+      "requires": {
+        "underscore": "1.8.3",
+        "web3-core": "1.0.0-beta.34",
+        "web3-core-helpers": "1.0.0-beta.34",
+        "web3-core-method": "1.0.0-beta.34",
+        "web3-core-promievent": "1.0.0-beta.34",
+        "web3-core-subscriptions": "1.0.0-beta.34",
+        "web3-eth-abi": "1.0.0-beta.34",
+        "web3-utils": "1.0.0-beta.34"
+      }
+    },
+    "web3-eth-iban": {
+      "version": "1.0.0-beta.34",
+      "resolved": "https://registry.npmjs.org/web3-eth-iban/-/web3-eth-iban-1.0.0-beta.34.tgz",
+      "integrity": "sha1-mvRYYFhnzPdOqXmq8yazi6alugw=",
+      "requires": {
+        "bn.js": "4.11.6",
+        "web3-utils": "1.0.0-beta.34"
+      },
+      "dependencies": {
+        "bn.js": {
+          "version": "4.11.6",
+          "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.6.tgz",
+          "integrity": "sha1-UzRK2xRhehP26N0s4okF0cC6MhU="
+        }
+      }
+    },
+    "web3-eth-personal": {
+      "version": "1.0.0-beta.34",
+      "resolved": "https://registry.npmjs.org/web3-eth-personal/-/web3-eth-personal-1.0.0-beta.34.tgz",
+      "integrity": "sha1-mvuhZzQuveVCC81YlcP2w0OI8gU=",
+      "requires": {
+        "web3-core": "1.0.0-beta.34",
+        "web3-core-helpers": "1.0.0-beta.34",
+        "web3-core-method": "1.0.0-beta.34",
+        "web3-net": "1.0.0-beta.34",
+        "web3-utils": "1.0.0-beta.34"
+      }
+    },
+    "web3-net": {
+      "version": "1.0.0-beta.34",
+      "resolved": "https://registry.npmjs.org/web3-net/-/web3-net-1.0.0-beta.34.tgz",
+      "integrity": "sha1-QnzqL0MYgUScjjjVIykPFz+f9j0=",
+      "requires": {
+        "web3-core": "1.0.0-beta.34",
+        "web3-core-method": "1.0.0-beta.34",
+        "web3-utils": "1.0.0-beta.34"
+      }
+    },
+    "web3-providers-http": {
+      "version": "1.0.0-beta.34",
+      "resolved": "https://registry.npmjs.org/web3-providers-http/-/web3-providers-http-1.0.0-beta.34.tgz",
+      "integrity": "sha1-5WG1K7tDdmKCAH1AKFv+NVDCfno=",
+      "requires": {
+        "web3-core-helpers": "1.0.0-beta.34",
+        "xhr2": "0.1.4"
+      }
+    },
+    "web3-providers-ipc": {
+      "version": "1.0.0-beta.34",
+      "resolved": "https://registry.npmjs.org/web3-providers-ipc/-/web3-providers-ipc-1.0.0-beta.34.tgz",
+      "integrity": "sha1-obd/GjBtc2SanAOQUuQMtxMo0Ao=",
+      "requires": {
+        "oboe": "2.1.3",
+        "underscore": "1.8.3",
+        "web3-core-helpers": "1.0.0-beta.34"
+      }
+    },
+    "web3-providers-ws": {
+      "version": "1.0.0-beta.34",
+      "resolved": "https://registry.npmjs.org/web3-providers-ws/-/web3-providers-ws-1.0.0-beta.34.tgz",
+      "integrity": "sha1-fecPG4Py3jZHZ3IVa+z+9uNRbrM=",
+      "requires": {
+        "underscore": "1.8.3",
+        "web3-core-helpers": "1.0.0-beta.34",
+        "websocket": "1.0.25"
+      }
+    },
+    "web3-shh": {
+      "version": "1.0.0-beta.34",
+      "resolved": "https://registry.npmjs.org/web3-shh/-/web3-shh-1.0.0-beta.34.tgz",
+      "integrity": "sha1-l1Bh1x6uxCzO5Xb3vY9w8DhEr+A=",
+      "requires": {
+        "web3-core": "1.0.0-beta.34",
+        "web3-core-method": "1.0.0-beta.34",
+        "web3-core-subscriptions": "1.0.0-beta.34",
+        "web3-net": "1.0.0-beta.34"
+      }
+    },
+    "web3-utils": {
+      "version": "1.0.0-beta.34",
+      "resolved": "https://registry.npmjs.org/web3-utils/-/web3-utils-1.0.0-beta.34.tgz",
+      "integrity": "sha1-lBH8OarvOcpOBhafdiKX2f8CCXA=",
+      "requires": {
+        "bn.js": "4.11.6",
+        "eth-lib": "0.1.27",
+        "ethjs-unit": "0.1.6",
+        "number-to-bn": "1.7.0",
+        "randomhex": "0.1.5",
+        "underscore": "1.8.3",
+        "utf8": "2.1.1"
+      },
+      "dependencies": {
+        "bn.js": {
+          "version": "4.11.6",
+          "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.6.tgz",
+          "integrity": "sha1-UzRK2xRhehP26N0s4okF0cC6MhU="
         }
       }
     },
@@ -10713,6 +10897,7 @@
       "version": "0.1.19",
       "resolved": "https://registry.npmjs.org/webcrypto-core/-/webcrypto-core-0.1.19.tgz",
       "integrity": "sha1-8CTjoCu8oW3tRtJpaMQlNaORJNw=",
+      "optional": true,
       "requires": {
         "tslib": "1.9.0"
       }
@@ -10781,7 +10966,9 @@
       }
     },
     "websocket": {
-      "version": "git://github.com/frozeman/WebSocket-Node.git#7004c39c42ac98875ab61126e5b4a925430f592c",
+      "version": "1.0.25",
+      "resolved": "https://registry.npmjs.org/websocket/-/websocket-1.0.25.tgz",
+      "integrity": "sha512-M58njvi6ZxVb5k7kpnHh2BvNKuBWiwIYvsToErBzWhvBZYwlEiLcyLrG41T1jRcrY9ettqPYEqduLI7ul54CVQ==",
       "requires": {
         "debug": "2.6.9",
         "nan": "2.9.2",
@@ -10877,7 +11064,7 @@
     "ws": {
       "version": "3.3.3",
       "resolved": "https://registry.npmjs.org/ws/-/ws-3.3.3.tgz",
-      "integrity": "sha1-8c+E/i1ekB686U767OeF8YeiKPI=",
+      "integrity": "sha512-nnWLa/NwZSt4KQJu51MYlCcSQ5g7INpOrOMt4XV8j4dqTXdmlUmSHQ8/oLC069ckre0fRsgfvsKwbTdtKLCDkA==",
       "requires": {
         "async-limiter": "1.0.0",
         "safe-buffer": "5.1.1",
@@ -10887,7 +11074,7 @@
     "xhr": {
       "version": "2.4.1",
       "resolved": "https://registry.npmjs.org/xhr/-/xhr-2.4.1.tgz",
-      "integrity": "sha1-upgsztIFrl7sOHFprJ3HfKSFPTg=",
+      "integrity": "sha512-pAIU5vBr9Hiy5cpFIbPnwf0C18ZF86DBsZKrlsf87N5De/JbA6RJ83UP/cv+aljl4S40iRVMqP4pr4sF9Dnj0A==",
       "requires": {
         "global": "4.3.2",
         "is-function": "1.0.1",
@@ -10898,7 +11085,7 @@
     "xhr-request": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/xhr-request/-/xhr-request-1.1.0.tgz",
-      "integrity": "sha1-9KfBhoufGYcjRE2C3K4xdkPy4u0=",
+      "integrity": "sha512-Y7qzEaR3FDtL3fP30k9wO/e+FBnBByZeybKOhASsGP30NIkRAAkKD/sCnLvgEfAIEC1rcmK7YG8f4oEnIrrWzA==",
       "requires": {
         "buffer-to-arraybuffer": "0.0.5",
         "object-assign": "4.1.1",
@@ -10912,7 +11099,7 @@
         "query-string": {
           "version": "5.1.1",
           "resolved": "https://registry.npmjs.org/query-string/-/query-string-5.1.1.tgz",
-          "integrity": "sha1-p4wBK3HBfgXy4/ojGd0zBoLvs8s=",
+          "integrity": "sha512-gjWOsm2SoGlgLEdAGt7a6slVOk9mGiXmPFMqrEhLQ68rhQuBnpfs3+EmlvqKyxnCo9/PPlF+9MtY02S1aFg+Jw==",
           "requires": {
             "decode-uri-component": "0.2.0",
             "object-assign": "4.1.1",


### PR DESCRIPTION
The issue was the npm dependency graph was causing the web3 dependencies to be nested inside the `node_modules/web3/node_modules` folder. After removing web3 from  `package-lock.json`, and allowing npm to rebuild the graph with `npm install`, the web3 depedencies (ie web3-bzz) were correctly installed at the same level as web3.

However, this also introduced a new dependency issue in that web3-providers-ws required and depended on the websocket package at a specific github commit and was causing the same issue with websocket being installed at `node_modules/web3-providers-ws/node_modules/websocket`. Removing the web3-providers-ws dependency on websocket and replacing with version 1.0.25 requirement brought the websocket package back to the same level as web3.