### PR TITLE
Add a cargo to not run file write for each file

### DIFF
--- a/lib/core/engine.js
+++ b/lib/core/engine.js
@@ -146,16 +146,9 @@ class Engine {
       plugins: this.plugins
     });
 
-    const queue = async.queue((task, callback) => {
-      pipeline.build(task.abi, task.contractsJSON, task.path, callback);
-    }, 1);
-
     this.events.on('code-generator-ready', function () {
       self.events.request('code', function (abi, contractsJSON) {
-        self.currentAbi = abi;
-        self.contractsJSON = contractsJSON;
-
-        queue.push({abi, contractsJSON, path: null}, () => {
+        pipeline.build(abi, contractsJSON, null, () => {
           if (self.watch) {
             self.watch.restart(); // Necessary because changing a file while it is writing can stop it from being watched
           }
@@ -168,7 +161,7 @@ class Engine {
   codeGeneratorService(_options) {
     let self = this;
 
-    let generateCode = function (contractsManager) {
+    const generateCode = function (contractsManager) {
       let codeGenerator = new CodeGenerator({
         blockchainConfig: self.config.blockchainConfig,
         contractsConfig: self.config.contractsConfig,
@@ -183,9 +176,17 @@ class Engine {
         self.events.emit('code-generator-ready');
       });
     };
-    this.events.on('contractsDeployed', generateCode);
-    this.events.on('blockchainDisabled', generateCode);
-    this.events.on('asset-changed', generateCode);
+    const cargo = async.cargo((tasks, callback) => {
+      generateCode(tasks[tasks.length - 1].contractsManager);
+      self.events.once('outputDone', callback);
+    });
+    const addToCargo = function (contractsManager) {
+      cargo.push({contractsManager});
+    };
+
+    this.events.on('contractsDeployed', addToCargo);
+    this.events.on('blockchainDisabled', addToCargo);
+    this.events.on('asset-changed', addToCargo);
   }
 
   deploymentService(options) {
@@ -226,9 +227,13 @@ class Engine {
       // TODO: still need to redeploy contracts because the original contracts
       // config is being corrupted
       if (fileType === 'asset') {
-        self.events.emit('asset-changed', self.contractsManager);
+        // Throttle file changes so we re-write only once for all files
+        clearTimeout(self.fileTimeout);
+        self.fileTimeout = setTimeout(() => {
+          self.events.emit('asset-changed', self.contractsManager);
+        }, 50);
       }
-      // TODO: for now need to deploy on asset chanes as well
+      // TODO: for now need to deploy on asset changes as well
       // because the contractsManager config is corrupted after a deploy
       if (fileType === 'contract' || fileType === 'config') {
         self.config.reloadConfig();

--- a/lib/core/engine.js
+++ b/lib/core/engine.js
@@ -224,22 +224,22 @@ class Engine {
     });
 
     this.events.on('file-event', function (fileType) {
-      // TODO: still need to redeploy contracts because the original contracts
-      // config is being corrupted
-      if (fileType === 'asset') {
-        // Throttle file changes so we re-write only once for all files
-        clearTimeout(self.fileTimeout);
-        self.fileTimeout = setTimeout(() => {
+      clearTimeout(self.fileTimeout);
+      self.fileTimeout = setTimeout(() => {
+        // TODO: still need to redeploy contracts because the original contracts
+        // config is being corrupted
+        if (fileType === 'asset') {
+          // Throttle file changes so we re-write only once for all files
           self.events.emit('asset-changed', self.contractsManager);
-        }, 50);
-      }
-      // TODO: for now need to deploy on asset changes as well
-      // because the contractsManager config is corrupted after a deploy
-      if (fileType === 'contract' || fileType === 'config') {
-        self.config.reloadConfig();
-        self.deployManager.deployContracts(function () {
-        });
-      }
+        }
+        // TODO: for now need to deploy on asset changes as well
+        // because the contractsManager config is corrupted after a deploy
+        if (fileType === 'contract' || fileType === 'config') {
+          self.config.reloadConfig();
+          self.deployManager.deployContracts(function () {
+          });
+        }
+      }, 50);
     });
   }
 


### PR DESCRIPTION
Cargo enables you to change multiple files while a file write is running and it will only run once after for all the other files.

Also, adds throttling for file changes, so we trigger a file change event only once for multiple files.