### PR TITLE
Initialize web3 provider before deployAll

### DIFF
--- a/lib/tests/test.js
+++ b/lib/tests/test.js
@@ -41,17 +41,17 @@ var Test = function(options) {
   });
 
   this.web3 = new Web3();
-};
-
-Test.prototype.deployAll = function(contractsConfig, cb) {
-  var self = this;
-
+  
   if (this.simOptions.node) {
     this.web3.setProvider(new this.web3.providers.HttpProvider(this.simOptions.node));
   } else {
     this.sim = getSimulator();
     this.web3.setProvider(this.sim.provider(this.simOptions));
   }
+};
+
+Test.prototype.deployAll = function(contractsConfig, cb) {
+  var self = this;
 
   async.waterfall([
       function getConfig(callback) {


### PR DESCRIPTION
This makes possible to load accounts before deploying the contracts.