### PR TITLE
support for test imports

### DIFF
--- a/lib/tests/run_tests.js
+++ b/lib/tests/run_tests.js
@@ -89,7 +89,9 @@ module.exports = {
 
       // Clean contracts folder for next test run
       fs.remove('.embark/contracts', (_err) => {
-        process.exit(failures);
+        fs.remove('Embark/', (_err) => {
+          process.exit(failures);
+        });
       });
     });
   }

--- a/lib/tests/test.js
+++ b/lib/tests/test.js
@@ -6,6 +6,8 @@ const utils = require('../utils/utils');
 const constants = require('../constants');
 const Events = require('../core/events');
 const cloneDeep = require('clone-deep');
+const fs = require('../core/fs');
+const path = require('path');
 
 function getSimulator() {
   try {
@@ -74,7 +76,24 @@ class Test {
     this.engine.contractsManager.build(() => {
       self.builtContracts = cloneDeep(self.engine.contractsManager.contracts);
       self.compiledContracts = cloneDeep(self.engine.contractsManager.compiledContracts);
-      callback();
+      self.buildImportFile(callback);
+    });
+  }
+
+  buildImportFile(callback) {
+    let content = 'module.exports = {';
+    Object.keys(this.builtContracts).forEach(className => {
+      content += `\n\t"${className}": embark.require('Embark/contract/AnotherStorage'),`;
+    });
+    content += '\n};';
+    const filePath = fs.dappPath('Embark/contracts/index.js');
+    fs.mkdirp(path.dirname(filePath), (err) => {
+      if (err) {
+        return callback(err);
+      }
+      fs.writeFile(filePath, content, (err) => {
+        callback(err);
+      });
     });
   }
 

--- a/test_apps/contracts_app/test/another_storage_spec.js
+++ b/test_apps/contracts_app/test/another_storage_spec.js
@@ -1,7 +1,6 @@
-/*global contract, config, it, embark*/
+/*global contract, config, it*/
 const assert = require('assert');
-const AnotherStorage = embark.require('Embark/contracts/AnotherStorage');
-const SimpleStorage = embark.require('Embark/contracts/SimpleStorage');
+import {AnotherStorage, SimpleStorage} from 'Embark/contracts';
 
 config({
   contracts: {


### PR DESCRIPTION
Really simple way without using webpack to support `import {ContractName} from 'Embark/contracts'