### PR TITLE
Fixed bug where dist folder is created before placeholder page

### DIFF
--- a/lib/pipeline/pipeline.js
+++ b/lib/pipeline/pipeline.js
@@ -31,6 +31,7 @@ class Pipeline {
     async.waterfall([
       function createPlaceholderPage(next){
         self.events.request('embark-building-placeholder', (html) => {
+          fs.mkdirpSync(self.buildDir); // create dist/ folder if not already exists
           fs.writeFile(self.buildDir + 'index.html', html, next);
         });
       },


### PR DESCRIPTION
If dist folder did not already exist, the folder is created prior to creation of the placeholder page. Without this, the dapp files are never built.