### PR TITLE
Fix glob in Windows for chokidar

### DIFF
--- a/lib/pipeline/watch.js
+++ b/lib/pipeline/watch.js
@@ -1,5 +1,6 @@
 let chokidar = require('chokidar');
 let path = require('path');
+const _ = require('underscore');
 
 let fs = require('../core/fs.js');
 
@@ -57,14 +58,16 @@ class Watch {
 
       // workaround for imports issue
       // so embark reacts to changes made in imported js files
+      // chokidar glob patterns only work with front-slashes
       if (!Array.isArray(files)) {
-        fileGlob = path.join(path.dirname(files), '**', '*.*');
+        fileGlob = path.join(path.dirname(files), '**', '*.*').replace(/\\/g, '/');
       } else if (files.length === 1) {
-        fileGlob = path.join(path.dirname(files[0]), '**', '*.*');
+        fileGlob = path.join(path.dirname(files[0]), '**', '*.*').replace(/\\/g, '/');
       }
 
       filesToWatch.push(fileGlob);
     }
+    filesToWatch = _.uniq(filesToWatch);
 
     this.watchFiles(
       filesToWatch,


### PR DESCRIPTION
Globs only work with forward-slashes for chokidar.watch