### PR TITLE
change account funding order to enable starting a node before

### DIFF
--- a/lib/contracts/blockchain.js
+++ b/lib/contracts/blockchain.js
@@ -54,26 +54,34 @@ class Blockchain {
       };
       provider = new Provider(providerOptions);
 
-      provider.startWeb3Provider(() => {
-        self.assertNodeConnection(true, (err) => {
-          if (err && self.web3StartedInProcess) {
-            // Already started blockchain in another node, we really have a node problem
-            self.logger.error(__('Unable to start the blockchain process. Is Geth installed?').red);
-            return cb(err);
-          }
-          if (!err) {
-            self.isWeb3Ready = true;
-            self.events.emit(WEB3_READY);
-            return cb();
-          }
-          self.web3StartedInProcess = true;
-          self.startBlockchainNode(() => {
-            // Need to re-initialize web3 to connect to the new blockchain node
-            provider.stop();
-            self.initWeb3(cb);
+      async.waterfall([
+        function startProvider(next) {
+          provider.startWeb3Provider(next);
+        },
+        function checkNode(next) {
+          self.assertNodeConnection(true, (err) => {
+            if (err && self.web3StartedInProcess) {
+              // Already started blockchain in another node, we really have a node problem
+              self.logger.error(__('Unable to start the blockchain process. Is Geth installed?').red);
+              return next(err);
+            }
+            if (!err) {
+              self.isWeb3Ready = true;
+              self.events.emit(WEB3_READY);
+              return next();
+            }
+            self.web3StartedInProcess = true;
+            self.startBlockchainNode(() => {
+              // Need to re-initialize web3 to connect to the new blockchain node
+              provider.stop();
+              self.initWeb3(cb);
+            });
           });
-        });
-      });
+        },
+        function fundAccountsIfNeeded(next) {
+          provider.fundAccounts(next);
+        }
+      ], cb);
     } else {
       throw new Error("contracts config error: unknown deployment type " + this.contractsConfig.deployment.type);
     }

--- a/lib/contracts/provider.js
+++ b/lib/contracts/provider.js
@@ -35,18 +35,10 @@ class Provider {
     self.accounts = AccountParser.parseAccountsConfig(self.accountsConfig, self.web3, self.logger);
     self.addresses = [];
     async.waterfall([
-      function fundAccounts(next) {
+      function populateWeb3Wallet(next) {
         if (!self.accounts.length) {
           return next(NO_ACCOUNTS);
         }
-        if (!self.isDev) {
-          return next();
-        }
-        async.each(self.accounts, (account, eachCb) => {
-          fundAccount(self.web3, account.address, eachCb);
-        }, next);
-      },
-      function populateWeb3Wallet(next) {
         self.accounts.forEach(account => {
           self.addresses.push(account.address);
           self.web3.eth.accounts.wallet.add(account);
@@ -62,6 +54,19 @@ class Provider {
       }
       callback();
     });
+  }
+
+  fundAccounts(callback) {
+    const self = this;
+    if (!self.accounts.length) {
+      return callback();
+    }
+    if (!self.isDev) {
+      return callback();
+    }
+    async.each(self.accounts, (account, eachCb) => {
+      fundAccount(self.web3, account.address, eachCb);
+    }, callback);
   }
 
   stop() {


### PR DESCRIPTION
Was a bug where if you specified and account in contracts.json to use the wallet feature, you ran in a hanging situation. That is because the order was:
1. Start provider
   1.  Get accounts
   2. Fund accounts (which requires a blockchain node)
   3. Callback that everything started
2. Check for node and start one if no node is there

You can easily see that 1.3 will stuck.

Fixed by changing the order to fund accounts after the node has been detected