### PR TITLE
Add 'auto' setting for geth CORS and websockets origin

### DIFF
--- a/lib/cmds/blockchain/geth_commands.js
+++ b/lib/cmds/blockchain/geth_commands.js
@@ -103,14 +103,14 @@ class GethCommands {
       if (config.wsOrigins) {
         if (config.wsOrigins === '*') {
           console.log('==================================');
-          console.log('rpcCorsDomain set to *');
+          console.log('wsOrigins set to *');
           console.log('make sure you know what you are doing');
           console.log('==================================');
         }
         cmd += "--wsorigins \"" + config.wsOrigins + "\" ";
       } else {
         console.log('==================================');
-        console.log('warning: cors is not set');
+        console.log('warning: wsOrigins is not set');
         console.log('==================================');
       }
     }

--- a/lib/index.js
+++ b/lib/index.js
@@ -39,7 +39,19 @@ class Embark {
 
   blockchain(env, client) {
     this.context = [constants.contexts.blockchain];
-    return require('./cmds/blockchain/blockchain.js')(this.config.blockchainConfig, client, env).run();
+    let blockchainConfig = this.config.blockchainConfig;
+    let storageConfig = this.config.storageConfig;
+    let webServerConfig = this.config.webServerConfig;
+
+    if(blockchainConfig.rpcCorsDomain === 'auto') {
+      if(webServerConfig) blockchainConfig.rpcCorsDomain = `http://${webServerConfig.host}:${webServerConfig.port}`;
+      if(storageConfig) blockchainConfig.rpcCorsDomain += `${blockchainConfig.rpcCorsDomain.length ? ',' : ''}http://${storageConfig.host}:${storageConfig.port}`;
+    }
+    if(blockchainConfig.wsOrigins === 'auto') {
+      if(webServerConfig) blockchainConfig.wsOrigins = `http://${webServerConfig.host}:${webServerConfig.port}`;
+      if(storageConfig) blockchainConfig.wsOrigins += `${blockchainConfig.wsOrigins.length ? ',' : ''}http://${storageConfig.host}:${storageConfig.port}`;
+    }
+    return require('./cmds/blockchain/blockchain.js')(blockchainConfig, client, env).run();
   }
 
   simulator(options) {

--- a/templates/boilerplate/config/blockchain.json
+++ b/templates/boilerplate/config/blockchain.json
@@ -9,12 +9,12 @@
     "maxpeers": 0,
     "rpcHost": "localhost",
     "rpcPort": 8545,
-    "rpcCorsDomain": "http://localhost:8000",
+    "rpcCorsDomain": "auto",
     "account": {
       "password": "config/development/password"
     },
     "targetGasLimit": 8000000,
-    "wsOrigins": "http://localhost:8000",
+    "wsOrigins": "auto",
     "wsRPC": true,
     "wsHost": "localhost",
     "wsPort": 8546,

--- a/templates/demo/config/blockchain.json
+++ b/templates/demo/config/blockchain.json
@@ -9,12 +9,12 @@
     "maxpeers": 0,
     "rpcHost": "localhost",
     "rpcPort": 8545,
-    "rpcCorsDomain": "http://localhost:8000",
+    "rpcCorsDomain": "auto",
     "account": {
       "password": "config/development/password"
     },
     "targetGasLimit": 8000000,
-    "wsOrigins": "http://localhost:8000",
+    "wsOrigins": "auto",
     "wsRPC": true,
     "wsHost": "localhost",
     "wsPort": 8546,

--- a/test/test1/config/blockchain.json
+++ b/test/test1/config/blockchain.json
@@ -7,7 +7,7 @@
     "nodiscover": true,
     "rpcHost": "localhost",
     "rpcPort": 8545,
-    "rpcCorsDomain": "auto",
+    "rpcCorsDomain": "http://localhost:8000",
     "account": {
       "password": "config/development/password"
     }

--- a/test/test1/config/blockchain.json
+++ b/test/test1/config/blockchain.json
@@ -7,7 +7,7 @@
     "nodiscover": true,
     "rpcHost": "localhost",
     "rpcPort": 8545,
-    "rpcCorsDomain": "http://localhost:8000",
+    "rpcCorsDomain": "auto",
     "account": {
       "password": "config/development/password"
     }

--- a/test_apps/contracts_app/blockchain.json
+++ b/test_apps/contracts_app/blockchain.json
@@ -9,12 +9,12 @@
     "maxpeers": 0,
     "rpcHost": "localhost",
     "rpcPort": 8545,
-    "rpcCorsDomain": "http://localhost:8000",
+    "rpcCorsDomain": "auto",
     "account": {
       "password": "development/password"
     },
     "targetGasLimit": 8000000,
-    "wsOrigins": "http://localhost:8000",
+    "wsOrigins": "auto",
     "wsRPC": true,
     "wsHost": "localhost",
     "wsPort": 8546

--- a/test_apps/test_app/config/blockchain.json
+++ b/test_apps/test_app/config/blockchain.json
@@ -9,12 +9,12 @@
     "maxpeers": 0,
     "rpcHost": "localhost",
     "rpcPort": 8545,
-    "rpcCorsDomain": "http://localhost:8000",
+    "rpcCorsDomain": "auto",
     "account": {
       "password": "config/development/password"
     },
     "targetGasLimit": 8000000,
-    "wsOrigins": "http://localhost:8000",
+    "wsOrigins": "auto",
     "wsRPC": true,
     "wsHost": "localhost",
     "wsPort": 8546


### PR DESCRIPTION
* 'auto' now supported for `rpcCorsDomain` and `wsOrigins` in the blockchain config.
* 'auto' set to the default value in blockchain config for test and demo apps.