### PR TITLE
Enables specifying accounts in simulator mode in the tests

### DIFF
--- a/lib/contracts/accountParser.js
+++ b/lib/contracts/accountParser.js
@@ -21,9 +21,28 @@ class AccountParser {
     return accounts;
   }
 
+  static getHexBalance(balanceString, web3) {
+    if (!balanceString) {
+      return 0xFFFFFFFFFFFFFFFFFF;
+    }
+    if (web3.utils.isHexStrict(balanceString)) {
+      return balanceString;
+    }
+    const match = balanceString.match(/([0-9]+) ?([a-zA-Z]*)/);
+    if (!match[2]) {
+      return web3.utils.toHex(parseInt(match[1], 10));
+    }
+
+    return web3.utils.toHex(web3.utils.toWei(match[1], match[2]));
+  }
+
   static getAccount(accountConfig, web3, logger) {
     if (!logger) {
       logger = console;
+    }
+    let hexBalance = null;
+    if (accountConfig.balance) {
+      hexBalance = AccountParser.getHexBalance(accountConfig.balance, web3);
     }
     if (accountConfig.privateKey) {
       if (!accountConfig.privateKey.startsWith('0x')) {
@@ -33,7 +52,7 @@ class AccountParser {
         logger.warn(`Private key ending with ${accountConfig.privateKey.substr(accountConfig.privateKey.length - 5)} is not a HEX string`);
         return null;
       }
-      return web3.eth.accounts.privateKeyToAccount(accountConfig.privateKey);
+      return Object.assign(web3.eth.accounts.privateKeyToAccount(accountConfig.privateKey), {hexBalance});
     }
     if (accountConfig.privateKeyFile) {
       let fileContent = fs.readFileSync(fs.dappPath(accountConfig.privateKeyFile)).toString();
@@ -46,7 +65,7 @@ class AccountParser {
           logger.warn(`Private key is not a HEX string in file ${accountConfig.privateKeyFile} at index ${index}`);
           return null;
         }
-        return web3.eth.accounts.privateKeyToAccount(key);
+        return Object.assign(web3.eth.accounts.privateKeyToAccount(key), {hexBalance});
       });
     }
     if (accountConfig.mnemonic) {
@@ -59,7 +78,7 @@ class AccountParser {
       const accounts = [];
       for (let i = addressIndex; i < addressIndex + numAddresses; i++) {
         const wallet = hdwallet.derivePath(wallet_hdpath + i).getWallet();
-        accounts.push(web3.eth.accounts.privateKeyToAccount('0x' + wallet.getPrivateKey().toString('hex')));
+        accounts.push(Object.assign(web3.eth.accounts.privateKeyToAccount('0x' + wallet.getPrivateKey().toString('hex')), {hexBalance}));
       }
       return accounts;
     }

--- a/lib/contracts/accountParser.js
+++ b/lib/contracts/accountParser.js
@@ -29,6 +29,9 @@ class AccountParser {
       return balanceString;
     }
     const match = balanceString.match(/([0-9]+) ?([a-zA-Z]*)/);
+    if (!match) {
+      throw new Error(__('Unrecognized balance string "%s"', balanceString));
+    }
     if (!match[2]) {
       return web3.utils.toHex(parseInt(match[1], 10));
     }

--- a/lib/contracts/blockchain.js
+++ b/lib/contracts/blockchain.js
@@ -54,26 +54,34 @@ class Blockchain {
       };
       provider = new Provider(providerOptions);
 
-      provider.startWeb3Provider(() => {
-        self.assertNodeConnection(true, (err) => {
-          if (err && self.web3StartedInProcess) {
-            // Already started blockchain in another node, we really have a node problem
-            self.logger.error(__('Unable to start the blockchain process. Is Geth installed?').red);
-            return cb(err);
-          }
-          if (!err) {
-            self.isWeb3Ready = true;
-            self.events.emit(WEB3_READY);
-            return cb();
-          }
-          self.web3StartedInProcess = true;
-          self.startBlockchainNode(() => {
-            // Need to re-initialize web3 to connect to the new blockchain node
-            provider.stop();
-            self.initWeb3(cb);
+      async.waterfall([
+        function startProvider(next) {
+          provider.startWeb3Provider(next);
+        },
+        function checkNode(next) {
+          self.assertNodeConnection(true, (err) => {
+            if (err && self.web3StartedInProcess) {
+              // Already started blockchain in another node, we really have a node problem
+              self.logger.error(__('Unable to start the blockchain process. Is Geth installed?').red);
+              return next(err);
+            }
+            if (!err) {
+              self.isWeb3Ready = true;
+              self.events.emit(WEB3_READY);
+              return next();
+            }
+            self.web3StartedInProcess = true;
+            self.startBlockchainNode(() => {
+              // Need to re-initialize web3 to connect to the new blockchain node
+              provider.stop();
+              self.initWeb3(cb);
+            });
           });
-        });
-      });
+        },
+        function fundAccountsIfNeeded(next) {
+          provider.fundAccounts(next);
+        }
+      ], cb);
     } else {
       throw new Error("contracts config error: unknown deployment type " + this.contractsConfig.deployment.type);
     }

--- a/lib/contracts/deploy_manager.js
+++ b/lib/contracts/deploy_manager.js
@@ -29,8 +29,8 @@ class DeployManager {
       async.eachOfSeries(contracts,
         function (contract, key, callback) {
           contract._gasLimit = self.gasLimit;
-          self.events.request('deploy:contract', contract, () => {
-            callback();
+          self.events.request('deploy:contract', contract, (err) => {
+            callback(err);
           });
         },
         function (err, _results) {

--- a/lib/contracts/fundAccount.js
+++ b/lib/contracts/fundAccount.js
@@ -1,8 +1,12 @@
 const async = require('async');
-const TARGET = 15000000000000000000;
+const TARGET = 0x7FFFFFFFFFFFFFFF;
 const ALREADY_FUNDED = 'alreadyFunded';
 
-function fundAccount(web3, accountAddress, callback) {
+function fundAccount(web3, accountAddress, hexBalance, callback) {
+  if (!hexBalance) {
+    hexBalance = TARGET;
+  }
+  const targetBalance = (typeof hexBalance === 'string') ? parseInt(hexBalance, 16) : hexBalance;
   let accountBalance;
   let coinbaseAddress;
   let lastNonce;
@@ -14,7 +18,7 @@ function fundAccount(web3, accountAddress, callback) {
         if (err) {
           return next(err);
         }
-        if (balance >= TARGET) {
+        if (balance >= targetBalance) {
           return next(ALREADY_FUNDED);
         }
         accountBalance = balance;
@@ -56,7 +60,7 @@ function fundAccount(web3, accountAddress, callback) {
       web3.eth.sendTransaction({
         from: coinbaseAddress,
         to: accountAddress,
-        value: TARGET - accountBalance,
+        value: targetBalance - accountBalance,
         gasPrice: gasPrice,
         nonce: lastNonce
       }, next);

--- a/lib/contracts/provider.js
+++ b/lib/contracts/provider.js
@@ -65,7 +65,7 @@ class Provider {
       return callback();
     }
     async.each(self.accounts, (account, eachCb) => {
-      fundAccount(self.web3, account.address, eachCb);
+      fundAccount(self.web3, account.address, account.hexBalance, eachCb);
     }, callback);
   }
 

--- a/lib/contracts/provider.js
+++ b/lib/contracts/provider.js
@@ -35,18 +35,10 @@ class Provider {
     self.accounts = AccountParser.parseAccountsConfig(self.accountsConfig, self.web3, self.logger);
     self.addresses = [];
     async.waterfall([
-      function fundAccounts(next) {
+      function populateWeb3Wallet(next) {
         if (!self.accounts.length) {
           return next(NO_ACCOUNTS);
         }
-        if (!self.isDev) {
-          return next();
-        }
-        async.each(self.accounts, (account, eachCb) => {
-          fundAccount(self.web3, account.address, eachCb);
-        }, next);
-      },
-      function populateWeb3Wallet(next) {
         self.accounts.forEach(account => {
           self.addresses.push(account.address);
           self.web3.eth.accounts.wallet.add(account);
@@ -62,6 +54,19 @@ class Provider {
       }
       callback();
     });
+  }
+
+  fundAccounts(callback) {
+    const self = this;
+    if (!self.accounts.length) {
+      return callback();
+    }
+    if (!self.isDev) {
+      return callback();
+    }
+    async.each(self.accounts, (account, eachCb) => {
+      fundAccount(self.web3, account.address, eachCb);
+    }, callback);
   }
 
   stop() {

--- a/lib/core/plugin.js
+++ b/lib/core/plugin.js
@@ -60,7 +60,6 @@ Plugin.prototype.hasContext = function(context) {
 
 Plugin.prototype.loadPlugin = function() {
   if (!this.isContextValid())  {
-    console.log(this.acceptedContext);
     this.logger.warn(__('Plugin {{name}} can only be loaded in the context of "{{contextes}}"', {name: this.name, contextes: this.acceptedContext.join(', ')}));
     return false;
   }

--- a/lib/modules/solidity/solcP.js
+++ b/lib/modules/solidity/solcP.js
@@ -19,7 +19,7 @@ class SolcProcess extends ProcessWrapper {
       return {contents: fs.readFileSync(path.join('./node_modules/', filename)).toString()};
     }
     if (fs.existsSync(path.join(constants.httpContractsDirectory, filename))) {
-      return {contents: fs.readFileSync(path.join('./.embark/contracts', filename)).toString()};
+      return {contents: fs.readFileSync(path.join(constants.httpContractsDirectory, filename)).toString()};
     }
     return {error: 'File not found'};
   }

--- a/lib/tests/run_tests.js
+++ b/lib/tests/run_tests.js
@@ -37,6 +37,12 @@ module.exports = {
         global.assert = assert;
         global.config = test.config.bind(test);
 
+        global.deployAll = function () {
+          console.error(__('%s is not supported anymore', 'deployAll').red);
+          console.info(__('You can learn about the new revamped tests here: %s', 'https://embark.status.im/docs/testing.html'.underline));
+          process.exit();
+        };
+
         // TODO: this global here might not be necessary at all
         global.web3 = global.embark.web3;
 

--- a/lib/tests/test.js
+++ b/lib/tests/test.js
@@ -61,29 +61,13 @@ class Test {
     this.engine.startService("codeGenerator");
   }
 
-  getBalance(balanceString) {
-    if (!balanceString) {
-      return 0xFFFFFFFFFFFFFFFFFF;
-    }
-    if (this.web3.utils.isHexStrict(balanceString)) {
-      return balanceString;
-    }
-    const match = balanceString.match(/([0-9]+) ?([a-zA-Z]*)/);
-    if (!match[2]) {
-      return this.web3.utils.toHex(parseInt(match[1], 10));
-    }
-
-    return this.web3.utils.toHex(this.web3.utils.toWei(match[1], match[2]));
-  }
-
   initWeb3Provider() {
     if (this.simOptions.node) {
       this.web3.setProvider(new this.web3.providers.HttpProvider(this.simOptions.node));
     } else {
       if (this.simOptions.accounts) {
-        this.simOptions.accounts = this.simOptions.accounts.map((account, index) => {
-          const balance = this.getBalance(this.options.deployment.accounts[index].balance);
-          return {balance, secretKey: account.privateKey};
+        this.simOptions.accounts = this.simOptions.accounts.map((account) => {
+          return {balance: account.hexBalance, secretKey: account.privateKey};
         });
       }
       this.sim = getSimulator();

--- a/lib/tests/test.js
+++ b/lib/tests/test.js
@@ -61,39 +61,6 @@ class Test {
     this.engine.startService("codeGenerator");
   }
 
-  // eslint-disable-next-line complexity
-  getMutliplicator(keyword) {
-    switch (keyword.toLowerCase()) {
-      case 'wei': return 1;
-      case 'ether':
-      case 'eth': return 1000000000000000000;
-      case 'finney':
-      case 'milli':
-      case 'milliether': return 1000000000000000;
-      case 'szabo':
-      case 'microether,':
-      case 'micro':  return 1000000000000;
-      case 'gwei':
-      case 'nanoether':
-      case 'shannon':
-      case 'nano': return 1000000000;
-      case 'mwei':
-      case 'babbage':
-      case 'picoether': return 1000000;
-      case 'kwei':
-      case 'ada':
-      case 'femtoether': return 1000;
-      case 'kether':
-      case 'grand':
-      case 'einstein': return 1000000000000000000000;
-      case 'mether': return 1000000000000000000000000;
-      case 'gether': return 1000000000000000000000000000;
-      case 'tether': return 1000000000000000000000000000000;
-      default: console.warn('\n' + __(`Unrecognised keyword ${keyword} in balance. Will assume Wei`).yellow);
-        return 1;
-    }
-  }
-
   getBalance(balanceString) {
     if (!balanceString) {
       return 0xFFFFFFFFFFFFFFFFFF;
@@ -106,7 +73,7 @@ class Test {
       return this.web3.utils.toHex(parseInt(match[1], 10));
     }
 
-    return this.web3.utils.toHex(parseInt(match[1], 10) * this.getMutliplicator(match[2]));
+    return this.web3.utils.toHex(this.web3.utils.toWei(match[1], match[2]));
   }
 
   initWeb3Provider() {

--- a/lib/tests/test.js
+++ b/lib/tests/test.js
@@ -6,6 +6,7 @@ const utils = require('../utils/utils');
 const constants = require('../constants');
 const Events = require('../core/events');
 const cloneDeep = require('clone-deep');
+const AccountParser = require('../contracts/accountParser');
 
 function getSimulator() {
   try {
@@ -36,12 +37,7 @@ class Test {
     this.compiledContracts = {};
 
     this.web3 = new Web3();
-    if (this.simOptions.node) {
-      this.web3.setProvider(new this.web3.providers.HttpProvider(this.simOptions.node));
-    } else {
-      this.sim = getSimulator();
-      this.web3.setProvider(this.sim.provider(this.simOptions));
-    }
+    this.initWeb3Provider();
 
     this.engine = new Engine({
       env: this.options.env || 'test',
@@ -55,11 +51,32 @@ class Test {
     });
 
     this.versions_default = this.engine.config.contractsConfig.versions;
+    const deploymentConfig = this.engine.config.contractsConfig.versions;
     // Reset contract config to nothing to make sure we deploy only what we want
-    this.engine.config.contractsConfig = {contracts: {}, versions: this.versions_default};
+    this.engine.config.contractsConfig = {contracts: {}, versions: this.versions_default, deployment: deploymentConfig};
 
     this.engine.startService("libraryManager");
     this.engine.startService("codeRunner");
+    this.initDeployServices();
+    this.engine.startService("codeGenerator");
+  }
+
+  initWeb3Provider() {
+    if (this.simOptions.node) {
+      this.web3.setProvider(new this.web3.providers.HttpProvider(this.simOptions.node));
+    } else {
+      if (this.simOptions.accounts) {
+        this.simOptions.accounts = this.simOptions.accounts.map((account, index) => {
+          return {balance: this.options.deployment.accounts[index].balance || 0xFFFFFFFFFFFFFFFFFF,
+            secretKey: account.privateKey};
+        });
+      }
+      this.sim = getSimulator();
+      this.web3.setProvider(this.sim.provider(this.simOptions));
+    }
+  }
+
+  initDeployServices() {
     this.engine.startService("web3", {
       web3: this.web3
     });
@@ -67,7 +84,6 @@ class Test {
       trackContracts: false,
       ipcRole: 'client'
     });
-    this.engine.startService("codeGenerator");
   }
 
   init(callback) {
@@ -99,6 +115,13 @@ class Test {
     this.options = utils.recursiveMerge(this.options, options);
     this.simOptions = this.options.simulatorOptions || {};
     this.ready = false;
+
+    if (this.options.deployment && this.options.deployment.accounts) {
+      // Account setup
+      this.simOptions.accounts = AccountParser.parseAccountsConfig(this.options.deployment.accounts, this.web3);
+      this.initWeb3Provider();
+      this.initDeployServices();
+    }
 
     // Reset contracts
     this.engine.contractsManager.contracts = cloneDeep(this.builtContracts);

--- a/lib/tests/test.js
+++ b/lib/tests/test.js
@@ -61,14 +61,62 @@ class Test {
     this.engine.startService("codeGenerator");
   }
 
+  // eslint-disable-next-line complexity
+  getMutliplicator(keyword) {
+    switch (keyword.toLowerCase()) {
+      case 'wei': return 1;
+      case 'ether':
+      case 'eth': return 1000000000000000000;
+      case 'finney':
+      case 'milli':
+      case 'milliether': return 1000000000000000;
+      case 'szabo':
+      case 'microether,':
+      case 'micro':  return 1000000000000;
+      case 'gwei':
+      case 'nanoether':
+      case 'shannon':
+      case 'nano': return 1000000000;
+      case 'mwei':
+      case 'babbage':
+      case 'picoether': return 1000000;
+      case 'kwei':
+      case 'ada':
+      case 'femtoether': return 1000;
+      case 'kether':
+      case 'grand':
+      case 'einstein': return 1000000000000000000000;
+      case 'mether': return 1000000000000000000000000;
+      case 'gether': return 1000000000000000000000000000;
+      case 'tether': return 1000000000000000000000000000000;
+      default: console.warn('\n' + __(`Unrecognised keyword ${keyword} in balance. Will assume Wei`).yellow);
+        return 1;
+    }
+  }
+
+  getBalance(balanceString) {
+    if (!balanceString) {
+      return 0xFFFFFFFFFFFFFFFFFF;
+    }
+    if (this.web3.utils.isHexStrict(balanceString)) {
+      return balanceString;
+    }
+    const match = balanceString.match(/([0-9]+) ?([a-zA-Z]*)/);
+    if (!match[2]) {
+      return this.web3.utils.toHex(parseInt(match[1], 10));
+    }
+
+    return this.web3.utils.toHex(parseInt(match[1], 10) * this.getMutliplicator(match[2]));
+  }
+
   initWeb3Provider() {
     if (this.simOptions.node) {
       this.web3.setProvider(new this.web3.providers.HttpProvider(this.simOptions.node));
     } else {
       if (this.simOptions.accounts) {
         this.simOptions.accounts = this.simOptions.accounts.map((account, index) => {
-          return {balance: this.options.deployment.accounts[index].balance || 0xFFFFFFFFFFFFFFFFFF,
-            secretKey: account.privateKey};
+          const balance = this.getBalance(this.options.deployment.accounts[index].balance);
+          return {balance, secretKey: account.privateKey};
         });
       }
       this.sim = getSimulator();

--- a/test_apps/test_app/test/another_storage_spec.js
+++ b/test_apps/test_app/test/another_storage_spec.js
@@ -1,13 +1,16 @@
-/*global contract, config, it, embark*/
+/*global contract, config, it, embark, web3*/
 const assert = require('assert');
 const AnotherStorage = embark.require('Embark/contracts/AnotherStorage');
 const SimpleStorage = embark.require('Embark/contracts/SimpleStorage');
+
+let accounts;
 
 config({
   deployment: {
     "accounts": [
       {
-        "mnemonic": "example exile argue silk regular smile grass bomb merge arm assist farm"
+        "mnemonic": "example exile argue silk regular smile grass bomb merge arm assist farm",
+        balance: "5ether"
       }
     ]
   },
@@ -19,6 +22,8 @@ config({
       args: ["$SimpleStorage"]
     }
   }
+}, (err, theAccounts) => {
+  accounts = theAccounts;
 });
 
 contract("AnotherStorage", function() {
@@ -27,5 +32,11 @@ contract("AnotherStorage", function() {
   it("set SimpleStorage address", async function() {
     let result = await AnotherStorage.methods.simpleStorageAddress().call();
     assert.equal(result.toString(), SimpleStorage.options.address);
+  });
+
+  it('should set the balance correctly', async function () {
+    const balance = await web3.eth.getBalance(accounts[0]);
+    assert.ok(balance < 5000000000000000000);
+    assert.ok(balance > 4000000000000000000);
   });
 });

--- a/test_apps/test_app/test/another_storage_spec.js
+++ b/test_apps/test_app/test/another_storage_spec.js
@@ -4,6 +4,13 @@ const AnotherStorage = embark.require('Embark/contracts/AnotherStorage');
 const SimpleStorage = embark.require('Embark/contracts/SimpleStorage');
 
 config({
+  deployment: {
+    "accounts": [
+      {
+        "mnemonic": "example exile argue silk regular smile grass bomb merge arm assist farm"
+      }
+    ]
+  },
   contracts: {
     "SimpleStorage": {
       args: [100]


### PR DESCRIPTION
Please review https://github.com/embark-framework/embark/pull/495 first please as it contains a bug fix that is used in this branch too.

Uses the config to tell which accounts to use and which balance. 

You can now specify your balance also for the normal wallet (in embark run) and you can do so using the unit name (eg: 5eth, 432432wei, 324gwei, etc.)

Currently only works with the simulator. Will make it work in a node in the next PR.