### PR TITLE
Improve Process Launcher

### DIFF
--- a/lib/modules/solidity/solcW.js
+++ b/lib/modules/solidity/solcW.js
@@ -24,7 +24,7 @@ class SolcW {
     });
     this.solcProcess.send({action: "init", options: {}});
 
-    this.solcProcess.subscribeTo('result', 'loadedCompiler', () => {
+    this.solcProcess.on('result', 'loadedCompiler', () => {
       self.compilerLoaded = true;
       done();
     });
@@ -50,7 +50,7 @@ class SolcW {
 
   compile(jsonObj,  done) {
     const self = this;
-    this.solcProcess.subscribeTo('result', 'compilation', (msg) => {
+    this.solcProcess.on('result', 'compilation', (msg) => {
       self.solcProcess.unsubscribeTo('result', 'compilation');
       done(JSON.parse(msg.output));
     });

--- a/lib/modules/solidity/solcW.js
+++ b/lib/modules/solidity/solcW.js
@@ -15,7 +15,7 @@ class SolcW {
   load_compiler(done) {
     const self = this;
     if (this.compilerLoaded) {
-      done();
+      return done();
     }
     this.solcProcess = new ProcessLauncher({
       modulePath: utils.joinPath(__dirname, 'solcP.js'),
@@ -24,7 +24,7 @@ class SolcW {
     });
     this.solcProcess.send({action: "init", options: {}});
 
-    this.solcProcess.on('result', 'loadedCompiler', () => {
+    this.solcProcess.once('result', 'loadedCompiler', () => {
       self.compilerLoaded = true;
       done();
     });
@@ -49,9 +49,7 @@ class SolcW {
   }
 
   compile(jsonObj,  done) {
-    const self = this;
-    this.solcProcess.on('result', 'compilation', (msg) => {
-      self.solcProcess.unsubscribeTo('result', 'compilation');
+    this.solcProcess.once('result', 'compilation', (msg) => {
       done(JSON.parse(msg.output));
     });
 

--- a/lib/pipeline/pipeline.js
+++ b/lib/pipeline/pipeline.js
@@ -80,7 +80,7 @@ class Pipeline {
                     webpackProcess.send({action: constants.pipeline.init, options: {}});
                     webpackProcess.send({action: constants.pipeline.build, file, importsList});
 
-                    webpackProcess.on('result', constants.pipeline.built, (msg) => {
+                    webpackProcess.once('result', constants.pipeline.built, (msg) => {
                       webpackProcess.disconnect();
                       return next(msg.error);
                     });

--- a/lib/pipeline/pipeline.js
+++ b/lib/pipeline/pipeline.js
@@ -80,7 +80,7 @@ class Pipeline {
                     webpackProcess.send({action: constants.pipeline.init, options: {}});
                     webpackProcess.send({action: constants.pipeline.build, file, importsList});
 
-                    webpackProcess.subscribeTo('result', constants.pipeline.built, (msg) => {
+                    webpackProcess.on('result', constants.pipeline.built, (msg) => {
                       webpackProcess.disconnect();
                       return next(msg.error);
                     });

--- a/lib/process/processLauncher.js
+++ b/lib/process/processLauncher.js
@@ -70,13 +70,13 @@ class ProcessLauncher {
   _checkSubscriptions(msg) {
     const messageKeys = Object.keys(msg);
     const subscriptionsKeys = Object.keys(this.subscriptions);
-    let subscriptions;
+    let subscriptionsForKey;
     let messageKey;
     // Find if the message contains a key that we are subscribed to
     messageKeys.some(_messageKey => {
       return subscriptionsKeys.some(subscriptionKey => {
         if (_messageKey === subscriptionKey) {
-          subscriptions = this.subscriptions[subscriptionKey];
+          subscriptionsForKey = this.subscriptions[subscriptionKey];
           messageKey = _messageKey;
           return true;
         }
@@ -84,20 +84,28 @@ class ProcessLauncher {
       });
     });
 
-    if (subscriptions) {
-      let subscription;
+    if (subscriptionsForKey) {
       // Find if we are subscribed to one of the values
-      subscriptions.some(sub => {
+      let subsIndex = [];
+      const subscriptionsForValue = subscriptionsForKey.filter((sub, index) => {
         if (msg[messageKey] === sub.value) {
-          subscription = sub;
+          subsIndex.push(index);
           return true;
         }
         return false;
       });
 
-      if (subscription) {
+      if (subscriptionsForValue.length) {
         // We are subscribed to that message, call the callback
-        subscription.callback(msg);
+        subscriptionsForValue.forEach((subscription, index) => {
+          subscription.callback(msg);
+
+          if (subscription.once) {
+            // Called only once, we can remove it
+            subscription = null;
+            this.subscriptions[messageKey].splice(subsIndex[index], 1);
+          }
+        });
       }
     }
   }
@@ -109,12 +117,28 @@ class ProcessLauncher {
    * @param {Function}  callback  callback(response)
    * @return {void}
    */
-  subscribeTo(key, value, callback) {
+  on(key, value, callback) {
     if (this.subscriptions[key]) {
       this.subscriptions[key].push({value, callback});
       return;
     }
     this.subscriptions[key] = [{value, callback}];
+  }
+
+  /**
+   * Same as .on, but only triggers once
+   * @param {String}    key       Message key to subscribe to
+   * @param {String}    value     Value that the above key must have for the callback to be called
+   * @param {Function}  callback  callback(response)
+   * @return {void}
+   */
+  once(key, value, callback) {
+    const obj = {value, callback, once: true};
+    if (this.subscriptions[key]) {
+      this.subscriptions[key].push(obj);
+      return;
+    }
+    this.subscriptions[key] = [obj];
   }
 
   /**

--- a/test/processLauncher.js
+++ b/test/processLauncher.js
@@ -14,14 +14,14 @@ describe('ProcessWrapper', () => {
     });
   });
 
-  describe('subscribeTo', () => {
+  describe('on', () => {
 
     beforeEach(() => {
       processLauncher.subscriptions = {};
     });
 
     it('should create an array for the key value', function () {
-      processLauncher.subscribeTo('test', 'value', 'myCallback');
+      processLauncher.on('test', 'value', 'myCallback');
       assert.deepEqual(processLauncher.subscriptions, {
         "test": [
           {
@@ -33,8 +33,8 @@ describe('ProcessWrapper', () => {
     });
 
     it('should add another value to the key', () => {
-      processLauncher.subscribeTo('test', 'value', 'myCallback');
-      processLauncher.subscribeTo('test', 'value2', 'myCallback2');
+      processLauncher.on('test', 'value', 'myCallback');
+      processLauncher.on('test', 'value2', 'myCallback2');
       assert.deepEqual(processLauncher.subscriptions, {
         "test": [
           {
@@ -134,6 +134,40 @@ describe('ProcessWrapper', () => {
       };
       processLauncher._checkSubscriptions({test: 'value'});
       assert.strictEqual(callback.callCount, 1);
+    });
+
+    it('should call the callback and remove the sub', function () {
+      const callback = sinon.stub();
+      processLauncher.subscriptions = {
+        "test": [
+          {
+            "callback": callback,
+            "value": "value",
+            "once": true
+          }
+        ]
+      };
+      processLauncher._checkSubscriptions({test: 'value'});
+      assert.strictEqual(callback.callCount, 1);
+      assert.deepEqual(processLauncher.subscriptions, {test: []});
+    });
+
+    it('should call the callback twice', function () {
+      const callback = sinon.stub();
+      processLauncher.subscriptions = {
+        "test": [
+          {
+            "callback": callback,
+            "value": "value"
+          },
+          {
+            "callback": callback,
+            "value": "value"
+          }
+        ]
+      };
+      processLauncher._checkSubscriptions({test: 'value'});
+      assert.strictEqual(callback.callCount, 2);
     });
   });
 });


### PR DESCRIPTION
- Rename `subscribeTo` to `on`
- Add `once`, which triggers only once
- Enable multiple subscriptions to the same key-value 
 - So for example, if module A subs to ('result', 'success'), module B can too and they both have their respective callbacks called
- Changed solcW and pipeline to use once