### PR TITLE
Fix contract calls in dashboard by removing the double evaluation

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -105,12 +105,6 @@ class Embark {
           contractsConfig: engine.config.contractsConfig
         });
         dashboard.start(function () {
-          engine.events.on('code-generator-ready', function () {
-            engine.events.request('code-vanila-deployment', function (abi) {
-              dashboard.console.runCode(abi);
-            });
-          });
-
           engine.logger.info('dashboard start');
           callback();
         });

--- a/package-lock.json
+++ b/package-lock.json
@@ -6043,7 +6043,7 @@
         "lockfile": "1.0.4",
         "node-fetch": "2.1.2",
         "semver": "5.5.0",
-        "tar": "4.4.1",
+        "tar": "4.4.2",
         "url-join": "4.0.0"
       },
       "dependencies": {
@@ -6078,21 +6078,26 @@
           "resolved": "https://registry.npmjs.org/minipass/-/minipass-2.2.4.tgz",
           "integrity": "sha512-hzXIWWet/BzWhYs2b+u7dRHlruXhwdgvlTMDKC6Cb1U7ps6Ac6yQlR39xsbjWJE377YTCtKwIXIpJ5oP+j5y8g==",
           "requires": {
-            "safe-buffer": "5.1.1",
+            "safe-buffer": "5.1.2",
             "yallist": "3.0.2"
           }
         },
+        "safe-buffer": {
+          "version": "5.1.2",
+          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+          "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+        },
         "tar": {
-          "version": "4.4.1",
-          "resolved": "https://registry.npmjs.org/tar/-/tar-4.4.1.tgz",
-          "integrity": "sha512-O+v1r9yN4tOsvl90p5HAP4AEqbYhx4036AGMm075fH9F8Qwi3oJ+v4u50FkT/KkvywNGtwkk0zRI+8eYm1X/xg==",
+          "version": "4.4.2",
+          "resolved": "https://registry.npmjs.org/tar/-/tar-4.4.2.tgz",
+          "integrity": "sha512-BfkE9CciGGgDsATqkikUHrQrraBCO+ke/1f6SFAEMnxyyfN9lxC+nW1NFWMpqH865DhHIy9vQi682gk1X7friw==",
           "requires": {
             "chownr": "1.0.1",
             "fs-minipass": "1.2.5",
             "minipass": "2.2.4",
             "minizlib": "1.1.0",
             "mkdirp": "0.5.1",
-            "safe-buffer": "5.1.1",
+            "safe-buffer": "5.1.2",
             "yallist": "3.0.2"
           }
         },


### PR DESCRIPTION
Really annoying bug to debug. It only happened in the dashboard and with a blockchain backend.
What happened is we ran a double eval on the global contract creation (so that it is available in the dashboard), but the second time, web.eth.defaultAccount is no defined because it is called from the index and not deploy (where the web3 object has been modified).