### PR TITLE
fix blockchain already booted

### DIFF
--- a/lib/core/services_monitor.js
+++ b/lib/core/services_monitor.js
@@ -11,8 +11,8 @@ class ServicesMonitor {
     this.checkState = {};
     this.working = false;
 
-    self.events.setCommandHandler("services:register", (checkName, checkFn, time) => {
-      self.addCheck(checkName, checkFn, time);
+    self.events.setCommandHandler("services:register", (checkName, checkFn, time, initialStatus) => {
+      self.addCheck(checkName, checkFn, time, initialStatus);
     });
   }
 }


### PR DESCRIPTION
I changed `addCheck` to accept the `initialState` a week back, but Iuri's refactor uses events now and he didn't add the new param