### PR TITLE
Changed path depth warning to path length

### DIFF
--- a/lib/cmds/blockchain/blockchain.js
+++ b/lib/cmds/blockchain/blockchain.js
@@ -106,9 +106,10 @@ Blockchain.prototype.run = function() {
     }
     const child = self.runCommand(cmd, {}, (err, stdout, _stderr) => {
       if (err && self.env === 'development' && stdout.indexOf('Failed to unlock') > 0) {
-        console.warn('\n' + __('Development blockchain has changed to use the --dev option.').yellow);
-        console.warn(__('You can reset your workspace to fix the problem with').yellow + ' embark reset'.cyan);
-        console.warn(__('Otherwise, you can change your data directory in blockchain.json (datadir)').yellow);
+        // console.error is captured and sent to the console output regardless of silent setting
+        console.error('\n' + __('Development blockchain has changed to use the --dev option.').yellow);
+        console.error(__('You can reset your workspace to fix the problem with').yellow + ' embark reset'.cyan);
+        console.error(__('Otherwise, you can change your data directory in blockchain.json (datadir)').yellow);
       }
     });
     if (self.onReadyCallback) {
@@ -134,10 +135,12 @@ Blockchain.prototype.run = function() {
 
 Blockchain.prototype.checkPathLength = function() {
   let dappPath = fs.dappPath('');
-  if (dappPath.split('/').length > 5) {
-    console.log("===============================================================================".yellow);
-    console.log("===========> Path depth is too long ".yellow + dappPath);
-    console.log("===========> This is known to cause issues with some applications, please consider putting your dapp in a different path".yellow);
+  if (dappPath.length > 66) {
+    // console.error is captured and sent to the console output regardless of silent setting
+    console.error("===============================================================================".yellow);
+    console.error("===========> ".yellow + __('WARNING! DApp path length is too long: ').yellow + dappPath.yellow);
+    console.error("===========> ".yellow + __('This is known to cause issues with starting geth, please consider reducing your DApp path\'s length to 66 characters or less.').yellow);
+    console.error("===============================================================================".yellow);
   }
 };
 

--- a/lib/i18n/locales/en.json
+++ b/lib/i18n/locales/en.json
@@ -127,5 +127,10 @@
 	"Cannot upload: {{platform}} node is not running on {{protocol}}://{{host}}:{{port}}.": "Cannot upload: {{platform}} node is not running on {{protocol}}://{{host}}:{{port}}.",
 	"Error while downloading the file": "Error while downloading the file",
 	"Error while loading the content of ": "Error while loading the content of ",
-	"no contracts found": "no contracts found"
+	"no contracts found": "no contracts found",
+	"DApp path length is too long: \"": "DApp path length is too long: \"",
+	"This is known to cause issues with some applications, please consider reducing your DApp path's length to 66 characters or less.": "This is known to cause issues with some applications, please consider reducing your DApp path's length to 66 characters or less.",
+	"DApp path length is too long: ": "DApp path length is too long: ",
+	"WARNING! DApp path length is too long: ": "WARNING! DApp path length is too long: ",
+	"This is known to cause issues with starting geth, please consider reducing your DApp path's length to 66 characters or less.": "This is known to cause issues with starting geth, please consider reducing your DApp path's length to 66 characters or less."
 }

--- a/lib/processes/blockchainProcessLauncher.js
+++ b/lib/processes/blockchainProcessLauncher.js
@@ -25,7 +25,7 @@ class BlockchainProcessLauncher {
       logger: this.logger,
       events: this.events,
       normalizeInput: this.normalizeInput,
-      silent: true,
+      silent: this.logger.logLevel !== 'trace',
       exitCallback: this.processEnded.bind(this)
     });
     this.blockchainProcess.send({


### PR DESCRIPTION
* Updated the path depth warning to check that the dapp path length is <= 66 characters.
* Updated the blockchain process to silent:false when loglevel == trace.
* Updated the path warning so that it would appear in the console regardless of loglevel (and silent:true)