### PR TITLE
Improve dapp imports to allow alternate syntax for importing contracts

### DIFF
--- a/lib/i18n/locales/en.json
+++ b/lib/i18n/locales/en.json
@@ -109,5 +109,10 @@
 	"{{className}} has code associated to it but it's configured as an instanceOf {{parentContractName}}": "{{className}} has code associated to it but it's configured as an instanceOf {{parentContractName}}",
 	"downloading {{packageName}} {{version}}....": "downloading {{packageName}} {{version}}....",
 	"Swarm node is offline...": "Swarm node is offline...",
-	"Swarm node detected...": "Swarm node detected..."
+	"Swarm node detected...": "Swarm node detected...",
+	"Cannot find file %s Please ensure you are running this command inside the Dapp folder": "Cannot find file %s Please ensure you are running this command inside the Dapp folder",
+	"finished building": "finished building",
+	"compiling Vyper contracts": "compiling Vyper contracts",
+	"Vyper exited with error code ": "Vyper exited with error code ",
+	"attempted to deploy %s without specifying parameters": "attempted to deploy %s without specifying parameters"
 }

--- a/lib/pipeline/pipeline.js
+++ b/lib/pipeline/pipeline.js
@@ -36,6 +36,7 @@ class Pipeline {
       function createImportList(next) {
         importsList["Embark/EmbarkJS"] = fs.dappPath(".embark", 'embark.js');
         importsList["Embark/web3"] = fs.dappPath(".embark", 'web3_instance.js');
+        importsList["Embark/contracts"] = fs.dappPath(".embark/contracts", '');
 
         self.plugins.getPluginsProperty('imports', 'imports').forEach(function (importObject) {
           let [importName, importLocation] = importObject;
@@ -44,15 +45,30 @@ class Pipeline {
 
         next();
       },
-      function writeContracts(next) {
+      function writeContracts(next) {        
         self.events.request('contracts:list', (contracts) => {
-          async.each(contracts, (contract, eachCb) => {
-            self.events.request('code-generator:contract', contract.className, (contractCode) => {
-              let filePath = fs.dappPath(".embark", contract.className + '.js');
-              importsList["Embark/contracts/" + contract.className] = filePath;
-              fs.writeFile(filePath, contractCode, eachCb);
+          // ensure the .embark/contracts directory exists (create if not exists)
+          fs.mkdirp(fs.dappPath(".embark/contracts", ''), (err) => {
+            if(err) return next(err);
+            async.each(contracts, (contract, eachCb) => {
+              self.events.request('code-generator:contract', contract.className, (contractCode) => {
+                let filePath = fs.dappPath(".embark/contracts", contract.className + '.js');
+                importsList["Embark/contracts/" + contract.className] = filePath;
+                fs.writeFile(filePath, contractCode, eachCb);
+              });
+            }, function(){
+              // create a file .embark/contracts/index.js that requires all files in the .embark/contracts directory
+              // except for itself. Used to enable alternate import syntax:
+              // e.g. import {Token} from 'Embark/contracts'
+              // e.g. import * as Contracts from 'Embark/contracts'
+              let importsHelper = `module.exports = (ctx => {
+                  let keys = ctx.keys();
+                  let values = keys.map(ctx);
+                  return keys.reduce((o, k, i) => { o[k.replace('./', '').replace('.js', '')] = values[i].default; return o; }, {});
+              })(require.context('./', true, /^(?!.*index).*\.js$/));`;
+              fs.writeFile(fs.dappPath('.embark/contracts/index.js'), importsHelper, next);
             });
-          }, next);
+          });
         });
       },
       function assetFileWrite(next) {


### PR DESCRIPTION
* Now supports alternate import statements:
 * import {Token} from 'Embark/contracts';
 * import * as Contracts from 'Embark/contracts';
as well as the existing syntax:
 * import Token from 'Embark/contracts/Token';

* Contracts  js files moved from .embark to .embark/contracts
* .embark/contracts/index.js generated on the fly which requires all contracts in .embark/contract automatically and then creates a module.exports with each of them.