### PR TITLE
Storage provider initialisation fixes and improvements.

### DIFF
--- a/lib/modules/ipfs/index.js
+++ b/lib/modules/ipfs/index.js
@@ -57,7 +57,7 @@ class IPFS {
       }
       function versionCb(err, body) {
         if (err) {
-          self.logger.trace("Check IPFS version error: " + err);
+          self.logger.trace("IPFS unavailable");
           return cb({name: "IPFS ", status: 'off'});
         }
         if (body.Version) {

--- a/lib/modules/storage/index.js
+++ b/lib/modules/storage/index.js
@@ -156,24 +156,22 @@ class Storage {
 
   checkStorageService(platform, url, callback) {
     const self = this;
-    const errorObj = {message: __('Cannot upload: {{platform}} node is not running on {{url}}.', {platform: platform, url: url})};
 
     // start the upload storage node
     self._checkStorageEndpoint(platform, function (err) {
       if (!err) {
-        return callback();
+        return callback(null);
       }
       self._startStorageNode(platform, (err) => {
         if (err) {
-          self._logger.error(err);
-          return callback(errorObj);
+          return callback(err);
         }
         // Check endpoint again to see if really did start
         self._checkStorageEndpoint(platform, (err) => {
           if (err) {
-            return callback(errorObj);
+            return callback(err);
           }
-          callback();
+          callback(null);
         });
       });
     });
@@ -182,20 +180,44 @@ class Storage {
   startStorageProcesses(){
     let platform = this._storageConfig.upload.provider;
     let self = this;
+    let withErrors = false;
 
     async.waterfall([
       function _checkStorageService(callback){
-        self.checkStorageService(platform, utils.buildUrlFromConfig(self._storageConfig.upload), callback);
+        self.checkStorageService(platform, utils.buildUrlFromConfig(self._storageConfig.upload), (err) => {
+          // log error and continue
+          if(err){
+            self._logger.error(err);
+            withErrors = true;
+          }
+          callback(null);
+        });
       },
       function checkDappConnectionStorageService(callback){
         // start any dappConnection storage nodes
-        self._validDappProviders.forEach(dappConn => {
-          if(!dappConn.provider || dappConn.provider === platform) return; // don't start the process we've just started above
+        async.each(self._validDappProviders, function(dappConn, cb) {
+          if(!dappConn.provider || dappConn.provider === platform) {
+            return cb(null);
+          } // don't start the process we've just started above
 
-          self.checkStorageService(dappConn.provider, utils.buildUrlFromConfig(dappConn), callback);
-        });
+          self.checkStorageService(dappConn.provider, utils.buildUrlFromConfig(dappConn), (err) => {
+            // log error and continue
+            if(err){
+              self._logger.error(err);
+              withErrors = true;
+            }
+            cb(null);
+          });
+        }, callback);
       }
-    ]);
+    ], function (){
+      let strComplete = __('Finished starting all storage providers');
+      if(withErrors){
+        strComplete += ', ' + __('with errors.');
+        return self._logger.warn(strComplete);
+      }
+      self._logger.info(strComplete + '.');
+    });
   }
 }
 


### PR DESCRIPTION
Fixed issue with IPFS not starting when swarm failed.

Added logging when starting of all storage providers has completed, and whether or not there were errors during starting of one of the providers.

Added parallel processing for starting dappConnection storage providers.

Removed irrelevant IPFS error from trace logs when IPFS not available.