### PR TITLE
set max listeners to 50

### DIFF
--- a/lib/core/events.js
+++ b/lib/core/events.js
@@ -14,7 +14,7 @@ function log(eventType, eventName) {
   //console.log(eventType, eventName);
 }
 
-EventEmitter.prototype._maxListeners = 50;
+EventEmitter.prototype._maxListeners = 200;
 const _on         = EventEmitter.prototype.on;
 const _setHandler = EventEmitter.prototype.setHandler;
 

--- a/lib/core/events.js
+++ b/lib/core/events.js
@@ -14,6 +14,7 @@ function log(eventType, eventName) {
   //console.log(eventType, eventName);
 }
 
+EventEmitter.prototype._maxListeners = 50;
 const _on         = EventEmitter.prototype.on;
 const _setHandler = EventEmitter.prototype.setHandler;
 


### PR DESCRIPTION
Looks like it fixes `MaxListenersExceededWarning: Possible EventEmitter memory leak detected.`, because the normal limit is 10.