### PR TITLE
Fix hanging tests when using a wrong node

### DIFF
--- a/lib/contracts/blockchain.js
+++ b/lib/contracts/blockchain.js
@@ -256,45 +256,8 @@ class Blockchain {
         if (!self.contractsConfig || !self.contractsConfig.deployment || !self.contractsConfig.deployment.host) {
           return next();
         }
-        const origin = self.blockchainConfig.wsOrigins.split(',')[0];
-        const options = {
-          protocolVersion: 13,
-          perMessageDeflate: true,
-          origin: origin,
-          host: self.contractsConfig.deployment.host,
-          port: self.contractsConfig.deployment.port
-        };
-        if (self.contractsConfig.deployment.type === 'ws') {
-          options.headers = {
-            'Sec-WebSocket-Version': 13,
-            Connection: 'Upgrade',
-            Upgrade: 'websocket',
-            'Sec-WebSocket-Extensions': 'permessage-deflate; client_max_window_bits',
-            Origin: origin
-          };
-        }
-        let req;
-        // remove trailing api key from infura, ie rinkeby.infura.io/nmY8WtT4QfEwz2S7wTbl
-        if(options.host.indexOf('/') > -1){
-          options.host = options.host.split('/')[0];
-        }
-        if((self.contractsConfig.deployment.protocol || 'http') === 'https'){
-          req = require('https').get(options);          
-        }else{
-          req = require('http').get(options);
-        }
-        
-        req.on('error', (err) => {
-          next(err);
-        });
-
-        req.on('response', (_response) => {
-          next();
-        });
-
-        req.on('upgrade', (_res, _socket, _head) => {
-          next();
-        });
+        const {host, port, type, protocol}  = self.contractsConfig.deployment;
+        utils.pingEndpoint(host, port, type, protocol, self.blockchainConfig.wsOrigins.split(',')[0], next);
       }
     ], function (err) {
       if (!noLogs && err === NO_NODE_ERROR) {

--- a/lib/tests/test.js
+++ b/lib/tests/test.js
@@ -7,6 +7,7 @@ const Events = require('../core/events');
 const cloneDeep = require('clone-deep');
 const AccountParser = require('../contracts/accountParser');
 const Provider = require('../contracts/provider');
+const utils = require('../utils/utils');
 
 const EmbarkJS = require('../../js/embark_node');
 
@@ -44,18 +45,29 @@ class Test {
 
   initWeb3Provider(callback) {
     if (this.simOptions.host) {
-      const protocol = (this.simOptions.type === "rpc") ? 'http' : 'ws';
+      let {host, port, type, protocol, accounts}  = this.simOptions;
+      if (!protocol) {
+        protocol = (this.simOptions.type === "rpc") ? 'http' : 'ws';
+      }
+      const endpoint = `${protocol}://${host}:${port}`;
       const providerOptions = {
         web3: this.web3,
-        type: this.simOptions.type,
-        accountsConfig: this.simOptions.accounts,
+        type,
+        accountsConfig: accounts,
         blockchainConfig: this.engine.config.blockchainConfig,
         logger: this.engine.logger,
         isDev: false,
-        web3Endpoint: `${protocol}://${this.simOptions.host}:${this.simOptions.port}`
+        web3Endpoint: endpoint
       };
-      this.provider = new Provider(providerOptions);
-      return this.provider.startWeb3Provider(callback);
+      console.info(`Connecting to node at ${endpoint}`.cyan);
+      return utils.pingEndpoint(host, port, type, protocol, this.engine.config.blockchainConfig.wsOrigins.split(',')[0], (err) => {
+        if (err) {
+          console.error(`Error connecting to the node, there might be an error in ${endpoint}`.red);
+          return callback(err);
+        }
+        this.provider = new Provider(providerOptions);
+        return this.provider.startWeb3Provider(callback);
+      });
     }
 
     if (this.simOptions.accounts) {
@@ -214,7 +226,12 @@ class Test {
           next(null, accounts);
         });
       }
-    ], callback);
+    ], (err, accounts) => {
+      if (err) {
+        process.exit(1);
+      }
+      callback(null, accounts);
+    });
   }
 
   _deploy(config, callback) {

--- a/lib/utils/utils.js
+++ b/lib/utils/utils.js
@@ -73,8 +73,7 @@ function httpsGetJson(url, callback) {
   });
 }
 
-function pingEndpoint(host, port, type, protocol, wsOrigins, callback) {
-  const origin = wsOrigins.split(',')[0];
+function pingEndpoint(host, port, type, protocol, origin, callback) {
   const options = {
     protocolVersion: 13,
     perMessageDeflate: true,
@@ -93,10 +92,10 @@ function pingEndpoint(host, port, type, protocol, wsOrigins, callback) {
   }
   let req;
   // remove trailing api key from infura, ie rinkeby.infura.io/nmY8WtT4QfEwz2S7wTbl
-  if(options.host.indexOf('/') > -1){
+  if (options.host.indexOf('/') > -1){
     options.host = options.host.split('/')[0];
   }
-  if(protocol === 'https') {
+  if (protocol === 'https') {
     req = require('https').get(options);
   } else {
     req = require('http').get(options);

--- a/lib/utils/utils.js
+++ b/lib/utils/utils.js
@@ -73,6 +73,48 @@ function httpsGetJson(url, callback) {
   });
 }
 
+function pingEndpoint(host, port, type, protocol, wsOrigins, callback) {
+  const origin = wsOrigins.split(',')[0];
+  const options = {
+    protocolVersion: 13,
+    perMessageDeflate: true,
+    origin: origin,
+    host: host,
+    port: port
+  };
+  if (type === 'ws') {
+    options.headers = {
+      'Sec-WebSocket-Version': 13,
+      Connection: 'Upgrade',
+      Upgrade: 'websocket',
+      'Sec-WebSocket-Extensions': 'permessage-deflate; client_max_window_bits',
+      Origin: origin
+    };
+  }
+  let req;
+  // remove trailing api key from infura, ie rinkeby.infura.io/nmY8WtT4QfEwz2S7wTbl
+  if(options.host.indexOf('/') > -1){
+    options.host = options.host.split('/')[0];
+  }
+  if(protocol === 'https') {
+    req = require('https').get(options);
+  } else {
+    req = require('http').get(options);
+  }
+
+  req.on('error', (err) => {
+    callback(err);
+  });
+
+  req.on('response', (_response) => {
+    callback();
+  });
+
+  req.on('upgrade', (_res, _socket, _head) => {
+    callback();
+  });
+}
+
 function runCmd(cmd, options) {
   const shelljs = require('shelljs');
   let result = shelljs.exec(cmd, options || {silent: true});
@@ -267,6 +309,7 @@ module.exports = {
   httpGetJson: httpGetJson,
   httpsGetJson: httpsGetJson,
   hexToNumber: hexToNumber,
+  pingEndpoint,
   decodeParams: decodeParams,
   runCmd: runCmd,
   cd: cd,


### PR DESCRIPTION
Fix the case where you try to test specifying a non available node or the node is off.
Moved the pingEndpoint function to utils so that I could use it in tests too.