### PR TITLE
Enable loglevel for test logger and actually log

### DIFF
--- a/lib/cmd.js
+++ b/lib/cmd.js
@@ -185,10 +185,11 @@ class Cmd {
     program
       .command('test [file]')
       .option('--locale [locale]', __('language to use (default: en)'))
+      .option('--loglevel [loglevel]', __('level of logging to display') + ' ["error", "warn", "info", "debug", "trace"]', /^(error|warn|info|debug|trace)$/i, 'warn')
       .description(__('run tests'))
       .action(function (file, options) {
         i18n.setOrDetectLocale(options.locale);
-        embark.runTests(file);
+        embark.runTests({file, loglevel: options.loglevel});
       });
   }
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -362,10 +362,10 @@ class Embark {
     });
   }
 
-  runTests(file) {
+  runTests(options) {
     this.context = [constants.contexts.test];
     let RunTests = require('./tests/run_tests.js');
-    RunTests.run(file);
+    RunTests.run(options);
   }
 }
 

--- a/lib/tests/run_tests.js
+++ b/lib/tests/run_tests.js
@@ -22,9 +22,11 @@ function getFilesFromDir(filePath, cb) {
 }
 
 module.exports = {
-  run: function (filePath) {
+  run: function (options) {
     process.env.isTest = true;
     let failures = 0;
+    let filePath = options.file;
+    const loglevel = options.loglevel || 'warn';
     if (!filePath) {
       filePath = 'test/';
     }
@@ -49,7 +51,7 @@ module.exports = {
       },
       function setupGlobalNamespace(files, next) {
         // TODO put default config
-        const test = new Test();
+        const test = new Test({loglevel});
         global.embark = test;
         global.assert = assert;
         global.config = test.config.bind(test);

--- a/lib/tests/test.js
+++ b/lib/tests/test.js
@@ -90,7 +90,7 @@ class Test {
       });
 
       this.engine.init({
-        logger: new TestLogger({logLevel: 'debug'})
+        logger: new TestLogger({logLevel: this.options.loglevel})
       });
 
       this.versions_default = this.engine.config.contractsConfig.versions;

--- a/lib/tests/test_logger.js
+++ b/lib/tests/test_logger.js
@@ -5,21 +5,11 @@ require('colors');
 class TestLogger {
   constructor(options) {
     this.logLevels = ['error', 'warn', 'info', 'debug', 'trace'];
-    this.logs = [];
     this.logLevel = options.logLevel || 'info';
   }
 
   logFunction() {
-    this.logs.push(arguments);
-    // console.log(...arguments);
-  }
-
-  contractsState() {
-    this.logs.push(arguments);
-  }
-
-  availableServices() {
-    this.logs.push(arguments);
+    console.log(...arguments);
   }
 
   error(txt) {


### PR DESCRIPTION
Set default loglevel for tests at warn. Also, actually enabled logs; before they were in comments.