### PR TITLE
Fix afterDeploy in build and also build files

### DIFF
--- a/lib/contracts/deploy_manager.js
+++ b/lib/contracts/deploy_manager.js
@@ -133,8 +133,7 @@ class DeployManager {
           return callback(new Error("error running afterDeploy"));
         }
 
-        // TODO: convert to for to avoid repeated callback
-        for(let cmd of onDeployCode) {
+        async.each(onDeployCode, (cmd, eachCb) => {
           self.logger.info("executing: " + cmd);
           try {
             RunCode.doEval(cmd, web3);
@@ -142,11 +141,14 @@ class DeployManager {
             if (e.message.indexOf("invalid opcode") >= 0) {
               self.logger.error('the transaction was rejected; this usually happens due to a throw or a require, it can also happen due to an invalid operation');
             }
-            return callback(new Error(e));
+            return eachCb(new Error(e));
           }
-        }
+          eachCb();
+        }, (err) => {
+          callback(err, contractsManager);
+        });
 
-        callback(null, contractsManager);
+
       }
     ], function (err, result) {
       if (err) {

--- a/lib/index.js
+++ b/lib/index.js
@@ -202,13 +202,20 @@ class Embark {
         engine.deployManager.deployContracts(function (err) {
           callback(err);
         });
+      },
+      function waitForWriteFinish(callback) {
+        engine.logger.info("Finished deploying".underline);
+        // Necessary log for simple projects. This event is trigger to soon because there is no file
+        // Also, not exiting straight after the deploy leaves time for async afterDeploys to finish
+        engine.logger.info("If you have no files to build, you can exit now with CTRL+C");
+        engine.events.on('outputDone', callback);
       }
     ], function (err, _result) {
       if (err) {
         engine.logger.error(err.message);
         engine.logger.debug(err.stack);
       } else {
-        engine.logger.info("finished building".underline);
+        engine.logger.info("Finished building".underline);
       }
       // needed due to child processes
       process.exit();


### PR DESCRIPTION
Before `embark build` only ran the deploy and exited, now we wait for file build too (which leaves time for async afterDeploys to finish and also, well, builds)

In the case of simple apps (no files, only contracts), it will tell them that they can close with ctrl+c