### PR TITLE
Write files in a different process

### DIFF
--- a/lib/constants.json
+++ b/lib/constants.json
@@ -15,5 +15,12 @@
   "events": {
     "contractFilesChanged": "contractFilesChanged",
     "contractConfigChanged": "contractConfigChanged"
+  },
+  "pipeline": {
+    "init": "init",
+    "build": "build",
+    "initiated": "initiated",
+    "built": "built",
+    "log": "log"
   }
 }

--- a/lib/core/engine.js
+++ b/lib/core/engine.js
@@ -182,6 +182,9 @@ class Engine {
           if (self.watch) {
             self.watch.restart(); // Necessary because changing a file while it is writing can stop it from being watched
           }
+          if (msg.error) {
+            return self.logger.error(msg.error);
+          }
           return self.events.emit('outputDone');
         }
 

--- a/lib/core/engine.js
+++ b/lib/core/engine.js
@@ -1,14 +1,15 @@
-let Web3 = require('web3');
-let Events = require('./events.js');
-let Logger = require('./logger.js');
-let Config = require('./config.js');
-let ContractsManager = require('../contracts/contracts.js');
-let DeployManager = require('../contracts/deploy_manager.js');
-let CodeGenerator = require('../contracts/code_generator.js');
-let ServicesMonitor = require('./services_monitor.js');
-let Pipeline = require('../pipeline/pipeline.js');
-let Watch = require('../pipeline/watch.js');
-let LibraryManager = require('../versions/library_manager.js');
+const Web3 = require('web3');
+const Events = require('./events.js');
+const Logger = require('./logger.js');
+const Config = require('./config.js');
+const ContractsManager = require('../contracts/contracts.js');
+const DeployManager = require('../contracts/deploy_manager.js');
+const CodeGenerator = require('../contracts/code_generator.js');
+const ServicesMonitor = require('./services_monitor.js');
+const Watch = require('../pipeline/watch.js');
+const LibraryManager = require('../versions/library_manager.js');
+const utils = require('../utils/utils');
+const constants = require('../constants');
 
 class Engine {
   constructor(options) {
@@ -41,46 +42,46 @@ class Engine {
     }
   }
 
+  normalizeInput(input) {
+    let args = Object.values(input);
+    if (args.length === 0) {
+      return "";
+    }
+    if (args.length === 1) {
+      if (Array.isArray(args[0])) { return args[0].join(','); }
+      return args[0] || "";
+    }
+    return ('[' + args.map((x) => {
+      if (x === null) { return "null"; }
+      if (x === undefined) { return "undefined"; }
+      if (Array.isArray(x)) { return x.join(','); }
+      return x;
+    }).toString() + ']');
+  }
+
   doInterceptLogs() {
     var self = this;
     let context = {};
     context.console = console;
 
-    let normalizeInput = function(input) {
-      let args = Object.values(input);
-      if (args.length === 0) {
-        return "";
-      }
-      if (args.length === 1) {
-        if (Array.isArray(args[0])) { return args[0].join(','); }
-        return args[0] || "";
-      }
-      return ('[' + args.map((x) => {
-        if (x === null) { return "null"; }
-        if (x === undefined) { return "undefined"; }
-        if (Array.isArray(x)) { return x.join(','); }
-        return x;
-      }).toString() + ']');
-    };
-
     context.console.log  = function() {
-      self.logger.info(normalizeInput(arguments));
+      self.logger.info(self.normalizeInput(arguments));
     };
     context.console.warn  = function() {
-      self.logger.warn(normalizeInput(arguments));
+      self.logger.warn(self.normalizeInput(arguments));
     };
     context.console.info  = function() {
-      self.logger.info(normalizeInput(arguments));
+      self.logger.info(self.normalizeInput(arguments));
     };
     context.console.debug  = function() {
       // TODO: ue JSON.stringify
-      self.logger.debug(normalizeInput(arguments));
+      self.logger.debug(self.normalizeInput(arguments));
     };
     context.console.trace  = function() {
-      self.logger.trace(normalizeInput(arguments));
+      self.logger.trace(self.normalizeInput(arguments));
     };
     context.console.dir  = function() {
-      self.logger.dir(normalizeInput(arguments));
+      self.logger.dir(self.normalizeInput(arguments));
     };
   }
 
@@ -132,25 +133,36 @@ class Engine {
 
   pipelineService(_options) {
     let self = this;
-    this.events.emit("status", "Building Assets");
-    let pipeline = new Pipeline({
-      buildDir: this.config.buildDir,
-      contractsFiles: this.config.contractsFiles,
-      assetFiles: this.config.assetFiles,
-      events: this.events,
-      logger: this.logger,
-      plugins: this.plugins
+    self.events.emit("status", "Building Assets");
+    const pipelineProcess = require('child_process').fork(utils.joinPath(__dirname, '../pipeline/pipeline.js'));
+
+    pipelineProcess.send({action: constants.pipeline.init, options: {
+        buildDir: self.config.buildDir,
+        contractsFiles: self.config.contractsFiles,
+        assetFiles: self.config.assetFiles,
+        events: self.events,
+        pipelinePlugins: self.plugins.getPluginsFor('pipeline'),
+        pluginImports: self.plugins.getPluginsProperty('imports', 'imports')
+      }});
+
+    pipelineProcess.on('message', function (msg) {
+      if (msg.result === constants.pipeline.built) {
+        if (self.watch) {
+          self.watch.restart(); // Necessary because changing a file while it is writing can stop it from being watched
+        }
+        return self.events.emit('outputDone');
+      }
+
+      if (msg.result === constants.pipeline.log) {
+        self.logger.debug(self.normalizeInput(msg.message));
+      }
     });
-    this.events.on('code-generator-ready', function () {
+
+    self.events.on('code-generator-ready', function () {
       self.events.request('code', function (abi, contractsJSON) {
         self.currentAbi = abi;
         self.contractsJSON = contractsJSON;
-        pipeline.build(abi, contractsJSON, null, function() {
-          if (self.watch) {
-            self.watch.restart(); // Necessary because changing a file while it is writing can stop it from being watched
-          }
-          self.events.emit('outputDone');
-        });
+        pipelineProcess.send({action: constants.pipeline.build, abi, contractsJSON, path: null});
       });
     });
   }

--- a/lib/core/engine.js
+++ b/lib/core/engine.js
@@ -10,6 +10,8 @@ const Watch = require('../pipeline/watch.js');
 const LibraryManager = require('../versions/library_manager.js');
 const utils = require('../utils/utils');
 const constants = require('../constants');
+const async = require('async');
+const fs = require('../core/fs.js');
 
 class Engine {
   constructor(options) {
@@ -136,34 +138,73 @@ class Engine {
     self.events.emit("status", "Building Assets");
     const pipelineProcess = require('child_process').fork(utils.joinPath(__dirname, '../pipeline/pipeline.js'));
 
-    pipelineProcess.send({action: constants.pipeline.init, options: {
-        buildDir: self.config.buildDir,
-        contractsFiles: self.config.contractsFiles,
-        assetFiles: self.config.assetFiles,
-        events: self.events,
-        pipelinePlugins: self.plugins.getPluginsFor('pipeline'),
-        pluginImports: self.plugins.getPluginsProperty('imports', 'imports')
-      }});
-
-    pipelineProcess.on('message', function (msg) {
-      if (msg.result === constants.pipeline.built) {
-        if (self.watch) {
-          self.watch.restart(); // Necessary because changing a file while it is writing can stop it from being watched
+    async.waterfall([
+      function getWeb3Version(next) {
+        console.log('Waiting for web3 version');
+        self.events.request("version:get:web3", function(web3Version) {
+          console.log('Web3 version', web3Version);
+          next(null, web3Version);
+        });
+      },
+      function getWeb3Location(web3Version, next) {
+        if (web3Version === "1.0.0-beta") {
+          return next(null, utils.joinPath(fs.embarkPath("js/web3-1.0.min.js")));
+        } else {
+          self.events.request("version:getPackageLocation", "web3", web3Version, function(err, location) {
+            return next(err, fs.dappPath(location));
+          });
         }
-        return self.events.emit('outputDone');
+      },
+      function getProviderCode(web3Location, next) {
+        self.events.once('code-generator-ready', function () {
+          self.events.request('provider-code', function(providerCode) {
+            next(null, web3Location, providerCode);
+          });
+        });
+      }
+    ], (err, web3Location, providerCode) => {
+      if (err) {
+        return self.logger.error(err);
       }
 
-      if (msg.result === constants.pipeline.log) {
-        self.logger.debug(self.normalizeInput(msg.message));
-      }
-    });
+      // Setup Pipeline
+      pipelineProcess.send({action: constants.pipeline.init, options: {
+          buildDir: self.config.buildDir,
+          contractsFiles: self.config.contractsFiles,
+          assetFiles: self.config.assetFiles,
+          events: self.events,
+          pipelinePlugins: self.plugins.getPluginsFor('pipeline'),
+          pluginImports: self.plugins.getPluginsProperty('imports', 'imports'),
+          web3Location,
+          providerCode
+        }});
 
-    self.events.on('code-generator-ready', function () {
-      self.events.request('code', function (abi, contractsJSON) {
-        self.currentAbi = abi;
-        self.contractsJSON = contractsJSON;
-        pipelineProcess.send({action: constants.pipeline.build, abi, contractsJSON, path: null});
+      pipelineProcess.on('message', function (msg) {
+        if (msg.result === constants.pipeline.built) {
+          if (self.watch) {
+            self.watch.restart(); // Necessary because changing a file while it is writing can stop it from being watched
+          }
+          return self.events.emit('outputDone');
+        }
+
+        if (msg.result === constants.pipeline.log) {
+          self.logger.debug(self.normalizeInput(msg.message));
+        }
       });
+
+      function build() {
+        self.events.request('code', function (abi, contractsJSON) {
+          self.currentAbi = abi;
+          self.contractsJSON = contractsJSON;
+          pipelineProcess.send({action: constants.pipeline.build, abi, contractsJSON, path: null});
+        });
+      }
+
+      self.events.on('code-generator-ready', function () {
+        build();
+      });
+
+      build();
     });
   }
 
@@ -180,6 +221,7 @@ class Engine {
         communicationConfig: self.config.communicationConfig,
         events: self.events
       });
+      console.log('LISTEN TO COMMANDS');
       codeGenerator.listenToCommands();
       codeGenerator.buildEmbarkJS(function() {
         self.events.emit('code-generator-ready');

--- a/lib/core/engine.js
+++ b/lib/core/engine.js
@@ -140,9 +140,7 @@ class Engine {
 
     async.waterfall([
       function getWeb3Version(next) {
-        console.log('Waiting for web3 version');
         self.events.request("version:get:web3", function(web3Version) {
-          console.log('Web3 version', web3Version);
           next(null, web3Version);
         });
       },
@@ -221,7 +219,6 @@ class Engine {
         communicationConfig: self.config.communicationConfig,
         events: self.events
       });
-      console.log('LISTEN TO COMMANDS');
       codeGenerator.listenToCommands();
       codeGenerator.buildEmbarkJS(function() {
         self.events.emit('code-generator-ready');

--- a/lib/core/engine.js
+++ b/lib/core/engine.js
@@ -189,6 +189,9 @@ class Engine {
         }
 
         if (msg.result === constants.pipeline.log) {
+          if (self.logger[msg.type]) {
+            return self.logger[msg.type](self.normalizeInput(msg.message));
+          }
           self.logger.debug(self.normalizeInput(msg.message));
         }
       });

--- a/lib/core/fs.js
+++ b/lib/core/fs.js
@@ -53,6 +53,10 @@ function writeJSONSync() {
   return fs.writeJSONSync.apply(fs.writeJSONSync, arguments);
 }
 
+function writeJson() {
+  return fs.writeJson.apply(fs.writeJson, arguments);
+}
+
 function existsSync() {
   return fs.existsSync.apply(fs.existsSync, arguments);
 }
@@ -89,6 +93,7 @@ module.exports = {
   writeFile,
   writeFileSync,
   readJSONSync,
+  writeJson,
   writeJSONSync,
   access,
   existsSync,

--- a/lib/core/fs.js
+++ b/lib/core/fs.js
@@ -19,6 +19,10 @@ function appendFileSync() {
   return fs.appendFileSync.apply(fs.writeFileSync, arguments);
 }
 
+function writeFile() {
+  return fs.writeFile.apply(fs.writeFileSync, arguments);
+}
+
 function writeFileSync() {
   return fs.writeFileSync.apply(fs.writeFileSync, arguments);
 }
@@ -67,18 +71,19 @@ function createWriteStream() {
 }
 
 module.exports = {
-  mkdirpSync: mkdirpSync,
+  mkdirpSync,
   mkdirp,
-  copySync: copySync,
+  copySync,
   readFile,
-  readFileSync: readFileSync,
-  appendFileSync: appendFileSync,
-  writeFileSync: writeFileSync,
-  readJSONSync: readJSONSync,
-  writeJSONSync: writeJSONSync,
-  existsSync: existsSync,
-  removeSync: removeSync,
-  embarkPath: embarkPath,
-  dappPath: dappPath,
+  readFileSync,
+  appendFileSync,
+  writeFile,
+  writeFileSync,
+  readJSONSync,
+  writeJSONSync,
+  existsSync,
+  removeSync,
+  embarkPath,
+  dappPath,
   createWriteStream
 };

--- a/lib/core/fs.js
+++ b/lib/core/fs.js
@@ -53,6 +53,10 @@ function existsSync() {
   return fs.existsSync.apply(fs.existsSync, arguments);
 }
 
+function access() {
+  return fs.access.apply(fs.access, arguments);
+}
+
 function removeSync() {
   return fs.removeSync.apply(fs.removeSync, arguments);
 }
@@ -81,6 +85,7 @@ module.exports = {
   writeFileSync,
   readJSONSync,
   writeJSONSync,
+  access,
   existsSync,
   removeSync,
   embarkPath,

--- a/lib/core/fs.js
+++ b/lib/core/fs.js
@@ -11,6 +11,10 @@ function mkdirp() {
   return fs.mkdirp.apply(fs.mkdirp, arguments);
 }
 
+function copy() {
+  return fs.copy.apply(fs.copy, arguments);
+}
+
 function copySync() {
   return fs.copySync.apply(fs.copySync, arguments);
 }
@@ -77,6 +81,7 @@ function createWriteStream() {
 module.exports = {
   mkdirpSync,
   mkdirp,
+  copy,
   copySync,
   readFile,
   readFileSync,

--- a/lib/pipeline/pipeline.js
+++ b/lib/pipeline/pipeline.js
@@ -129,20 +129,39 @@ class Pipeline {
                 function changeCwdBack(next) {
                   process.chdir(realCwd);
                   next();
+                },
+
+                function checkFile(next) {
+                  fs.access('./.embark/' + file.filename, (err) => {
+                    if (err) {
+                      self.log("couldn't find file: " + file.filename);
+                      return next("couldn't find file: " + file.filename);
+                    }
+                    next();
+                  });
+                },
+
+                function readFile(next) {
+                  fs.readFile('./.embark/' + file.filename, (err, data) => {
+                    if (err) {
+                      return next(err);
+                    }
+                    next(null, data.toString());
+                  });
+                },
+
+                function runPluginsOnContent(fileContent, next) {
+                  self.runPlugins(file, fileContent, next);
                 }
 
-              ], function(err, _result) {
+              ], function(err, contentFile) {
                 if (err) {
                   process.chdir(realCwd);
                   self.log(err);
                   return fileCb(err);
                 }
-                if (!fs.existsSync('./.embark/' + file.filename)) {
-                  self.log("couldn't find file: " + file.filename);
-                  return fileCb("couldn't find file: " + file.filename);
-                }
-                let fileContent = fs.readFileSync('./.embark/' + file.filename).toString();
-                self.runPlugins(file, fileContent, fileCb);
+
+                fileCb(null, contentFile);
               });
             } else {
               file.content(function(fileContent) {

--- a/lib/pipeline/pipeline.js
+++ b/lib/pipeline/pipeline.js
@@ -285,7 +285,6 @@ class Pipeline {
 
     webpack(webpackOptions).run((_err, _stats) => {
       if (_err) {
-        console.log('ERROS');
         console.log(_err);
       }
       if (!detectErrors) {
@@ -364,9 +363,7 @@ class Pipeline {
       }
     ], cb);
   }
-
 }
-
 
 process.on('message', (msg) => {
   if (msg.action === constants.pipeline.init) {
@@ -375,12 +372,11 @@ process.on('message', (msg) => {
   }
 
   if (msg.action === constants.pipeline.build) {
-    return pipeline.build(msg.abi, msg.contractsJSON, msg.path, (err, result) => {
-      process.send({result: constants.pipeline.built, error: err, data: result});
+    return pipeline.build(msg.abi, msg.contractsJSON, msg.path, (err) => {
+      process.send({result: constants.pipeline.built, error: err});
     });
   }
 });
-
 
 process.on('exit', () => {
   process.exit(0);

--- a/lib/pipeline/pipeline.js
+++ b/lib/pipeline/pipeline.js
@@ -39,16 +39,16 @@ class Pipeline {
     const context = {};
     context.console = console;
 
-    context.console.log = this.log;
-    context.console.warn = this.log;
-    context.console.info = this.log;
-    context.console.debug = this.log;
-    context.console.trace = this.log;
-    context.console.dir = this.log;
+    context.console.log = this.log.bind(this, 'log');
+    context.console.warn = this.log.bind(this, 'warn');
+    context.console.info = this.log.bind(this, 'info');
+    context.console.debug = this.log.bind(this, 'debug');
+    context.console.trace = this.log.bind(this, 'trace');
+    context.console.dir = this.log.bind(this, 'dir');
   }
 
-  log() {
-    process.send({result: constants.pipeline.log, message: arguments});
+  log(type, ...messages) {
+    process.send({result: constants.pipeline.log, message: messages, type});
   }
 
   build(abi, contractsJSON, path, callback) {
@@ -89,7 +89,7 @@ class Pipeline {
             async.mapLimit(files, 1,
               function (file, fileCb) {
                 file = new File(file); // Re-instantiate a File as through the process, we lose its prototype
-                self.log("reading " + file.filename);
+                console.trace("reading " + file.filename);
 
                 if (file.filename.indexOf('.js') < 0) {
                   return file.content(function (fileContent) {
@@ -124,7 +124,7 @@ class Pipeline {
                   function checkFile(next) {
                     fs.access('./.embark/' + file.filename, (err) => {
                       if (err) {
-                        self.log("couldn't find file: " + file.filename);
+                        console.error("couldn't find file: " + file.filename);
                         return next("couldn't find file: " + file.filename);
                       }
                       next();
@@ -147,7 +147,7 @@ class Pipeline {
                 ], function (err, contentFile) {
                   if (err) {
                     process.chdir(realCwd);
-                    self.log(err);
+                    console.error(err);
                     return fileCb(err);
                   }
 
@@ -156,10 +156,10 @@ class Pipeline {
               },
               function (err, contentFiles) {
                 if (err) {
-                  self.log('errors found while generating ' + targetFile);
+                  console.error('errors found while generating ' + targetFile);
                 }
                 let dir = targetFile.split('/').slice(0, -1).join('/');
-                self.log("creating dir " + self.buildDir + dir);
+                console.trace("creating dir " + self.buildDir + dir);
                 fs.mkdirpSync(self.buildDir + dir);
 
                 // if it's a directory
@@ -172,7 +172,7 @@ class Pipeline {
 
                   async.each(contentFiles, function (file, mapCb) {
                     let filename = file.filename.replace(file.basedir + '/', '');
-                    self.log("writing file " + (self.buildDir + targetDir + filename).bold.dim);
+                    console.info("writing file " + (self.buildDir + targetDir + filename).bold.dim);
 
                     fs.copy(file.path, self.buildDir + targetDir + filename, {overwrite: true}, mapCb);
                   }, cb);
@@ -186,7 +186,7 @@ class Pipeline {
                   return file.content;
                 }).join("\n");
 
-                self.log("writing file " + (self.buildDir + targetFile).bold.dim);
+                console.info("writing file " + (self.buildDir + targetFile).bold.dim);
                 fs.writeFile(self.buildDir + targetFile, content, cb);
               }
             );
@@ -219,7 +219,7 @@ class Pipeline {
       },
       function (err) {
         if (err) {
-          self.log(err.message);
+          console.error(err.message);
         }
         return fileCb(null, {
           content: fileContent,
@@ -283,16 +283,16 @@ class Pipeline {
       };
     }
 
-    webpack(webpackOptions).run((_err, _stats) => {
-      if (_err) {
-        console.log(_err);
+    webpack(webpackOptions).run((err, stats) => {
+      if (err) {
+        console.error(err);
       }
       if (!detectErrors) {
         return callback();
       }
 
-      if (_stats.hasErrors()) {
-        return callback(_stats.toJson().errors.join("\n"));
+      if (stats.hasErrors()) {
+        return callback(stats.toJson().errors.join("\n"));
       }
       callback();
     });

--- a/lib/pipeline/pipeline.js
+++ b/lib/pipeline/pipeline.js
@@ -39,12 +39,12 @@ class Pipeline {
     const context = {};
     context.console = console;
 
-    context.console.log  = this.log;
-    context.console.warn  = this.log;
-    context.console.info  = this.log;
-    context.console.debug  = this.log;
-    context.console.trace  = this.log;
-    context.console.dir  = this.log;
+    context.console.log = this.log;
+    context.console.warn = this.log;
+    context.console.info = this.log;
+    context.console.debug = this.log;
+    context.console.trace = this.log;
+    context.console.dir = this.log;
   }
 
   log() {
@@ -56,7 +56,7 @@ class Pipeline {
 
     this.buildContracts(contractsJSON);
 
-    self.buildWeb3JS(function(err) {
+    self.buildWeb3JS(function (err) {
       if (err) {
         return callback(err);
       }
@@ -67,145 +67,145 @@ class Pipeline {
       importsList["Embark/web3"] = fs.dappPath(".embark", 'web3_instance.js');
 
       self.pluginImports.forEach(function (importObject) {
-          let [importName, importLocation] = importObject;
-          importsList[importName] = importLocation;
+        let [importName, importLocation] = importObject;
+        importsList[importName] = importLocation;
       });
 
       for (let contractName in contractsJSON) {
-          let contractCode = self.buildContractJS(contractName);
-          let filePath = fs.dappPath(".embark", contractName + '.js');
-          fs.writeFileSync(filePath, contractCode);
-          importsList["Embark/contracts/" + contractName] = filePath;
+        let contractCode = self.buildContractJS(contractName);
+        let filePath = fs.dappPath(".embark", contractName + '.js');
+        fs.writeFileSync(filePath, contractCode);
+        importsList["Embark/contracts/" + contractName] = filePath;
       }
 
       // limit:1 due to issues when downloading required files such as web3.js
       async.eachOfLimit(self.assetFiles, 1, function (files, targetFile, cb) {
-        // limit:1 due to issues when downloading required files such as web3.js
-        async.mapLimit(files, 1,
-          function(file, fileCb) {
-            file = new File(file); // Re-instantiate a File as through the process, we lose its prototype
-            self.log("reading " + file.filename);
+          // limit:1 due to issues when downloading required files such as web3.js
+          async.mapLimit(files, 1,
+            function (file, fileCb) {
+              file = new File(file); // Re-instantiate a File as through the process, we lose its prototype
+              self.log("reading " + file.filename);
 
-            if (file.filename.indexOf('.js') >= 0) {
+              if (file.filename.indexOf('.js') >= 0) {
 
-              let realCwd;
+                let realCwd;
 
-              async.waterfall([
+                async.waterfall([
 
-                function findImports(next) {
-                  self.webpackRun(file.filename, {}, false, importsList, false, next);
-                },
+                  function findImports(next) {
+                    self.webpackRun(file.filename, {}, false, importsList, false, next);
+                  },
 
-                function changeCwd(next) {
-                  realCwd = utils.pwd();
-                  process.chdir(fs.embarkPath(''));
-                  next();
-                },
-
-                //function findImportsPhase2(next) {
-                //  console.log("====> findImports_2");
-                //  self.webpackRun(file.filename, {
-                //    externals: function(context, request, callback) {
-                //      if (request === utils.joinPath(fs.dappPath(), file.filename)) {
-                //        callback();
-                //      } else {
-                //        //if (request.indexOf('Embark/contracts/') === 0) {
-                //        //  let contractName = request.split('/')[2];
-                //        //  let contractCode = self.buildContractJS(contractName);
-                //        //  let filePath = utils.joinPath(fs.dappPath(), ".embark", contractName + '.js');
-                //        //  fs.writeFileSync(filePath, contractCode);
-                //        //  importsList[request] = filePath;
-                //        //}
-                //        callback(null, "amd " + Math.random());
-                //      }
-                //    }
-                //  }, true, importsList, next);
-                //},
-
-                function runWebpack(next) {
-                  self.webpackRun(file.filename, {}, true, importsList, true, next);
-                },
-
-                function changeCwdBack(next) {
-                  process.chdir(realCwd);
-                  next();
-                },
-
-                function checkFile(next) {
-                  fs.access('./.embark/' + file.filename, (err) => {
-                    if (err) {
-                      self.log("couldn't find file: " + file.filename);
-                      return next("couldn't find file: " + file.filename);
-                    }
+                  function changeCwd(next) {
+                    realCwd = utils.pwd();
+                    process.chdir(fs.embarkPath(''));
                     next();
-                  });
-                },
+                  },
 
-                function readFile(next) {
-                  fs.readFile('./.embark/' + file.filename, (err, data) => {
-                    if (err) {
-                      return next(err);
-                    }
-                    next(null, data.toString());
-                  });
-                },
+                  //function findImportsPhase2(next) {
+                  //  console.log("====> findImports_2");
+                  //  self.webpackRun(file.filename, {
+                  //    externals: function(context, request, callback) {
+                  //      if (request === utils.joinPath(fs.dappPath(), file.filename)) {
+                  //        callback();
+                  //      } else {
+                  //        //if (request.indexOf('Embark/contracts/') === 0) {
+                  //        //  let contractName = request.split('/')[2];
+                  //        //  let contractCode = self.buildContractJS(contractName);
+                  //        //  let filePath = utils.joinPath(fs.dappPath(), ".embark", contractName + '.js');
+                  //        //  fs.writeFileSync(filePath, contractCode);
+                  //        //  importsList[request] = filePath;
+                  //        //}
+                  //        callback(null, "amd " + Math.random());
+                  //      }
+                  //    }
+                  //  }, true, importsList, next);
+                  //},
 
-                function runPluginsOnContent(fileContent, next) {
-                  self.runPlugins(file, fileContent, next);
+                  function runWebpack(next) {
+                    self.webpackRun(file.filename, {}, true, importsList, true, next);
+                  },
+
+                  function changeCwdBack(next) {
+                    process.chdir(realCwd);
+                    next();
+                  },
+
+                  function checkFile(next) {
+                    fs.access('./.embark/' + file.filename, (err) => {
+                      if (err) {
+                        self.log("couldn't find file: " + file.filename);
+                        return next("couldn't find file: " + file.filename);
+                      }
+                      next();
+                    });
+                  },
+
+                  function readFile(next) {
+                    fs.readFile('./.embark/' + file.filename, (err, data) => {
+                      if (err) {
+                        return next(err);
+                      }
+                      next(null, data.toString());
+                    });
+                  },
+
+                  function runPluginsOnContent(fileContent, next) {
+                    self.runPlugins(file, fileContent, next);
+                  }
+
+                ], function (err, contentFile) {
+                  if (err) {
+                    process.chdir(realCwd);
+                    self.log(err);
+                    return fileCb(err);
+                  }
+
+                  fileCb(null, contentFile);
+                });
+              } else {
+                file.content(function (fileContent) {
+                  self.runPlugins(file, fileContent, fileCb);
+                });
+              }
+            },
+            function (err, contentFiles) {
+              if (err) {
+                self.log('errors found while generating ' + targetFile);
+              }
+              let dir = targetFile.split('/').slice(0, -1).join('/');
+              self.log("creating dir " + self.buildDir + dir);
+              fs.mkdirpSync(self.buildDir + dir);
+
+              // if it's a directory
+              if (targetFile.slice(-1) === '/' || targetFile.indexOf('.') === -1) {
+                let targetDir = targetFile;
+
+                if (targetDir.slice(-1) !== '/') {
+                  targetDir = targetDir + '/';
                 }
 
-              ], function(err, contentFile) {
-                if (err) {
-                  process.chdir(realCwd);
-                  self.log(err);
-                  return fileCb(err);
+                async.each(contentFiles, function (file, mapCb) {
+                  let filename = file.filename.replace(file.basedir + '/', '');
+                  self.log("writing file " + (self.buildDir + targetDir + filename).bold.dim);
+
+                  fs.copy(file.path, self.buildDir + targetDir + filename, {overwrite: true}, mapCb);
+                }, cb);
+                return;
+              }
+
+              let content = contentFiles.map(function (file) {
+                if (file === undefined) {
+                  return "";
                 }
+                return file.content;
+              }).join("\n");
 
-                fileCb(null, contentFile);
-              });
-            } else {
-              file.content(function(fileContent) {
-                self.runPlugins(file, fileContent, fileCb);
-              });
+              self.log("writing file ASYNC " + (self.buildDir + targetFile).bold.dim);
+              fs.writeFile(self.buildDir + targetFile, content, cb);
             }
-          },
-          function (err, contentFiles) {
-            if (err) {
-              self.log('errors found while generating ' + targetFile);
-            }
-            let dir = targetFile.split('/').slice(0, -1).join('/');
-            self.log("creating dir " + self.buildDir + dir);
-            fs.mkdirpSync(self.buildDir + dir);
-
-            // if it's a directory
-            if (targetFile.slice(-1) === '/' || targetFile.indexOf('.') === -1) {
-              let targetDir = targetFile;
-
-              if (targetDir.slice(-1) !== '/') {
-                targetDir = targetDir + '/';
-              }
-
-              async.each(contentFiles, function (file, mapCb) {
-                let filename = file.filename.replace(file.basedir + '/', '');
-                self.log("writing file " + (self.buildDir + targetDir + filename).bold.dim);
-
-                fs.copy(file.path, self.buildDir + targetDir + filename, {overwrite: true}, mapCb);
-              }, cb);
-              return;
-            }
-
-            let content = contentFiles.map(function (file) {
-              if (file === undefined) {
-                return "";
-              }
-              return file.content;
-            }).join("\n");
-
-            self.log("writing file ASYNC " + (self.buildDir + targetFile).bold.dim);
-            fs.writeFile(self.buildDir + targetFile, content, cb);
-          }
-        );
-      },
+          );
+        },
         function (_err) {
           callback();
         });
@@ -215,10 +215,16 @@ class Pipeline {
   runPlugins(file, fileContent, fileCb) {
     const self = this;
     if (self.pipelinePlugins.length <= 0) {
-      return fileCb(null, {content: fileContent, filename: file.filename, path: file.path, basedir: file.basedir, modified: true});
+      return fileCb(null, {
+        content: fileContent,
+        filename: file.filename,
+        path: file.path,
+        basedir: file.basedir,
+        modified: true
+      });
     }
     async.eachSeries(self.pipelinePlugins,
-      function(plugin, pluginCB) {
+      function (plugin, pluginCB) {
         if (file.options && file.options.skipPipeline) {
           return pluginCB();
         }
@@ -231,7 +237,13 @@ class Pipeline {
         if (err) {
           self.log(err.message);
         }
-        return fileCb(null, {content: fileContent, filename: file.filename, path: file.path, basedir: file.basedir, modified: true});
+        return fileCb(null, {
+          content: fileContent,
+          filename: file.filename,
+          path: file.path,
+          basedir: file.basedir,
+          modified: true
+        });
       }
     );
   }
@@ -251,12 +263,12 @@ class Pipeline {
           fs.dappPath('node_modules')
         ]
       },
-      externals: function(context, request, callback) {
+      externals: function (context, request, callback) {
         callback();
       }
     };
 
-    let webpackOptions =  utils.recursiveMerge(defaultOptions, options);
+    let webpackOptions = utils.recursiveMerge(defaultOptions, options);
 
     if (includeModules) {
       webpackOptions.module = {

--- a/lib/pipeline/pipeline.js
+++ b/lib/pipeline/pipeline.js
@@ -71,144 +71,127 @@ class Pipeline {
         importsList[importName] = importLocation;
       });
 
-      for (let contractName in contractsJSON) {
-        let contractCode = self.buildContractJS(contractName);
-        let filePath = fs.dappPath(".embark", contractName + '.js');
-        fs.writeFileSync(filePath, contractCode);
-        importsList["Embark/contracts/" + contractName] = filePath;
-      }
-
-      // limit:1 due to issues when downloading required files such as web3.js
-      async.eachOfLimit(self.assetFiles, 1, function (files, targetFile, cb) {
-          // limit:1 due to issues when downloading required files such as web3.js
-          async.mapLimit(files, 1,
-            function (file, fileCb) {
-              file = new File(file); // Re-instantiate a File as through the process, we lose its prototype
-              self.log("reading " + file.filename);
-
-              if (file.filename.indexOf('.js') >= 0) {
-
-                let realCwd;
-
-                async.waterfall([
-
-                  function findImports(next) {
-                    self.webpackRun(file.filename, {}, false, importsList, false, next);
-                  },
-
-                  function changeCwd(next) {
-                    realCwd = utils.pwd();
-                    process.chdir(fs.embarkPath(''));
-                    next();
-                  },
-
-                  //function findImportsPhase2(next) {
-                  //  console.log("====> findImports_2");
-                  //  self.webpackRun(file.filename, {
-                  //    externals: function(context, request, callback) {
-                  //      if (request === utils.joinPath(fs.dappPath(), file.filename)) {
-                  //        callback();
-                  //      } else {
-                  //        //if (request.indexOf('Embark/contracts/') === 0) {
-                  //        //  let contractName = request.split('/')[2];
-                  //        //  let contractCode = self.buildContractJS(contractName);
-                  //        //  let filePath = utils.joinPath(fs.dappPath(), ".embark", contractName + '.js');
-                  //        //  fs.writeFileSync(filePath, contractCode);
-                  //        //  importsList[request] = filePath;
-                  //        //}
-                  //        callback(null, "amd " + Math.random());
-                  //      }
-                  //    }
-                  //  }, true, importsList, next);
-                  //},
-
-                  function runWebpack(next) {
-                    self.webpackRun(file.filename, {}, true, importsList, true, next);
-                  },
-
-                  function changeCwdBack(next) {
-                    process.chdir(realCwd);
-                    next();
-                  },
-
-                  function checkFile(next) {
-                    fs.access('./.embark/' + file.filename, (err) => {
-                      if (err) {
-                        self.log("couldn't find file: " + file.filename);
-                        return next("couldn't find file: " + file.filename);
-                      }
-                      next();
-                    });
-                  },
-
-                  function readFile(next) {
-                    fs.readFile('./.embark/' + file.filename, (err, data) => {
-                      if (err) {
-                        return next(err);
-                      }
-                      next(null, data.toString());
-                    });
-                  },
-
-                  function runPluginsOnContent(fileContent, next) {
-                    self.runPlugins(file, fileContent, next);
-                  }
-
-                ], function (err, contentFile) {
-                  if (err) {
-                    process.chdir(realCwd);
-                    self.log(err);
-                    return fileCb(err);
-                  }
-
-                  fileCb(null, contentFile);
-                });
-              } else {
-                file.content(function (fileContent) {
-                  self.runPlugins(file, fileContent, fileCb);
-                });
-              }
-            },
-            function (err, contentFiles) {
-              if (err) {
-                self.log('errors found while generating ' + targetFile);
-              }
-              let dir = targetFile.split('/').slice(0, -1).join('/');
-              self.log("creating dir " + self.buildDir + dir);
-              fs.mkdirpSync(self.buildDir + dir);
-
-              // if it's a directory
-              if (targetFile.slice(-1) === '/' || targetFile.indexOf('.') === -1) {
-                let targetDir = targetFile;
-
-                if (targetDir.slice(-1) !== '/') {
-                  targetDir = targetDir + '/';
-                }
-
-                async.each(contentFiles, function (file, mapCb) {
-                  let filename = file.filename.replace(file.basedir + '/', '');
-                  self.log("writing file " + (self.buildDir + targetDir + filename).bold.dim);
-
-                  fs.copy(file.path, self.buildDir + targetDir + filename, {overwrite: true}, mapCb);
-                }, cb);
-                return;
-              }
-
-              let content = contentFiles.map(function (file) {
-                if (file === undefined) {
-                  return "";
-                }
-                return file.content;
-              }).join("\n");
-
-              self.log("writing file ASYNC " + (self.buildDir + targetFile).bold.dim);
-              fs.writeFile(self.buildDir + targetFile, content, cb);
-            }
-          );
+      async.waterfall([
+        function writeContracts(next) {
+          async.each(Object.keys(contractsJSON), (contractName, eachCb) => {
+            let contractCode = self.buildContractJS(contractName);
+            let filePath = fs.dappPath(".embark", contractName + '.js');
+            importsList["Embark/contracts/" + contractName] = filePath;
+            fs.writeFile(filePath, contractCode, eachCb);
+          }, next);
         },
-        function (_err) {
-          callback();
-        });
+        function assetFileWrite(next) {
+          // limit:1 due to issues when downloading required files such as web3.js
+          async.eachOfLimit(self.assetFiles, 1, function (files, targetFile, cb) {
+              // limit:1 due to issues when downloading required files such as web3.js
+              async.mapLimit(files, 1,
+                function (file, fileCb) {
+                  file = new File(file); // Re-instantiate a File as through the process, we lose its prototype
+                  self.log("reading " + file.filename);
+
+                  if (file.filename.indexOf('.js') < 0) {
+                    return file.content(function (fileContent) {
+                      self.runPlugins(file, fileContent, fileCb);
+                    });
+                  }
+
+                  // JS files
+                  let realCwd;
+
+                  async.waterfall([
+
+                    function findImports(next) {
+                      self.webpackRun(file.filename, {}, false, importsList, false, next);
+                    },
+
+                    function changeCwd(next) {
+                      realCwd = utils.pwd();
+                      process.chdir(fs.embarkPath(''));
+                      next();
+                    },
+
+                    function runWebpack(next) {
+                      self.webpackRun(file.filename, {}, true, importsList, true, next);
+                    },
+
+                    function changeCwdBack(next) {
+                      process.chdir(realCwd);
+                      next();
+                    },
+
+                    function checkFile(next) {
+                      fs.access('./.embark/' + file.filename, (err) => {
+                        if (err) {
+                          self.log("couldn't find file: " + file.filename);
+                          return next("couldn't find file: " + file.filename);
+                        }
+                        next();
+                      });
+                    },
+
+                    function readFile(next) {
+                      fs.readFile('./.embark/' + file.filename, (err, data) => {
+                        if (err) {
+                          return next(err);
+                        }
+                        next(null, data.toString());
+                      });
+                    },
+
+                    function runPluginsOnContent(fileContent, next) {
+                      self.runPlugins(file, fileContent, next);
+                    }
+
+                  ], function (err, contentFile) {
+                    if (err) {
+                      process.chdir(realCwd);
+                      self.log(err);
+                      return fileCb(err);
+                    }
+
+                    fileCb(null, contentFile);
+                  });
+                },
+                function (err, contentFiles) {
+                  if (err) {
+                    self.log('errors found while generating ' + targetFile);
+                  }
+                  let dir = targetFile.split('/').slice(0, -1).join('/');
+                  self.log("creating dir " + self.buildDir + dir);
+                  fs.mkdirpSync(self.buildDir + dir);
+
+                  // if it's a directory
+                  if (targetFile.slice(-1) === '/' || targetFile.indexOf('.') === -1) {
+                    let targetDir = targetFile;
+
+                    if (targetDir.slice(-1) !== '/') {
+                      targetDir = targetDir + '/';
+                    }
+
+                    async.each(contentFiles, function (file, mapCb) {
+                      let filename = file.filename.replace(file.basedir + '/', '');
+                      self.log("writing file " + (self.buildDir + targetDir + filename).bold.dim);
+
+                      fs.copy(file.path, self.buildDir + targetDir + filename, {overwrite: true}, mapCb);
+                    }, cb);
+                    return;
+                  }
+
+                  let content = contentFiles.map(function (file) {
+                    if (file === undefined) {
+                      return "";
+                    }
+                    return file.content;
+                  }).join("\n");
+
+                  self.log("writing file " + (self.buildDir + targetFile).bold.dim);
+                  fs.writeFile(self.buildDir + targetFile, content, cb);
+                }
+              );
+            },
+            next);
+        }
+      ], callback);
     });
   }
 

--- a/lib/pipeline/pipeline.js
+++ b/lib/pipeline/pipeline.js
@@ -1,12 +1,15 @@
-let fs = require('../core/fs.js');
-let async = require('async');
-var utils = require('../utils/utils.js');
+const fs = require('../core/fs.js');
+const async = require('async');
+const utils = require('../utils/utils.js');
 const webpack = require("webpack");
+const constants = require('../constants');
 
 require("babel-preset-react");
 require("babel-preset-es2015");
 require("babel-preset-es2016");
 require("babel-preset-es2017");
+
+let pipeline;
 
 class Pipeline {
 
@@ -15,8 +18,26 @@ class Pipeline {
     this.contractsFiles = options.contractsFiles;
     this.assetFiles = options.assetFiles;
     this.events = options.events;
-    this.logger = options.logger;
-    this.plugins = options.plugins;
+    this.pipelinePlugins = options.pipelinePlugins;
+    this.pluginImports = options.pluginImports;
+
+    this.interceptLogs();
+  }
+
+  interceptLogs() {
+    const context = {};
+    context.console = console;
+
+    context.console.log  = this.log;
+    context.console.warn  = this.log;
+    context.console.info  = this.log;
+    context.console.debug  = this.log;
+    context.console.trace  = this.log;
+    context.console.dir  = this.log;
+  }
+
+  log() {
+    process.send({result: constants.pipeline.log, message: arguments});
   }
 
   build(abi, contractsJSON, path, callback) {
@@ -31,7 +52,7 @@ class Pipeline {
       importsList["Embark/EmbarkJS"] = fs.dappPath(".embark", 'embark.js');
       importsList["Embark/web3"] = fs.dappPath(".embark", 'web3_instance.js');
 
-      self.plugins.getPluginsProperty('imports', 'imports').forEach(function (importObject) {
+      self.pluginImports.forEach(function (importObject) {
           let [importName, importLocation] = importObject;
           importsList[importName] = importLocation;
       });
@@ -48,7 +69,7 @@ class Pipeline {
         // limit:1 due to issues when downloading required files such as web3.js
         async.mapLimit(files, 1,
           function(file, fileCb) {
-            self.logger.trace("reading " + file.filename);
+            self.log("reading " + file.filename);
 
             if (file.filename.indexOf('.js') >= 0) {
 
@@ -98,11 +119,11 @@ class Pipeline {
               ], function(err, _result) {
                 if (err) {
                   process.chdir(realCwd);
-                  self.logger.error(err);
+                  self.log(err);
                   return fileCb(err);
                 }
                 if (!fs.existsSync('./.embark/' + file.filename)) {
-                  self.logger.error("couldn't find file: " + file.filename);
+                  self.log("couldn't find file: " + file.filename);
                   return fileCb("couldn't find file: " + file.filename);
                 }
                 let fileContent = fs.readFileSync('./.embark/' + file.filename).toString();
@@ -116,10 +137,10 @@ class Pipeline {
           },
           function (err, contentFiles) {
             if (err) {
-              self.logger.warn('errors found while generating ' + targetFile);
+              self.log('errors found while generating ' + targetFile);
             }
             let dir = targetFile.split('/').slice(0, -1).join('/');
-            self.logger.trace("creating dir " + self.buildDir + dir);
+            self.log("creating dir " + self.buildDir + dir);
             fs.mkdirpSync(self.buildDir + dir);
 
             // if it's a directory
@@ -132,7 +153,7 @@ class Pipeline {
 
               contentFiles.map(function (file) {
                 let filename = file.filename.replace(file.basedir + '/', '');
-                self.logger.info("writing file " + (self.buildDir + targetDir + filename).bold.dim);
+                self.log("writing file " + (self.buildDir + targetDir + filename).bold.dim);
 
                 fs.copySync(file.path, self.buildDir + targetDir + filename, {overwrite: true});
               });
@@ -144,7 +165,7 @@ class Pipeline {
                 return file.content;
               }).join("\n");
 
-              self.logger.info("writing file " + (self.buildDir + targetFile).bold.dim);
+              self.log("writing file " + (self.buildDir + targetFile).bold.dim);
               fs.writeFileSync(self.buildDir + targetFile, content);
             }
             cb();
@@ -159,11 +180,10 @@ class Pipeline {
 
   runPlugins(file, fileContent, fileCb) {
     const self = this;
-    let pipelinePlugins = self.plugins.getPluginsFor('pipeline');
-    if (pipelinePlugins.length <= 0) {
+    if (self.pipelinePlugins.length <= 0) {
       return fileCb(null, {content: fileContent, filename: file.filename, path: file.path, basedir: file.basedir, modified: true});
     }
-    async.eachSeries(pipelinePlugins,
+    async.eachSeries(self.pipelinePlugins,
       function(plugin, pluginCB) {
         if (file.options && file.options.skipPipeline) {
           return pluginCB();
@@ -175,7 +195,7 @@ class Pipeline {
       },
       function (err) {
         if (err) {
-          self.logger.error(err.message);
+          self.log(err.message);
         }
         return fileCb(null, {content: fileContent, filename: file.filename, path: file.path, basedir: file.basedir, modified: true});
       }
@@ -317,4 +337,21 @@ class Pipeline {
 
 }
 
-module.exports = Pipeline;
+
+process.on('message', (msg) => {
+  if (msg.action === constants.pipeline.init) {
+    pipeline = new Pipeline(msg.options);
+    return process.send({result: constants.pipeline.initiated});
+  }
+
+  if (msg.action === constants.pipeline.build) {
+    return pipeline.build(msg.abi, msg.contractsJSON, msg.path, (err, result) => {
+      process.send({result: constants.pipeline.built, error: err, data: result});
+    });
+  }
+});
+
+
+process.on('exit', () => {
+  process.exit(0);
+});

--- a/lib/pipeline/pipeline.js
+++ b/lib/pipeline/pipeline.js
@@ -3,6 +3,7 @@ const async = require('async');
 const utils = require('../utils/utils.js');
 const webpack = require("webpack");
 const constants = require('../constants');
+const File = require('../core/file');
 
 require("babel-preset-react");
 require("babel-preset-es2015");
@@ -10,6 +11,15 @@ require("babel-preset-es2016");
 require("babel-preset-es2017");
 
 let pipeline;
+
+// Override process.chdir so that we have a partial-implementation PWD for Windows
+const realChdir = process.chdir;
+process.chdir = (...args) => {
+  if (!process.env.PWD) {
+    process.env.PWD = process.cwd();
+  }
+  realChdir(...args);
+};
 
 class Pipeline {
 
@@ -73,6 +83,7 @@ class Pipeline {
         // limit:1 due to issues when downloading required files such as web3.js
         async.mapLimit(files, 1,
           function(file, fileCb) {
+            file = new File(file); // Re-instantiate a File as through the process, we lose its prototype
             self.log("reading " + file.filename);
 
             if (file.filename.indexOf('.js') >= 0) {

--- a/lib/pipeline/pipeline.js
+++ b/lib/pipeline/pipeline.js
@@ -17,9 +17,10 @@ class Pipeline {
     this.buildDir = options.buildDir;
     this.contractsFiles = options.contractsFiles;
     this.assetFiles = options.assetFiles;
-    this.events = options.events;
     this.pipelinePlugins = options.pipelinePlugins;
     this.pluginImports = options.pluginImports;
+    this.web3Location = options.web3Location;
+    this.providerCode = options.providerCode;
 
     this.interceptLogs();
   }
@@ -45,7 +46,10 @@ class Pipeline {
 
     this.buildContracts(contractsJSON);
 
-    self.buildWeb3JS(function() {
+    self.buildWeb3JS(function(err) {
+      if (err) {
+        return callback(err);
+      }
 
       let importsList = {};
 
@@ -254,6 +258,10 @@ class Pipeline {
     }
 
     webpack(webpackOptions).run((_err, _stats) => {
+      if (_err) {
+        console.log('ERROS');
+        console.log(_err);
+      }
       if (!detectErrors) {
         return callback();
       }
@@ -297,42 +305,31 @@ class Pipeline {
     let code = "";
 
     async.waterfall([
-      function getWeb3Location(next) {
-        self.events.request("version:get:web3", function(web3Version) {
-          if (web3Version === "1.0.0-beta") {
-            return next(null, utils.joinPath(fs.embarkPath("js/web3-1.0.min.js")));
-          } else {
-            self.events.request("version:getPackageLocation", "web3", web3Version, function(err, location) {
-              return next(null, fs.dappPath(location));
-            });
-          }
-        });
-      },
-      function getImports(web3Location, next) {
-        web3Location = web3Location.replace(/\\/g, '/'); // Import paths must always have forward slashes
-        code += "\nimport Web3 from '" + web3Location + "';\n";
+      function getImports(next) {
+        self.web3Location = self.web3Location.replace(/\\/g, '/'); // Import paths must always have forward slashes
+        code += "\nimport Web3 from '" + self.web3Location + "';\n";
 
         code += "\n if (typeof web3 !== 'undefined') {";
         code += "\n } else {";
         code += "\n var web3 = new Web3();\n";
         code += "\n }";
 
-        self.events.request('provider-code', function(providerCode)  {
-          code += providerCode;
-          code += "\nglobal.__embarkContext = __mainContext.__loadManagerInstance;\n";
-          code += "\nwindow.web3 = web3;\n";
-          code += "\nexport default web3;\n";
-          next();
+        code += self.providerCode;
+        code += "\nglobal.__embarkContext = __mainContext.__loadManagerInstance;\n";
+        code += "\nwindow.web3 = web3;\n";
+        code += "\nexport default web3;\n";
+
+        next();
+      },
+      function makeDirectory(next) {
+        fs.mkdirp(fs.dappPath(".embark"), (err, _result) => {
+          next(err);
         });
       },
       function writeFile(next) {
-        fs.mkdirpSync(fs.dappPath(".embark"));
-        fs.writeFileSync(fs.dappPath(".embark", 'web3_instance.js'), code);
-        next();
+        fs.writeFile(fs.dappPath(".embark", 'web3_instance.js'), code, next);
       }
-    ], function(_err, _result) {
-      cb();
-    });
+    ], cb);
   }
 
 }

--- a/lib/pipeline/pipeline.js
+++ b/lib/pipeline/pipeline.js
@@ -185,28 +185,28 @@ class Pipeline {
                 targetDir = targetDir + '/';
               }
 
-              contentFiles.map(function (file) {
+              async.each(contentFiles, function (file, mapCb) {
                 let filename = file.filename.replace(file.basedir + '/', '');
                 self.log("writing file " + (self.buildDir + targetDir + filename).bold.dim);
 
-                fs.copySync(file.path, self.buildDir + targetDir + filename, {overwrite: true});
-              });
-            } else {
-              let content = contentFiles.map(function (file) {
-                if (file === undefined) {
-                  return "";
-                }
-                return file.content;
-              }).join("\n");
-
-              self.log("writing file " + (self.buildDir + targetFile).bold.dim);
-              fs.writeFileSync(self.buildDir + targetFile, content);
+                fs.copy(file.path, self.buildDir + targetDir + filename, {overwrite: true}, mapCb);
+              }, cb);
+              return;
             }
-            cb();
+
+            let content = contentFiles.map(function (file) {
+              if (file === undefined) {
+                return "";
+              }
+              return file.content;
+            }).join("\n");
+
+            self.log("writing file ASYNC " + (self.buildDir + targetFile).bold.dim);
+            fs.writeFile(self.buildDir + targetFile, content, cb);
           }
         );
       },
-        function (_err, _results) {
+        function (_err) {
           callback();
         });
     });

--- a/lib/pipeline/pipeline.js
+++ b/lib/pipeline/pipeline.js
@@ -53,146 +53,146 @@ class Pipeline {
 
   build(abi, contractsJSON, path, callback) {
     let self = this;
+    const importsList = {};
 
-    this.buildContracts(contractsJSON);
+    async.waterfall([
+      function buildTheContracts(next) {
+        self.buildContracts(contractsJSON, next);
+      },
+      function buildWeb3(next) {
+        self.buildWeb3JS(next);
+      },
+      function createImportList(next) {
+        importsList["Embark/EmbarkJS"] = fs.dappPath(".embark", 'embark.js');
+        importsList["Embark/web3"] = fs.dappPath(".embark", 'web3_instance.js');
 
-    self.buildWeb3JS(function (err) {
-      if (err) {
-        return callback(err);
-      }
+        self.pluginImports.forEach(function (importObject) {
+          let [importName, importLocation] = importObject;
+          importsList[importName] = importLocation;
+        });
 
-      let importsList = {};
+        next();
+      },
+      function writeContracts(next) {
+        async.each(Object.keys(contractsJSON), (contractName, eachCb) => {
+          let contractCode = self.buildContractJS(contractName);
+          let filePath = fs.dappPath(".embark", contractName + '.js');
+          importsList["Embark/contracts/" + contractName] = filePath;
+          fs.writeFile(filePath, contractCode, eachCb);
+        }, next);
+      },
+      function assetFileWrite(next) {
+        // limit:1 due to issues when downloading required files such as web3.js
+        async.eachOfLimit(self.assetFiles, 1, function (files, targetFile, cb) {
+            // limit:1 due to issues when downloading required files such as web3.js
+            async.mapLimit(files, 1,
+              function (file, fileCb) {
+                file = new File(file); // Re-instantiate a File as through the process, we lose its prototype
+                self.log("reading " + file.filename);
 
-      importsList["Embark/EmbarkJS"] = fs.dappPath(".embark", 'embark.js');
-      importsList["Embark/web3"] = fs.dappPath(".embark", 'web3_instance.js');
-
-      self.pluginImports.forEach(function (importObject) {
-        let [importName, importLocation] = importObject;
-        importsList[importName] = importLocation;
-      });
-
-      async.waterfall([
-        function writeContracts(next) {
-          async.each(Object.keys(contractsJSON), (contractName, eachCb) => {
-            let contractCode = self.buildContractJS(contractName);
-            let filePath = fs.dappPath(".embark", contractName + '.js');
-            importsList["Embark/contracts/" + contractName] = filePath;
-            fs.writeFile(filePath, contractCode, eachCb);
-          }, next);
-        },
-        function assetFileWrite(next) {
-          // limit:1 due to issues when downloading required files such as web3.js
-          async.eachOfLimit(self.assetFiles, 1, function (files, targetFile, cb) {
-              // limit:1 due to issues when downloading required files such as web3.js
-              async.mapLimit(files, 1,
-                function (file, fileCb) {
-                  file = new File(file); // Re-instantiate a File as through the process, we lose its prototype
-                  self.log("reading " + file.filename);
-
-                  if (file.filename.indexOf('.js') < 0) {
-                    return file.content(function (fileContent) {
-                      self.runPlugins(file, fileContent, fileCb);
-                    });
-                  }
-
-                  // JS files
-                  let realCwd;
-
-                  async.waterfall([
-
-                    function findImports(next) {
-                      self.webpackRun(file.filename, {}, false, importsList, false, next);
-                    },
-
-                    function changeCwd(next) {
-                      realCwd = utils.pwd();
-                      process.chdir(fs.embarkPath(''));
-                      next();
-                    },
-
-                    function runWebpack(next) {
-                      self.webpackRun(file.filename, {}, true, importsList, true, next);
-                    },
-
-                    function changeCwdBack(next) {
-                      process.chdir(realCwd);
-                      next();
-                    },
-
-                    function checkFile(next) {
-                      fs.access('./.embark/' + file.filename, (err) => {
-                        if (err) {
-                          self.log("couldn't find file: " + file.filename);
-                          return next("couldn't find file: " + file.filename);
-                        }
-                        next();
-                      });
-                    },
-
-                    function readFile(next) {
-                      fs.readFile('./.embark/' + file.filename, (err, data) => {
-                        if (err) {
-                          return next(err);
-                        }
-                        next(null, data.toString());
-                      });
-                    },
-
-                    function runPluginsOnContent(fileContent, next) {
-                      self.runPlugins(file, fileContent, next);
-                    }
-
-                  ], function (err, contentFile) {
-                    if (err) {
-                      process.chdir(realCwd);
-                      self.log(err);
-                      return fileCb(err);
-                    }
-
-                    fileCb(null, contentFile);
+                if (file.filename.indexOf('.js') < 0) {
+                  return file.content(function (fileContent) {
+                    self.runPlugins(file, fileContent, fileCb);
                   });
-                },
-                function (err, contentFiles) {
-                  if (err) {
-                    self.log('errors found while generating ' + targetFile);
-                  }
-                  let dir = targetFile.split('/').slice(0, -1).join('/');
-                  self.log("creating dir " + self.buildDir + dir);
-                  fs.mkdirpSync(self.buildDir + dir);
-
-                  // if it's a directory
-                  if (targetFile.slice(-1) === '/' || targetFile.indexOf('.') === -1) {
-                    let targetDir = targetFile;
-
-                    if (targetDir.slice(-1) !== '/') {
-                      targetDir = targetDir + '/';
-                    }
-
-                    async.each(contentFiles, function (file, mapCb) {
-                      let filename = file.filename.replace(file.basedir + '/', '');
-                      self.log("writing file " + (self.buildDir + targetDir + filename).bold.dim);
-
-                      fs.copy(file.path, self.buildDir + targetDir + filename, {overwrite: true}, mapCb);
-                    }, cb);
-                    return;
-                  }
-
-                  let content = contentFiles.map(function (file) {
-                    if (file === undefined) {
-                      return "";
-                    }
-                    return file.content;
-                  }).join("\n");
-
-                  self.log("writing file " + (self.buildDir + targetFile).bold.dim);
-                  fs.writeFile(self.buildDir + targetFile, content, cb);
                 }
-              );
-            },
-            next);
-        }
-      ], callback);
-    });
+
+                // JS files
+                let realCwd;
+
+                async.waterfall([
+
+                  function findImports(next) {
+                    self.webpackRun(file.filename, {}, false, importsList, false, next);
+                  },
+
+                  function changeCwd(next) {
+                    realCwd = utils.pwd();
+                    process.chdir(fs.embarkPath(''));
+                    next();
+                  },
+
+                  function runWebpack(next) {
+                    self.webpackRun(file.filename, {}, true, importsList, true, next);
+                  },
+
+                  function changeCwdBack(next) {
+                    process.chdir(realCwd);
+                    next();
+                  },
+
+                  function checkFile(next) {
+                    fs.access('./.embark/' + file.filename, (err) => {
+                      if (err) {
+                        self.log("couldn't find file: " + file.filename);
+                        return next("couldn't find file: " + file.filename);
+                      }
+                      next();
+                    });
+                  },
+
+                  function readFile(next) {
+                    fs.readFile('./.embark/' + file.filename, (err, data) => {
+                      if (err) {
+                        return next(err);
+                      }
+                      next(null, data.toString());
+                    });
+                  },
+
+                  function runPluginsOnContent(fileContent, next) {
+                    self.runPlugins(file, fileContent, next);
+                  }
+
+                ], function (err, contentFile) {
+                  if (err) {
+                    process.chdir(realCwd);
+                    self.log(err);
+                    return fileCb(err);
+                  }
+
+                  fileCb(null, contentFile);
+                });
+              },
+              function (err, contentFiles) {
+                if (err) {
+                  self.log('errors found while generating ' + targetFile);
+                }
+                let dir = targetFile.split('/').slice(0, -1).join('/');
+                self.log("creating dir " + self.buildDir + dir);
+                fs.mkdirpSync(self.buildDir + dir);
+
+                // if it's a directory
+                if (targetFile.slice(-1) === '/' || targetFile.indexOf('.') === -1) {
+                  let targetDir = targetFile;
+
+                  if (targetDir.slice(-1) !== '/') {
+                    targetDir = targetDir + '/';
+                  }
+
+                  async.each(contentFiles, function (file, mapCb) {
+                    let filename = file.filename.replace(file.basedir + '/', '');
+                    self.log("writing file " + (self.buildDir + targetDir + filename).bold.dim);
+
+                    fs.copy(file.path, self.buildDir + targetDir + filename, {overwrite: true}, mapCb);
+                  }, cb);
+                  return;
+                }
+
+                let content = contentFiles.map(function (file) {
+                  if (file === undefined) {
+                    return "";
+                  }
+                  return file.content;
+                }).join("\n");
+
+                self.log("writing file " + (self.buildDir + targetFile).bold.dim);
+                fs.writeFile(self.buildDir + targetFile, content, cb);
+              }
+            );
+          },
+          next);
+      }
+    ], callback);
   }
 
   runPlugins(file, fileContent, fileCb) {
@@ -298,13 +298,16 @@ class Pipeline {
     });
   }
 
-  buildContracts(contractsJSON) {
-    fs.mkdirpSync(fs.dappPath(this.buildDir, 'contracts'));
-
-    for (let className in contractsJSON) {
-      let contract = contractsJSON[className];
-      fs.writeJSONSync(fs.dappPath(this.buildDir, 'contracts', className + ".json"), contract, {spaces: 2});
-    }
+  buildContracts(contractsJSON, callback) {
+    fs.mkdirp(fs.dappPath(this.buildDir, 'contracts'), (err) => {
+      if (err) {
+        return callback(err);
+      }
+      async.each(Object.keys(contractsJSON), (className, eachCb) => {
+        let contract = contractsJSON[className];
+        fs.writeJson(fs.dappPath(this.buildDir, 'contracts', className + ".json"), contract, {spaces: 2}, eachCb);
+      }, callback);
+    });
   }
 
   buildContractJS(contractName) {

--- a/lib/pipeline/pipeline.js
+++ b/lib/pipeline/pipeline.js
@@ -75,10 +75,11 @@ class Pipeline {
       },
       function writeContracts(next) {
         async.each(Object.keys(contractsJSON), (contractName, eachCb) => {
-          let contractCode = self.buildContractJS(contractName);
-          let filePath = fs.dappPath(".embark", contractName + '.js');
-          importsList["Embark/contracts/" + contractName] = filePath;
-          fs.writeFile(filePath, contractCode, eachCb);
+          self.buildContractJS(contractName, (err, contractCode) => {
+            let filePath = fs.dappPath(".embark", contractName + '.js');
+            importsList["Embark/contracts/" + contractName] = filePath;
+            fs.writeFile(filePath, contractCode, eachCb);
+          });
         }, next);
       },
       function assetFileWrite(next) {
@@ -310,22 +311,26 @@ class Pipeline {
     });
   }
 
-  buildContractJS(contractName) {
-    let contractJSON = fs.readFileSync(fs.dappPath(this.buildDir, 'contracts', contractName + '.json')).toString();
+  buildContractJS(contractName, callback) {
+    fs.readFile(fs.dappPath(this.buildDir, 'contracts', contractName + '.json'), (err, contractJSON) => {
+      if (err) {
+        return callback(err);
+      }
+      contractJSON = contractJSON.toString();
 
-    let contractCode = "";
-    contractCode += "import web3 from 'Embark/web3';\n";
-    contractCode += "import EmbarkJS from 'Embark/EmbarkJS';\n";
-    contractCode += "let " + contractName + "JSONConfig = " + contractJSON + ";\n";
-    contractCode += "let " + contractName + " = new EmbarkJS.Contract(" + contractName + "JSONConfig);\n";
+      let contractCode = "";
+      contractCode += "import web3 from 'Embark/web3';\n";
+      contractCode += "import EmbarkJS from 'Embark/EmbarkJS';\n";
+      contractCode += "let " + contractName + "JSONConfig = " + contractJSON + ";\n";
+      contractCode += "let " + contractName + " = new EmbarkJS.Contract(" + contractName + "JSONConfig);\n";
 
-    contractCode += "\n__embarkContext.execWhenReady(function() {\n";
-    contractCode += "\n" + contractName + ".setProvider(web3.currentProvider);\n";
-    contractCode += "\n});\n";
+      contractCode += "\n__embarkContext.execWhenReady(function() {\n";
+      contractCode += "\n" + contractName + ".setProvider(web3.currentProvider);\n";
+      contractCode += "\n});\n";
 
-    contractCode += "export default " + contractName + ";\n";
-
-    return contractCode;
+      contractCode += "export default " + contractName + ";\n";
+      callback(null, contractCode);
+    });
   }
 
   buildWeb3JS(cb) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "embark",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -6056,9 +6056,9 @@
           }
         },
         "minipass": {
-          "version": "2.2.4",
-          "resolved": "https://registry.npmjs.org/minipass/-/minipass-2.2.4.tgz",
-          "integrity": "sha512-hzXIWWet/BzWhYs2b+u7dRHlruXhwdgvlTMDKC6Cb1U7ps6Ac6yQlR39xsbjWJE377YTCtKwIXIpJ5oP+j5y8g==",
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/minipass/-/minipass-2.3.0.tgz",
+          "integrity": "sha512-jWC2Eg+Np4bxah7llu1IrUNSJQxtLz/J+pOjTM0nFpJXGAaV18XBWhUn031Q1tAA/TJtA1jgwnOe9S2PQa4Lbg==",
           "requires": {
             "safe-buffer": "5.1.2",
             "yallist": "3.0.2"
@@ -6076,7 +6076,7 @@
           "requires": {
             "chownr": "1.0.1",
             "fs-minipass": "1.2.5",
-            "minipass": "2.2.4",
+            "minipass": "2.3.0",
             "minizlib": "1.1.0",
             "mkdirp": "0.5.1",
             "safe-buffer": "5.1.2",


### PR DESCRIPTION
Does the file processing in a separate process, which greatly increases the responsiveness of the Console. For example, it is now possible to type commands like help during the file processing.

Was able to send logs from the child process to the main. I didn't create a wrapper for it yet, but it would be possible afterwards. PR is already not so nice to review, so adding another layer of complexity would make it a nightmare.

Another step would be to process each file in a separate process. Maybe after having a wrapper, it would be easy. (Right now, the step that takes a lot of time in the webpack step). 