### PR TITLE
Register web3 object after init

### DIFF
--- a/lib/contracts/blockchain.js
+++ b/lib/contracts/blockchain.js
@@ -90,7 +90,10 @@ class Blockchain {
       function fundAccountsIfNeeded(next) {
         provider.fundAccounts(next);
       }
-    ], cb);
+    ], (err) => {
+      self.registerWeb3Object();
+      cb(err);
+    });
   }
 
   onReady(callback) {


### PR DESCRIPTION
Fixes the issue of defaultAccount not being set in the dashboard and in onDeploy.
Was caused when initiating the blockchain node during node, because we need to reset the web3 object when creating the node, so I register the new object at the end of init