### PR TITLE
geth CORS updates to fix issues and add to auto blockchain process

### DIFF
--- a/lib/core/config.js
+++ b/lib/core/config.js
@@ -54,6 +54,8 @@ Config.prototype.loadConfigFiles = function(options) {
   this.loadWebServerConfigFile();
   this.loadChainTrackerFile();
   this.loadPluginContractFiles();
+
+  this._updateBlockchainCors();
 };
 
 Config.prototype.reloadConfig = function() {
@@ -66,6 +68,27 @@ Config.prototype.reloadConfig = function() {
   this.loadContractsConfigFile();
   this.loadExternalContractsFiles();
   this.loadChainTrackerFile();
+
+  this._updateBlockchainCors();
+};
+
+Config.prototype._updateBlockchainCors = function(){
+  let blockchainConfig = this.blockchainConfig;
+  let storageConfig = this.storageConfig;
+  let webServerConfig = this.webServerConfig;
+  let cors = '';
+
+  if(webServerConfig && webServerConfig.enabled) {
+    let webServerPort = webServerConfig.port ? `:${webServerConfig.port}` : '';
+    if(webServerConfig.host) cors = `http://${webServerConfig.host}${webServerPort}`;
+  }
+  if(storageConfig && storageConfig.enabled) {
+    let storagePort = storageConfig.port ? `:${storageConfig.port}` : '';
+    if(storageConfig.host) cors += `${cors.length ? ',' : ''}${storageConfig.protocol || 'http'}://${storageConfig.host}${storagePort}`;
+  }
+
+  if(blockchainConfig.rpcCorsDomain === 'auto' && cors.length) blockchainConfig.rpcCorsDomain = cors;
+  if(blockchainConfig.wsOrigins === 'auto' && cors.length) blockchainConfig.wsOrigins = cors;
 };
 
 Config.prototype._mergeConfig = function(configFilePath, defaultConfig, env, enabledByDefault) {

--- a/lib/index.js
+++ b/lib/index.js
@@ -49,19 +49,7 @@ class Embark {
 
   blockchain(env, client) {
     this.context = [constants.contexts.blockchain];
-    let blockchainConfig = this.config.blockchainConfig;
-    let storageConfig = this.config.storageConfig;
-    let webServerConfig = this.config.webServerConfig;
-
-    if(blockchainConfig.rpcCorsDomain === 'auto') {
-      if(webServerConfig) blockchainConfig.rpcCorsDomain = `http://${webServerConfig.host}:${webServerConfig.port}`;
-      if(storageConfig) blockchainConfig.rpcCorsDomain += `${blockchainConfig.rpcCorsDomain.length ? ',' : ''}${storageConfig.protocol}://${storageConfig.host}:${storageConfig.port}`;
-    }
-    if(blockchainConfig.wsOrigins === 'auto') {
-      if(webServerConfig) blockchainConfig.wsOrigins = `http://${webServerConfig.host}:${webServerConfig.port}`;
-      if(storageConfig) blockchainConfig.wsOrigins += `${blockchainConfig.wsOrigins.length ? ',' : ''}${storageConfig.protocol}://${storageConfig.host}:${storageConfig.port}`;
-    }
-    return require('./cmds/blockchain/blockchain.js')(blockchainConfig, client, env, this.isDev(env)).run();
+    return require('./cmds/blockchain/blockchain.js')(this.config.blockchainConfig, client, env, this.isDev(env)).run();
   }
 
   simulator(options) {

--- a/test_apps/test_app/config/storage.json
+++ b/test_apps/test_app/config/storage.json
@@ -11,7 +11,7 @@
     "enabled": true,
     "provider": "swarm",
     "host": "swarm-gateways.net",
-    "port": 80,
+    "port": false,
     "getUrl": "http://swarm-gateways.net/bzzr:/"
   },
   "livenet": {


### PR DESCRIPTION
* Adds auto cors updates to geth command when blockchain started via run command.
* Fixes issues with storage/webserver configs not enabled but still having their values put in to geth cors
* Adds fixes for not including port when port  == false
* Refactor of cors logic, and also now blockchainConfig updated in Config class so can be used by both `embark blockchain` and when blockchain started in separate process
