### PR TITLE
Fix watch by not restarting anymore and enable config for contracts

### DIFF
--- a/lib/core/engine.js
+++ b/lib/core/engine.js
@@ -108,9 +108,6 @@ class Engine {
     this.events.on('code-generator-ready', function () {
       self.events.request('code', function (abi, contractsJSON) {
         pipeline.build(abi, contractsJSON, null, () => {
-          if (self.watch) {
-            self.watch.restart(); // Necessary because changing a file while it is writing can stop it from being watched
-          }
           self.events.emit('outputDone');
         });
       });

--- a/lib/pipeline/watch.js
+++ b/lib/pipeline/watch.js
@@ -27,7 +27,7 @@ class Watch {
       self.logger.trace('ready to watch contract changes');
     });
 
-    this.watchConfigs(function () {
+    this.watchConfigs(embarkConfig, function () {
       self.logger.trace('ready to watch config changes');
     });
 
@@ -45,7 +45,6 @@ class Watch {
       if (fileWatcher.isReady) fileWatcher.close();
       fileWatcher.shouldClose = true;
     });
-    this.fileWatchers = [];
   }
 
   watchAssets(embarkConfig, callback) {
@@ -98,10 +97,14 @@ class Watch {
     );
   }
 
-  watchConfigs(callback) {
+  watchConfigs(embarkConfig, callback) {
     let self = this;
+    let configFolder = embarkConfig.config.replace(/\\/g, '/');
+    if (configFolder.charAt(configFolder.length - 1) !== '/') {
+      configFolder += '/';
+    }
     this.watchFiles(
-      "config/**/contracts.json",
+      [`${configFolder}**/contracts.json`, `${configFolder}**/contracts.js`],
       function (eventName, path) {
         self.logger.info(`${eventName}: ${path}`);
         self.events.emit('file-' + eventName, 'config', path);


### PR DESCRIPTION
Before, we needed to restart the watch everytime, otherwise chokidar "lost" the files or just stopped watching, it was weird.
I think adding processes plus webpack taking a lot less time fixed that, so I removed the fact that we restart everytime, especially since it created a bug where watchers kept piling on.

Also, enabled the use of embark.json confgi to specify where we watch the contracts.json and also, enable watching contracts.js too