### PR TITLE
Allow plugins to override core compilers

### DIFF
--- a/lib/contracts/compiler.js
+++ b/lib/contracts/compiler.js
@@ -16,7 +16,8 @@ class Compiler {
 
     let pluginCompilers = self.plugins.getPluginsProperty('compilers', 'compilers');
     pluginCompilers.forEach(function (compilerObject) {
-      available_compilers[compilerObject.extension] = compilerObject.cb;
+      if(available_compilers[compilerObject.extension] === undefined)
+        available_compilers[compilerObject.extension] = compilerObject.cb;
     });
 
     let compiledObject = {};

--- a/lib/contracts/compiler.js
+++ b/lib/contracts/compiler.js
@@ -16,7 +16,7 @@ class Compiler {
 
     let pluginCompilers = self.plugins.getPluginsProperty('compilers', 'compilers');
     pluginCompilers.forEach(function (compilerObject) {
-      if(available_compilers[compilerObject.extension] == undefined){
+      if(!available_compilers[compilerObject.extension]){
         available_compilers[compilerObject.extension] = [];
       }
       available_compilers[compilerObject.extension].push(compilerObject.cb);

--- a/lib/contracts/compiler.js
+++ b/lib/contracts/compiler.js
@@ -16,8 +16,9 @@ class Compiler {
 
     let pluginCompilers = self.plugins.getPluginsProperty('compilers', 'compilers');
     pluginCompilers.forEach(function (compilerObject) {
-      if(available_compilers[compilerObject.extension] === undefined)
+      if(available_compilers[compilerObject.extension] === undefined){
         available_compilers[compilerObject.extension] = compilerObject.cb;
+      }
     });
 
     let compiledObject = {};

--- a/lib/contracts/compiler.js
+++ b/lib/contracts/compiler.js
@@ -16,15 +16,16 @@ class Compiler {
 
     let pluginCompilers = self.plugins.getPluginsProperty('compilers', 'compilers');
     pluginCompilers.forEach(function (compilerObject) {
-      if(available_compilers[compilerObject.extension] === undefined){
-        available_compilers[compilerObject.extension] = compilerObject.cb;
+      if(available_compilers[compilerObject.extension] == undefined){
+        available_compilers[compilerObject.extension] = [];
       }
+      available_compilers[compilerObject.extension].push(compilerObject.cb);
     });
 
     let compiledObject = {};
 
     async.eachObject(available_compilers,
-      function (extension, compiler, callback) {
+      function (extension, compilers, callback) {
         let matchingFiles = contractFiles.filter(function (file) {
           let fileMatch = file.filename.match(/\.[0-9a-z]+$/);
           if (fileMatch && (fileMatch[0] === extension)) {
@@ -37,6 +38,9 @@ class Compiler {
         if (!matchingFiles || !matchingFiles.length) {
           return callback();
         }
+
+        let compiler = compilers[0];
+
         compiler.call(compiler, matchingFiles, function (err, compileResult) {
           Object.assign(compiledObject, compileResult);
           callback(err, compileResult);

--- a/lib/contracts/compiler.js
+++ b/lib/contracts/compiler.js
@@ -16,16 +16,13 @@ class Compiler {
 
     let pluginCompilers = self.plugins.getPluginsProperty('compilers', 'compilers');
     pluginCompilers.forEach(function (compilerObject) {
-      if(!available_compilers[compilerObject.extension]){
-        available_compilers[compilerObject.extension] = [];
-      }
-      available_compilers[compilerObject.extension].push(compilerObject.cb);
+      available_compilers[compilerObject.extension] = compilerObject.cb;
     });
 
     let compiledObject = {};
 
     async.eachObject(available_compilers,
-      function (extension, compilers, callback) {
+      function (extension, compiler, callback) {
         let matchingFiles = contractFiles.filter(function (file) {
           let fileMatch = file.filename.match(/\.[0-9a-z]+$/);
           if (fileMatch && (fileMatch[0] === extension)) {
@@ -38,9 +35,6 @@ class Compiler {
         if (!matchingFiles || !matchingFiles.length) {
           return callback();
         }
-
-        let compiler = compilers[0];
-
         compiler.call(compiler, matchingFiles, function (err, compileResult) {
           Object.assign(compiledObject, compileResult);
           callback(err, compileResult);

--- a/lib/core/plugins.js
+++ b/lib/core/plugins.js
@@ -104,6 +104,17 @@ Plugins.prototype.getPluginsProperty = function(pluginType, property, sub_proper
     return plugin.has(pluginType);
   });
 
+  // Sort internal plugins first
+  matchingPlugins.sort((a, b) => {
+    if (a.isInternal) {
+      return -1;
+    }
+    if (b.isInternal) {
+      return 1;
+    }
+    return 0;
+  });
+
   let matchingProperties = matchingPlugins.map((plugin) => {
     if (sub_property) {
       return plugin[property][sub_property];
@@ -111,6 +122,7 @@ Plugins.prototype.getPluginsProperty = function(pluginType, property, sub_proper
     return plugin[property];
   });
 
+  // Remove empty properties
   matchingProperties = matchingProperties.filter((property) => property);
 
   //return flattened list

--- a/test_apps/test_app/README.md
+++ b/test_apps/test_app/README.md
@@ -5,4 +5,3 @@ Test App for integration testing purposes.
 ```../../bin/embark test``` to see tests are working as expected
 
 ```dist/index.html``` and ```dist/test.html``` to check different functionality
-


### PR DESCRIPTION
External plugins that use registerCompiler are loaded before the internal modules for Solidity and Vyper.
When the internal modules are loaded, they override the external plugin compiler.
This change will allow the external plugin to have preference over the internal modules for compilers.