### PR TITLE
Fix log interception and enable multi-argument logging

### DIFF
--- a/js/embark.js
+++ b/js/embark.js
@@ -36,7 +36,7 @@ EmbarkJS.Contract = function (options) {
     ContractClass = new this.web3.eth.Contract(this.abi, this.address);
     ContractClass.setProvider(this.web3.currentProvider);
     ContractClass.options.data = this.code;
-    ContractClass.options.from = this.from;
+    ContractClass.options.from = this.from || this.web3.eth.defaultAccount;
     ContractClass.abi = ContractClass.options.abi;
     ContractClass.address = this.address;
     ContractClass.gas = this.gas;

--- a/js/embark_node.js
+++ b/js/embark_node.js
@@ -36,7 +36,7 @@ EmbarkJS.Contract = function(options) {
       ContractClass = new this.web3.eth.Contract(this.abi, this.address);
       ContractClass.setProvider(this.web3.currentProvider);
       ContractClass.options.data = this.code;
-      ContractClass.options.from = this.from;
+      ContractClass.options.from = this.from || this.web3.eth.defaultAccount;
       ContractClass.abi = ContractClass.options.abi;
       ContractClass.address = this.address;
       ContractClass.gas = this.gas;

--- a/lib/contracts/blockchain.js
+++ b/lib/contracts/blockchain.js
@@ -90,7 +90,10 @@ class Blockchain {
       function fundAccountsIfNeeded(next) {
         provider.fundAccounts(next);
       }
-    ], cb);
+    ], (err) => {
+      self.registerWeb3Object();
+      cb(err);
+    });
   }
 
   onReady(callback) {

--- a/lib/contracts/blockchain.js
+++ b/lib/contracts/blockchain.js
@@ -256,45 +256,8 @@ class Blockchain {
         if (!self.contractsConfig || !self.contractsConfig.deployment || !self.contractsConfig.deployment.host) {
           return next();
         }
-        const origin = self.blockchainConfig.wsOrigins.split(',')[0];
-        const options = {
-          protocolVersion: 13,
-          perMessageDeflate: true,
-          origin: origin,
-          host: self.contractsConfig.deployment.host,
-          port: self.contractsConfig.deployment.port
-        };
-        if (self.contractsConfig.deployment.type === 'ws') {
-          options.headers = {
-            'Sec-WebSocket-Version': 13,
-            Connection: 'Upgrade',
-            Upgrade: 'websocket',
-            'Sec-WebSocket-Extensions': 'permessage-deflate; client_max_window_bits',
-            Origin: origin
-          };
-        }
-        let req;
-        // remove trailing api key from infura, ie rinkeby.infura.io/nmY8WtT4QfEwz2S7wTbl
-        if(options.host.indexOf('/') > -1){
-          options.host = options.host.split('/')[0];
-        }
-        if((self.contractsConfig.deployment.protocol || 'http') === 'https'){
-          req = require('https').get(options);          
-        }else{
-          req = require('http').get(options);
-        }
-        
-        req.on('error', (err) => {
-          next(err);
-        });
-
-        req.on('response', (_response) => {
-          next();
-        });
-
-        req.on('upgrade', (_res, _socket, _head) => {
-          next();
-        });
+        const {host, port, type, protocol}  = self.contractsConfig.deployment;
+        utils.pingEndpoint(host, port, type, protocol, self.blockchainConfig.wsOrigins.split(',')[0], next);
       }
     ], function (err) {
       if (!noLogs && err === NO_NODE_ERROR) {

--- a/lib/contracts/blockchain.js
+++ b/lib/contracts/blockchain.js
@@ -1,7 +1,6 @@
 const Web3 = require('web3');
 const async = require('async');
 const Provider = require('./provider.js');
-const http = require('http');
 const BlockchainProcessLauncher = require('../processes/blockchainProcessLauncher');
 const utils = require('../utils/utils');
 const constants = require('../constants');
@@ -274,9 +273,17 @@ class Blockchain {
             Origin: origin
           };
         }
-
-        const req = http.get(options);
-
+        let req;
+        // remove trailing api key from infura, ie rinkeby.infura.io/nmY8WtT4QfEwz2S7wTbl
+        if(options.host.indexOf('/') > -1){
+          options.host = options.host.split('/')[0];
+        }
+        if((self.contractsConfig.deployment.protocol || 'http') === 'https'){
+          req = require('https').get(options);          
+        }else{
+          req = require('http').get(options);
+        }
+        
         req.on('error', (err) => {
           next(err);
         });

--- a/lib/contracts/blockchain.js
+++ b/lib/contracts/blockchain.js
@@ -48,9 +48,9 @@ class Blockchain {
       return cb(message);
     }
 
-    const protocol = (this.contractsConfig.deployment.type === "rpc") ? 'http' : 'ws';
+    const protocol = (this.contractsConfig.deployment.type === "rpc") ? this.contractsConfig.deployment.protocol : 'ws';
     let provider;
-    this.web3Endpoint = `${protocol}://${this.contractsConfig.deployment.host}:${this.contractsConfig.deployment.port}`;
+    this.web3Endpoint = utils.buildUrl(protocol, this.contractsConfig.deployment.host, this.contractsConfig.deployment.port);//`${protocol}://${this.contractsConfig.deployment.host}:${this.contractsConfig.deployment.port}`;
 
     const providerOptions = {
       web3: this.web3,

--- a/lib/contracts/code_generator.js
+++ b/lib/contracts/code_generator.js
@@ -137,7 +137,7 @@ class CodeGenerator {
         if (self.env === 'development') {
           web3Load = Templates.web3_connector({connectionList: connectionList, done: 'done();', warnAboutMetamask: true});
         } else {
-          web3Load = Templates.web3_connector({connectionList: connectionList, done: 'done();'});
+          web3Load = Templates.web3_connector({connectionList: connectionList, done: 'done();', warnAboutMetamask: true});
         }
       }
 

--- a/lib/core/logger.js
+++ b/lib/core/logger.js
@@ -11,57 +11,57 @@ class Logger {
   }
 }
 
-Logger.prototype.writeToFile = function (txt) {
+Logger.prototype.writeToFile = function () {
   if (!this.logFile) {
     return;
   }
 
-  fs.appendFileSync(this.logFile, "\n" + txt);
+  fs.appendFileSync(this.logFile, "\n" + Array.from(arguments).join(' '));
 };
 
-Logger.prototype.error = function (txt) {
-  if (!txt || !(this.shouldLog('error'))) {
+Logger.prototype.error = function () {
+  if (!arguments.length || !(this.shouldLog('error'))) {
     return;
   }
-  this.events.emit("log", "error", txt);
-  this.logFunction(txt.red);
-  this.writeToFile("[error]: " + txt);
+  this.events.emit("log", "error", ...arguments);
+  this.logFunction(...Array.from(arguments).map(t => t.red));
+  this.writeToFile("[error]: ", ...arguments);
 };
 
-Logger.prototype.warn = function (txt) {
-  if (!txt || !(this.shouldLog('warn'))) {
+Logger.prototype.warn = function () {
+  if (!arguments.length || !(this.shouldLog('warn'))) {
     return;
   }
-  this.events.emit("log", "warning", txt);
-  this.logFunction(txt.yellow);
-  this.writeToFile("[warning]: " + txt);
+  this.events.emit("log", "warning", ...arguments);
+  this.logFunction(...Array.from(arguments).map(t => t.yellow));
+  this.writeToFile("[warning]: ", ...arguments);
 };
 
-Logger.prototype.info = function (txt) {
-  if (!txt || !(this.shouldLog('info'))) {
+Logger.prototype.info = function () {
+  if (!arguments.length || !(this.shouldLog('info'))) {
     return;
   }
-  this.events.emit("log", "info", txt);
-  this.logFunction(txt.green);
-  this.writeToFile("[info]: " + txt);
+  this.events.emit("log", "info", ...arguments);
+  this.logFunction(...Array.from(arguments).map(t => t.green));
+  this.writeToFile("[info]: ", ...arguments);
 };
 
-Logger.prototype.debug = function (txt) {
-  if (!txt || !(this.shouldLog('debug'))) {
+Logger.prototype.debug = function () {
+  if (!arguments.length || !(this.shouldLog('debug'))) {
     return;
   }
-  this.events.emit("log", "debug", txt);
-  this.logFunction(txt);
-  this.writeToFile("[debug]: " + txt);
+  this.events.emit("log", "debug", ...arguments);
+  this.logFunction(...arguments);
+  this.writeToFile("[debug]: ", ...arguments);
 };
 
-Logger.prototype.trace = function (txt) {
-  if (!txt || !(this.shouldLog('trace'))) {
+Logger.prototype.trace = function () {
+  if (!arguments.length || !(this.shouldLog('trace'))) {
     return;
   }
-  this.events.emit("log", "trace", txt);
-  this.logFunction(txt);
-  this.writeToFile("[trace]: " + txt);
+  this.events.emit("log", "trace", ...arguments);
+  this.logFunction(...arguments);
+  this.writeToFile("[trace]: ", ...arguments);
 };
 
 Logger.prototype.dir = function (txt) {

--- a/lib/core/plugin.js
+++ b/lib/core/plugin.js
@@ -29,7 +29,8 @@ var Plugin = function(options) {
   this.afterContractsDeployActions = [];
   this.onDeployActions = [];
   this.eventActions = {};
-  this.logger = options.logger;
+  this._loggerObject = options.logger;
+  this.logger = this._loggerObject; // Might get changed if we do intercept
   this.events = options.events;
   this.config = options.config;
   this.env = options.env;
@@ -43,6 +44,22 @@ var Plugin = function(options) {
   if (!Array.isArray(this.acceptedContext)) {
     this.acceptedContext = [this.acceptedContext];
   }
+};
+
+Plugin.prototype._log = function(type) {
+  this._loggerObject[type](this.name + ':', ...[].slice.call(arguments, 1));
+};
+
+Plugin.prototype.setUpLogger = function () {
+  this.logger = {
+    log: this._log.bind(this, 'log'),
+    warn: this._log.bind(this, 'warn'),
+    error: this._log.bind(this, 'error'),
+    info: this._log.bind(this, 'info'),
+    debug: this._log.bind(this, 'debug'),
+    trace: this._log.bind(this, 'trace'),
+    dir: this._log.bind(this, 'dir')
+  };
 };
 
 Plugin.prototype.isContextValid = function() {
@@ -65,7 +82,7 @@ Plugin.prototype.loadPlugin = function() {
   }
   this.loaded = true;
   if (this.shouldInterceptLogs) {
-    this.interceptLogs(this.pluginModule);
+    this.setUpLogger();
   }
   (this.pluginModule.call(this, this));
 };
@@ -83,37 +100,6 @@ Plugin.prototype.pathToFile = function(filename) {
     throw new Error('pluginPath not defined for plugin: ' + this.name);
   }
   return utils.joinPath(this.pluginPath, filename);
-};
-
-Plugin.prototype.interceptLogs = function(context) {
-  var self = this;
-  // TODO: this is a bit nasty, figure out a better way
-  context.console = context.console || console;
-
-  //context.console.error  = function(txt) {
-  //  // TODO: logger should support an array instead of a single argument
-  //  //self.logger.error.apply(self.logger, arguments);
-  //  self.logger.error(self.name + " > " + txt);
-  //};
-  context.console.log  = function(txt) {
-    self.logger.info(self.name + " > " + txt);
-  };
-  context.console.warn  = function(txt) {
-    self.logger.warn(self.name + " > " + txt);
-  };
-  context.console.info  = function(txt) {
-    self.logger.info(self.name + " > " + txt);
-  };
-  context.console.debug  = function(txt) {
-    // TODO: ue JSON.stringify
-    self.logger.debug(self.name + " > " + txt);
-  };
-  context.console.trace  = function(txt) {
-    self.logger.trace(self.name + " > " + txt);
-  };
-  context.console.dir  = function(txt) {
-    self.logger.dir(txt);
-  };
 };
 
 // TODO: add deploy provider

--- a/lib/core/plugin.js
+++ b/lib/core/plugin.js
@@ -10,7 +10,6 @@ var Plugin = function(options) {
   this.pluginModule = options.pluginModule;
   this.pluginPath = options.pluginPath;
   this.pluginConfig = options.pluginConfig;
-  this.shouldInterceptLogs = options.interceptLogs;
   this.clientWeb3Providers = [];
   this.beforeDeploy = [];
   this.contractsGenerators = [];
@@ -64,9 +63,6 @@ Plugin.prototype.loadPlugin = function() {
     return false;
   }
   this.loaded = true;
-  if (this.shouldInterceptLogs) {
-    this.interceptLogs(this.pluginModule);
-  }
   (this.pluginModule.call(this, this));
 };
 
@@ -83,37 +79,6 @@ Plugin.prototype.pathToFile = function(filename) {
     throw new Error('pluginPath not defined for plugin: ' + this.name);
   }
   return utils.joinPath(this.pluginPath, filename);
-};
-
-Plugin.prototype.interceptLogs = function(context) {
-  var self = this;
-  // TODO: this is a bit nasty, figure out a better way
-  context.console = context.console || console;
-
-  //context.console.error  = function(txt) {
-  //  // TODO: logger should support an array instead of a single argument
-  //  //self.logger.error.apply(self.logger, arguments);
-  //  self.logger.error(self.name + " > " + txt);
-  //};
-  context.console.log  = function(txt) {
-    self.logger.info(self.name + " > " + txt);
-  };
-  context.console.warn  = function(txt) {
-    self.logger.warn(self.name + " > " + txt);
-  };
-  context.console.info  = function(txt) {
-    self.logger.info(self.name + " > " + txt);
-  };
-  context.console.debug  = function(txt) {
-    // TODO: ue JSON.stringify
-    self.logger.debug(self.name + " > " + txt);
-  };
-  context.console.trace  = function(txt) {
-    self.logger.trace(self.name + " > " + txt);
-  };
-  context.console.dir  = function(txt) {
-    self.logger.dir(txt);
-  };
 };
 
 // TODO: add deploy provider

--- a/lib/core/plugin.js
+++ b/lib/core/plugin.js
@@ -10,6 +10,7 @@ var Plugin = function(options) {
   this.pluginModule = options.pluginModule;
   this.pluginPath = options.pluginPath;
   this.pluginConfig = options.pluginConfig;
+  this.shouldInterceptLogs = options.interceptLogs;
   this.clientWeb3Providers = [];
   this.beforeDeploy = [];
   this.contractsGenerators = [];
@@ -63,6 +64,9 @@ Plugin.prototype.loadPlugin = function() {
     return false;
   }
   this.loaded = true;
+  if (this.shouldInterceptLogs) {
+    this.interceptLogs(this.pluginModule);
+  }
   (this.pluginModule.call(this, this));
 };
 
@@ -79,6 +83,37 @@ Plugin.prototype.pathToFile = function(filename) {
     throw new Error('pluginPath not defined for plugin: ' + this.name);
   }
   return utils.joinPath(this.pluginPath, filename);
+};
+
+Plugin.prototype.interceptLogs = function(context) {
+  var self = this;
+  // TODO: this is a bit nasty, figure out a better way
+  context.console = context.console || console;
+
+  //context.console.error  = function(txt) {
+  //  // TODO: logger should support an array instead of a single argument
+  //  //self.logger.error.apply(self.logger, arguments);
+  //  self.logger.error(self.name + " > " + txt);
+  //};
+  context.console.log  = function(txt) {
+    self.logger.info(self.name + " > " + txt);
+  };
+  context.console.warn  = function(txt) {
+    self.logger.warn(self.name + " > " + txt);
+  };
+  context.console.info  = function(txt) {
+    self.logger.info(self.name + " > " + txt);
+  };
+  context.console.debug  = function(txt) {
+    // TODO: ue JSON.stringify
+    self.logger.debug(self.name + " > " + txt);
+  };
+  context.console.trace  = function(txt) {
+    self.logger.trace(self.name + " > " + txt);
+  };
+  context.console.dir  = function(txt) {
+    self.logger.dir(txt);
+  };
 };
 
 // TODO: add deploy provider

--- a/lib/core/plugins.js
+++ b/lib/core/plugins.js
@@ -5,6 +5,7 @@ var fs = require('../core/fs.js');
 
 var Plugins = function(options) {
   this.pluginList = options.plugins || [];
+  this.interceptLogs = options.interceptLogs;
   this.plugins = [];
   // TODO: need backup 'NullLogger'
   this.logger = options.logger;
@@ -42,6 +43,7 @@ Plugins.prototype.createPlugin = function(pluginName, pluginConfig) {
     pluginConfig: pluginConfig,
     logger: this.logger,
     pluginPath: pluginPath,
+    interceptLogs: this.interceptLogs,
     events: this.events,
     config: this.config,
     isInternal: true,
@@ -61,6 +63,7 @@ Plugins.prototype.loadInternalPlugin = function(pluginName, pluginConfig) {
     pluginConfig: pluginConfig || {},
     logger: this.logger,
     pluginPath: pluginPath,
+    interceptLogs: this.interceptLogs,
     events: this.events,
     config: this.config,
     isInternal: true,
@@ -81,6 +84,7 @@ Plugins.prototype.loadPlugin = function(pluginName, pluginConfig) {
     pluginConfig: pluginConfig,
     logger: this.logger,
     pluginPath: pluginPath,
+    interceptLogs: this.interceptLogs,
     events: this.events,
     config: this.config,
     isInternal: false,

--- a/lib/core/plugins.js
+++ b/lib/core/plugins.js
@@ -5,7 +5,6 @@ var fs = require('../core/fs.js');
 
 var Plugins = function(options) {
   this.pluginList = options.plugins || [];
-  this.interceptLogs = options.interceptLogs;
   this.plugins = [];
   // TODO: need backup 'NullLogger'
   this.logger = options.logger;
@@ -43,7 +42,6 @@ Plugins.prototype.createPlugin = function(pluginName, pluginConfig) {
     pluginConfig: pluginConfig,
     logger: this.logger,
     pluginPath: pluginPath,
-    interceptLogs: this.interceptLogs,
     events: this.events,
     config: this.config,
     isInternal: true,
@@ -63,7 +61,6 @@ Plugins.prototype.loadInternalPlugin = function(pluginName, pluginConfig) {
     pluginConfig: pluginConfig || {},
     logger: this.logger,
     pluginPath: pluginPath,
-    interceptLogs: this.interceptLogs,
     events: this.events,
     config: this.config,
     isInternal: true,
@@ -84,7 +81,6 @@ Plugins.prototype.loadPlugin = function(pluginName, pluginConfig) {
     pluginConfig: pluginConfig,
     logger: this.logger,
     pluginPath: pluginPath,
-    interceptLogs: this.interceptLogs,
     events: this.events,
     config: this.config,
     isInternal: false,

--- a/lib/dashboard/monitor.js
+++ b/lib/dashboard/monitor.js
@@ -77,8 +77,8 @@ class Dashboard {
     this.screen.render();
   }
 
-  logEntry(text) {
-    this.logText.log(text);
+  logEntry() {
+    this.logText.log(...arguments);
     this.screen.render();
   }
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -6,17 +6,17 @@ require('colors');
 // Override process.chdir so that we have a partial-implementation PWD for Windows
 const realChdir = process.chdir;
 process.chdir = (...args) => {
-    if (!process.env.PWD) {
-        process.env.PWD = process.cwd();
-    }
-    realChdir(...args);
+  if (!process.env.PWD) {
+    process.env.PWD = process.cwd();
+  }
+  realChdir(...args);
 };
 
 let version = require('../package.json').version;
 
 class Embark {
 
-  constructor (options) {
+  constructor(options) {
     this.version = version;
     this.options = options || {};
   }
@@ -52,7 +52,7 @@ class Embark {
     this.context = options.context || [constants.contexts.simulator, constants.contexts.blockchain];
     let Simulator = require('./cmds/simulator.js');
     let simulator = new Simulator({
-      blockchainConfig: this.config.blockchainConfig, 
+      blockchainConfig: this.config.blockchainConfig,
       logger: this.logger
     });
     simulator.run(options);
@@ -129,7 +129,7 @@ class Embark {
         engine.events.on('check:backOnline:Ethereum', function () {
           engine.logger.info(__('Ethereum node detected') + '..');
           engine.config.reloadConfig();
-          engine.events.request('deploy:contracts', function(err) {
+          engine.events.request('deploy:contracts', function (err) {
             if (err) {
               return;
             }
@@ -201,7 +201,7 @@ class Embark {
         callback();
       },
       function deploy(callback) {
-        engine.events.request('deploy:contracts', function(err) {
+        engine.events.request('deploy:contracts', function (err) {
           callback(err);
         });
       },
@@ -227,7 +227,7 @@ class Embark {
   graph(options) {
     this.context = options.context || [constants.contexts.graph];
     options.onlyCompile = true;
-    
+
     const Engine = require('./core/engine.js');
     const engine = new Engine({
       env: options.env,
@@ -239,8 +239,7 @@ class Embark {
     });
     engine.init();
 
-    async.parallel([
-
+    async.waterfall([
       function (callback) {
         let pluginList = engine.plugins.listPlugins();
         if (pluginList.length > 0) {
@@ -251,14 +250,12 @@ class Embark {
         engine.startService("libraryManager");
         engine.startService("pipeline");
         engine.startService("deployment", {onlyCompile: true});
-        
+        engine.startService("web3");
         engine.startService("codeGenerator");
 
-        engine.events.request('deploy:contracts', function(err) {
-          callback(err);
-        });
+        engine.events.request('deploy:contracts', callback);
       }
-    ],  (err, _result) => {
+    ], (err) => {
       if (err) {
         engine.logger.error(err.message);
         engine.logger.info(err.stack);
@@ -320,7 +317,7 @@ class Embark {
         engine.startService("codeGenerator");
         callback();
       },
-      function setupStoragePlugin(callback){
+      function setupStoragePlugin(callback) {
         let pluginList = engine.plugins.listPlugins();
         if (pluginList.length > 0) {
           engine.logger.info(__("loaded plugins") + ": " + pluginList.join(", "));
@@ -344,15 +341,15 @@ class Embark {
       function deploy(callback) {
         engine.events.on('outputDone', function () {
           cmdPlugin.uploadCmds[0].cb()
-          .then((success) => {
-            callback(null, success);
-          })
-          .catch(callback);
+            .then((success) => {
+              callback(null, success);
+            })
+            .catch(callback);
         });
 
-        engine.events.request('deploy:contracts', function(err) {
+        engine.events.request('deploy:contracts', function (err) {
           engine.logger.info(__("finished deploying").underline);
-          if(err){
+          if (err) {
             callback(err);
           }
         });

--- a/lib/tests/run_tests.js
+++ b/lib/tests/run_tests.js
@@ -32,14 +32,23 @@ module.exports = {
     }
 
     async.waterfall([
-      function getFiles(next) {
-        if (filePath.substr(-1) !== '/') {
-          return fs.access(filePath, (err) => {
-            if (err) {
-              return next(`File "${filePath}" doesn't exist or you don't have permission to it`.red);
-            }
-            next(null, [filePath]);
-          });
+      function checkIfDir(next) {
+        if (filePath.substr(-1) === '/') {
+          return next(null, null);
+        }
+        fs.stat(filePath, (err, stats) => {
+          if (err) {
+            return next(`File "${filePath}" doesn't exist or you don't have permission to it`.red);
+          }
+          if (stats.isDirectory()) {
+            return next(null, null);
+          }
+          next(null, [filePath]);
+        });
+      },
+      function getFiles(files, next) {
+        if (files) {
+          return next(null, files);
         }
         getFilesFromDir(filePath, (err, files) => {
           if (err) {
@@ -56,7 +65,7 @@ module.exports = {
         global.assert = assert;
         global.config = test.config.bind(test);
 
-        let deprecatedWarning = function() {
+        let deprecatedWarning = function () {
           console.error(__('%s are not supported anymore', 'EmbarkSpec & deployAll').red);
           console.info(__('You can learn about the new revamped tests here: %s', 'https://embark.status.im/docs/testing.html'.underline));
           process.exit();
@@ -69,7 +78,7 @@ module.exports = {
         // Override require to enable `require('Embark/contracts/contractName');`
         const Module = require('module');
         const originalRequire = require('module').prototype.require;
-        Module.prototype.require = function(requireName) {
+        Module.prototype.require = function (requireName) {
           if (requireName.startsWith('Embark')) {
             return test.require(...arguments);
           }
@@ -101,7 +110,7 @@ module.exports = {
             });
           });
 
-          mocha.run(function(fails) {
+          mocha.run(function (fails) {
             failures += fails;
             // Mocha prints the error already
             eachCb();

--- a/lib/tests/test.js
+++ b/lib/tests/test.js
@@ -7,6 +7,7 @@ const Events = require('../core/events');
 const cloneDeep = require('clone-deep');
 const AccountParser = require('../contracts/accountParser');
 const Provider = require('../contracts/provider');
+const utils = require('../utils/utils');
 
 const EmbarkJS = require('../../js/embark_node');
 
@@ -44,18 +45,29 @@ class Test {
 
   initWeb3Provider(callback) {
     if (this.simOptions.host) {
-      const protocol = (this.simOptions.type === "rpc") ? 'http' : 'ws';
+      let {host, port, type, protocol, accounts}  = this.simOptions;
+      if (!protocol) {
+        protocol = (this.simOptions.type === "rpc") ? 'http' : 'ws';
+      }
+      const endpoint = `${protocol}://${host}:${port}`;
       const providerOptions = {
         web3: this.web3,
-        type: this.simOptions.type,
-        accountsConfig: this.simOptions.accounts,
+        type,
+        accountsConfig: accounts,
         blockchainConfig: this.engine.config.blockchainConfig,
         logger: this.engine.logger,
         isDev: false,
-        web3Endpoint: `${protocol}://${this.simOptions.host}:${this.simOptions.port}`
+        web3Endpoint: endpoint
       };
-      this.provider = new Provider(providerOptions);
-      return this.provider.startWeb3Provider(callback);
+      console.info(`Connecting to node at ${endpoint}`.cyan);
+      return utils.pingEndpoint(host, port, type, protocol, this.engine.config.blockchainConfig.wsOrigins.split(',')[0], (err) => {
+        if (err) {
+          console.error(`Error connecting to the node, there might be an error in ${endpoint}`.red);
+          return callback(err);
+        }
+        this.provider = new Provider(providerOptions);
+        return this.provider.startWeb3Provider(callback);
+      });
     }
 
     if (this.simOptions.accounts) {
@@ -214,7 +226,12 @@ class Test {
           next(null, accounts);
         });
       }
-    ], callback);
+    ], (err, accounts) => {
+      if (err) {
+        process.exit(1);
+      }
+      callback(null, accounts);
+    });
   }
 
   _deploy(config, callback) {

--- a/lib/utils/utils.js
+++ b/lib/utils/utils.js
@@ -73,8 +73,7 @@ function httpsGetJson(url, callback) {
   });
 }
 
-function pingEndpoint(host, port, type, protocol, wsOrigins, callback) {
-  const origin = wsOrigins.split(',')[0];
+function pingEndpoint(host, port, type, protocol, origin, callback) {
   const options = {
     protocolVersion: 13,
     perMessageDeflate: true,
@@ -93,10 +92,10 @@ function pingEndpoint(host, port, type, protocol, wsOrigins, callback) {
   }
   let req;
   // remove trailing api key from infura, ie rinkeby.infura.io/nmY8WtT4QfEwz2S7wTbl
-  if(options.host.indexOf('/') > -1){
+  if (options.host.indexOf('/') > -1){
     options.host = options.host.split('/')[0];
   }
-  if(protocol === 'https') {
+  if (protocol === 'https') {
     req = require('https').get(options);
   } else {
     req = require('http').get(options);

--- a/lib/utils/utils.js
+++ b/lib/utils/utils.js
@@ -73,6 +73,48 @@ function httpsGetJson(url, callback) {
   });
 }
 
+function pingEndpoint(host, port, type, protocol, wsOrigins, callback) {
+  const origin = wsOrigins.split(',')[0];
+  const options = {
+    protocolVersion: 13,
+    perMessageDeflate: true,
+    origin: origin,
+    host: host,
+    port: port
+  };
+  if (type === 'ws') {
+    options.headers = {
+      'Sec-WebSocket-Version': 13,
+      Connection: 'Upgrade',
+      Upgrade: 'websocket',
+      'Sec-WebSocket-Extensions': 'permessage-deflate; client_max_window_bits',
+      Origin: origin
+    };
+  }
+  let req;
+  // remove trailing api key from infura, ie rinkeby.infura.io/nmY8WtT4QfEwz2S7wTbl
+  if(options.host.indexOf('/') > -1){
+    options.host = options.host.split('/')[0];
+  }
+  if(protocol === 'https') {
+    req = require('https').get(options);
+  } else {
+    req = require('http').get(options);
+  }
+
+  req.on('error', (err) => {
+    callback(err);
+  });
+
+  req.on('response', (_response) => {
+    callback();
+  });
+
+  req.on('upgrade', (_res, _socket, _head) => {
+    callback();
+  });
+}
+
 function runCmd(cmd, options) {
   const shelljs = require('shelljs');
   let result = shelljs.exec(cmd, options || {silent: true});
@@ -267,6 +309,7 @@ module.exports = {
   httpGetJson: httpGetJson,
   httpsGetJson: httpsGetJson,
   hexToNumber: hexToNumber,
+  pingEndpoint,
   decodeParams: decodeParams,
   runCmd: runCmd,
   cd: cd,

--- a/package-lock.json
+++ b/package-lock.json
@@ -33,7 +33,7 @@
     },
     "@sinonjs/formatio": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@sinonjs/formatio/-/formatio-2.0.0.tgz",
+      "resolved": "http://registry.npmjs.org/@sinonjs/formatio/-/formatio-2.0.0.tgz",
       "integrity": "sha512-ls6CAMA6/5gG+O/IdsBcblvnd8qcO/l1TYoNeAzp3wcISOxlPXQEus0mLcdwazEkWjaBdaJ3TaxmNgCLWwvWzg==",
       "dev": true,
       "requires": {
@@ -92,7 +92,7 @@
     "abbrev": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
-      "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q=="
+      "integrity": "sha1-+PLIh60Qv2f2NPAFtph/7TF5qsg="
     },
     "abstract-leveldown": {
       "version": "2.6.3",
@@ -286,7 +286,7 @@
     "argparse": {
       "version": "1.0.10",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
-      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+      "integrity": "sha1-vNZ5HqWuCXJeF+WtmIE0zUCz2RE=",
       "requires": {
         "sprintf-js": "1.0.3"
       }
@@ -299,7 +299,7 @@
     "arr-flatten": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.1.0.tgz",
-      "integrity": "sha512-L3hKV5R/p5o81R7O02IGnwpDmkp6E982XhtbuwSe3O4qOtMMMtodicASA1Cny2U+aCXcNpml+m4dPsvsJ3jatg=="
+      "integrity": "sha1-NgSLv/TntH4TZkQxbJlmnqWukfE="
     },
     "arr-union": {
       "version": "3.1.0",
@@ -501,7 +501,7 @@
     "babel-generator": {
       "version": "6.26.1",
       "resolved": "https://registry.npmjs.org/babel-generator/-/babel-generator-6.26.1.tgz",
-      "integrity": "sha512-HyfwY6ApZj7BYTcJURpM5tznulaBvyio7/0d4zFOeMPUmfxkCjHocCuoLa2SAGzBI8AREcH3eP3758F672DppA==",
+      "integrity": "sha1-GERAjTuPDTWkBOp6wYDwh6YBvZA=",
       "requires": {
         "babel-messages": "6.23.0",
         "babel-runtime": "6.26.0",
@@ -672,7 +672,7 @@
     "babel-loader": {
       "version": "7.1.4",
       "resolved": "https://registry.npmjs.org/babel-loader/-/babel-loader-7.1.4.tgz",
-      "integrity": "sha512-/hbyEvPzBJuGpk9o80R0ZyTej6heEOr59GoEUtn8qFKbnx4cJm9FWES6J/iv644sYgrtVw9JJQkjaLW/bqb5gw==",
+      "integrity": "sha1-40Y5OL1ObVXRwXTFSF1AahiO0BU=",
       "requires": {
         "find-cache-dir": "1.0.0",
         "loader-utils": "1.1.0",
@@ -1362,7 +1362,7 @@
     "babylon": {
       "version": "6.18.0",
       "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.18.0.tgz",
-      "integrity": "sha512-q/UEjfGJ2Cm3oKV71DJz9d25TPnq5rhBVL2Q4fA5wcC3jcrdn7+SssEybFIxwAvvP+YCsCYNKughoF33GxgycQ=="
+      "integrity": "sha1-ry87iPpvXB5MY00aD46sT1WzleM="
     },
     "backoff": {
       "version": "2.5.0",
@@ -1380,7 +1380,7 @@
     "base": {
       "version": "0.11.2",
       "resolved": "https://registry.npmjs.org/base/-/base-0.11.2.tgz",
-      "integrity": "sha512-5T6P4xPgpp0YDFvSWwEZ4NoE3aM4QBQXDzmVbraCkFj8zHM+mba8SyqB5DbZWyR7mYHo6Y7BdQo3MoA4m0TeQg==",
+      "integrity": "sha1-e95c7RRbbVUakNuH+DxVi060io8=",
       "requires": {
         "cache-base": "1.0.1",
         "class-utils": "0.3.6",
@@ -1457,7 +1457,7 @@
     "big.js": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/big.js/-/big.js-3.2.0.tgz",
-      "integrity": "sha512-+hN/Zh2D08Mx65pZ/4g5bsmNiZUuChDiQfTUQ7qJr4/kuopCr88xZsAXv6mBoZEsUI4OuGHlX59qE94K2mMW8Q=="
+      "integrity": "sha1-pfwpi4G54Nyi5FiCR4S2XFK6WI4="
     },
     "binary-extensions": {
       "version": "1.11.0",
@@ -1472,7 +1472,7 @@
     "bindings": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.3.0.tgz",
-      "integrity": "sha512-DpLh5EzMR2kzvX1KIlVC0VkC3iZtHKTgdtZ0a3pglBZdaQFjt5S9g9xd1lE+YvXyfd6mtCeRnrUfOLYiTMlNSw=="
+      "integrity": "sha1-s0b27PapX1qBXFg5/HzbIlAvHtc="
     },
     "bip39": {
       "version": "2.5.0",
@@ -1524,7 +1524,7 @@
     "bn.js": {
       "version": "4.11.8",
       "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.8.tgz",
-      "integrity": "sha512-ItfYfPLkWHUjckQCk8xC+LwxgK8NYcXywGigJgSwOP8Y2iyWT4f2vsZnoOXTTbo+o5yXmIUJ4gn5538SO5S3gA=="
+      "integrity": "sha1-LN4J617jQfSEdGuwMJsyU7GxRC8="
     },
     "body-parser": {
       "version": "1.18.3",
@@ -1554,7 +1554,7 @@
     "brace-expansion": {
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "integrity": "sha1-PH/L9SnYcibz0vUrlm/1Jx60Qd0=",
       "requires": {
         "balanced-match": "1.0.0",
         "concat-map": "0.0.1"
@@ -1671,7 +1671,7 @@
     "browserify-zlib": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/browserify-zlib/-/browserify-zlib-0.2.0.tgz",
-      "integrity": "sha512-Z942RysHXmJrhqk88FmKBVq/v5tqmSkDz7p54G/MGyjMnCFFnC79XWNbg+Vta8W6Wb2qtSZTSxIGkJrRpCFEiA==",
+      "integrity": "sha1-KGlFnZqjviRf6P4sofRuLn9U1z8=",
       "requires": {
         "pako": "1.0.6"
       }
@@ -1778,7 +1778,7 @@
     "cache-base": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/cache-base/-/cache-base-1.0.1.tgz",
-      "integrity": "sha512-AKcdTnFSWATd5/GCPRxr2ChwIJ85CeyrEyjRHlKxQ56d4XJMGym0uAiKn0xbLOGOl3+yRpOTi484dVCEc5AUzQ==",
+      "integrity": "sha1-Cn9GQWgxyLZi7jb+TnxZ129marI=",
       "requires": {
         "collection-visit": "1.0.0",
         "component-emitter": "1.2.1",
@@ -1975,7 +1975,7 @@
     "cids": {
       "version": "0.5.3",
       "resolved": "https://registry.npmjs.org/cids/-/cids-0.5.3.tgz",
-      "integrity": "sha512-ujWbNP8SeLKg5KmGrxYZM4c+ttd+wwvegrdtgmbi2KNFUbQN4pqsGZaGQE3rhjayXTbKFq36bYDbKhsnD0eMsg==",
+      "integrity": "sha1-miW2l+t2+vgHr87DXEq5Nu370KQ=",
       "requires": {
         "multibase": "0.4.0",
         "multicodec": "0.2.7",
@@ -1985,7 +1985,7 @@
     "cipher-base": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/cipher-base/-/cipher-base-1.0.4.tgz",
-      "integrity": "sha512-Kkht5ye6ZGmwv40uUDZztayT2ThLQGfnj/T71N/XzeZeo3nf8foyW7zGTsPYkEya3m5f3cAypH+qe7YOrM1U2Q==",
+      "integrity": "sha1-h2Dk7MJy9MNjUy+SbYdKriwTl94=",
       "requires": {
         "inherits": "2.0.3",
         "safe-buffer": "5.1.2"
@@ -2000,7 +2000,7 @@
     "clap": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/clap/-/clap-1.2.3.tgz",
-      "integrity": "sha512-4CoL/A3hf90V3VIEjeuhSvlGFEHKzOz+Wfc2IVZc+FaUgU0ZQafJTP49fvnULipOPcAfqhyI2duwQyns6xqjYA==",
+      "integrity": "sha1-TzZ0WzIAhJJVf0ZBLWbVDLmbzlE=",
       "requires": {
         "chalk": "1.1.3"
       }
@@ -2008,7 +2008,7 @@
     "class-utils": {
       "version": "0.3.6",
       "resolved": "https://registry.npmjs.org/class-utils/-/class-utils-0.3.6.tgz",
-      "integrity": "sha512-qOhPa/Fj7s6TY8H8esGu5QNpMMQxz79h+urzrNYN6mn+9BnxlDGf5QZ+XeCDsxSjPqsSR56XOZOJmpeurnLMeg==",
+      "integrity": "sha1-+TNprouafOAv1B+q0MqDAzGQxGM=",
       "requires": {
         "arr-union": "3.1.0",
         "define-property": "0.2.5",
@@ -2422,7 +2422,7 @@
     "crypto-browserify": {
       "version": "3.12.0",
       "resolved": "https://registry.npmjs.org/crypto-browserify/-/crypto-browserify-3.12.0.tgz",
-      "integrity": "sha512-fz4spIh+znjO2VjL+IdhEpRJ3YN6sMzITSBijk6FK2UvTqruSQW+/cCZTSNsMiZNvUeq0CqurF+dAbyiGOY6Wg==",
+      "integrity": "sha1-OWz58xN/A+S45TLFj2mCVOAPgOw=",
       "requires": {
         "browserify-cipher": "1.0.1",
         "browserify-sign": "4.0.4",
@@ -2603,7 +2603,7 @@
     "debug": {
       "version": "2.6.9",
       "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "integrity": "sha1-XRKFFd8TT/Mn6QpMk/Tgd6U2NB8=",
       "requires": {
         "ms": "2.0.0"
       }
@@ -2763,7 +2763,7 @@
     "define-property": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/define-property/-/define-property-2.0.2.tgz",
-      "integrity": "sha512-jwK2UV4cnPpbcG7+VRARKTZPUWowwXA8bzH5NP6ud0oeAxyYPuGZUAC7hMugpCdz4BeSZl2Dl9k66CHJ/46ZYQ==",
+      "integrity": "sha1-1Flono1lS6d+AqgX+HENcCyxbp0=",
       "requires": {
         "is-descriptor": "1.0.2",
         "isobject": "3.0.1"
@@ -2934,7 +2934,7 @@
     "domain-browser": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/domain-browser/-/domain-browser-1.2.0.tgz",
-      "integrity": "sha512-jnjyiM6eRyZl2H+W8Q/zLMA481hzi0eszAaBUzIVnmYVDBbnLxVNnfu1HgEBvCbL+71FrxMl3E6lpKH7Ge3OXA=="
+      "integrity": "sha1-PTH1AZGmdJ3RN1p/Ui6CPULlTto="
     },
     "drbg.js": {
       "version": "1.0.1",
@@ -3090,7 +3090,7 @@
     "end-of-stream": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.1.tgz",
-      "integrity": "sha512-1MkrZNvWTKCaigbn+W15elq2BB/L22nqrSY5DKlo3X6+vclJm8Bb5djXJBmEX6fS3+zCh/F4VBK5Z2KxJt4s2Q==",
+      "integrity": "sha1-7SljTRm6ukY7bOa4CjchPqtx7EM=",
       "requires": {
         "once": "1.4.0"
       }
@@ -3113,7 +3113,7 @@
     "errno": {
       "version": "0.1.7",
       "resolved": "https://registry.npmjs.org/errno/-/errno-0.1.7.tgz",
-      "integrity": "sha512-MfrRBDWzIWifgq6tJj60gkAwtLNb6sQPlcFrSOflcP1aFmmruKQ2wRnze/8V6kgyz7H3FF8Npzv78mZ7XLLflg==",
+      "integrity": "sha1-RoTXF3mtOa8Xfj8AeZb3xnyFJhg=",
       "requires": {
         "prr": "1.0.1"
       }
@@ -3465,7 +3465,7 @@
     "esrecurse": {
       "version": "4.2.1",
       "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.2.1.tgz",
-      "integrity": "sha512-64RBB++fIOAXPw3P9cy89qfMlvZEXZkqqJkjqqXIvzP5ezRZjW+lPWjw35UX/3EhUPFYbg5ER4JYgDw4007/DQ==",
+      "integrity": "sha1-AHo7n9vCs7uH5IeeoZyS/b05Qs8=",
       "requires": {
         "estraverse": "4.2.0"
       }
@@ -3981,7 +3981,7 @@
     "evp_bytestokey": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/evp_bytestokey/-/evp_bytestokey-1.0.3.tgz",
-      "integrity": "sha512-/f2Go4TognH/KvCISP7OUsHn85hT9nUkxxA9BEWxFn+Oj9o8ZNLm/40hdlgSLyuOimsrTKLUMEorQexp/aPQeA==",
+      "integrity": "sha1-f8vbGY3HGVlDLv4ThCaE4FJaywI=",
       "requires": {
         "md5.js": "1.3.4",
         "safe-buffer": "5.1.2"
@@ -4232,7 +4232,7 @@
         "is-extendable": {
           "version": "1.0.1",
           "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
-          "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
+          "integrity": "sha1-p0cPnkJnM9gb2B4RVSZOOjUHyrQ=",
           "requires": {
             "is-plain-object": "2.0.4"
           }
@@ -4433,7 +4433,7 @@
     "file-loader": {
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/file-loader/-/file-loader-1.1.11.tgz",
-      "integrity": "sha512-TGR4HU7HUsGg6GCOPJnFk06RhWgEWFLAGWiT6rcD+GRC2keU3s9RGJ+b3Z6/U73jwwNb2gKLJ7YCrp+jvU4ALg==",
+      "integrity": "sha1-b+iGRJsPKpNuQ8q6rAzb+zaVBvg=",
       "requires": {
         "loader-utils": "1.1.0",
         "schema-utils": "0.4.5"
@@ -4724,7 +4724,7 @@
     "function-bind": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
-      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
+      "integrity": "sha1-pWiZ0+o8m6uHS7l3O3xe3pL0iV0="
     },
     "functional-red-black-tree": {
       "version": "1.0.1",
@@ -4900,7 +4900,7 @@
     "glob": {
       "version": "7.1.2",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
-      "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
+      "integrity": "sha1-wZyd+aAocC1nhhI4SmVSQExjbRU=",
       "requires": {
         "fs.realpath": "1.0.0",
         "inflight": "1.0.6",
@@ -5029,7 +5029,7 @@
     "globals": {
       "version": "9.18.0",
       "resolved": "https://registry.npmjs.org/globals/-/globals-9.18.0.tgz",
-      "integrity": "sha512-S0nG3CLEQiY/ILxqtztTWH/3iRRdyBLw6KMDxnKMchrtbj2OFmehVh0WUCfW3DUrIgx/qFrJPICrq4Z4sTR9UQ=="
+      "integrity": "sha1-qjiWs+abSH8X4x7SFD1pqOMMLYo="
     },
     "globby": {
       "version": "8.0.1",
@@ -5388,7 +5388,7 @@
     "grunt-mocha-test": {
       "version": "0.13.3",
       "resolved": "https://registry.npmjs.org/grunt-mocha-test/-/grunt-mocha-test-0.13.3.tgz",
-      "integrity": "sha512-zQGEsi3d+ViPPi7/4jcj78afKKAKiAA5n61pknQYi25Ugik+aNOuRmiOkmb8mN2CeG8YxT+YdT1H1Q7B/eNkoQ==",
+      "integrity": "sha1-kChHK2Fb2m3eqnswpaFk6YBd4AU=",
       "dev": true,
       "requires": {
         "hooker": "0.2.3",
@@ -5615,7 +5615,7 @@
     "hosted-git-info": {
       "version": "2.6.0",
       "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.6.0.tgz",
-      "integrity": "sha512-lIbgIIQA3lz5XaB6vxakj6sDHADJiZadYEJB+FgA+C4nubM1NwcuvUr9EJPmnH1skZqpqUzWborWo8EIUi0Sdw=="
+      "integrity": "sha1-IyNbKasjDFdqqw1PE/wEawsDgiI="
     },
     "html-comment-regex": {
       "version": "1.1.1",
@@ -5710,7 +5710,7 @@
         "ansi-styles": {
           "version": "3.2.1",
           "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+          "integrity": "sha1-QfuyAkPlCxK+DwS43tvwdSDOhB0=",
           "requires": {
             "color-convert": "1.9.2"
           }
@@ -5743,7 +5743,7 @@
         "source-map": {
           "version": "0.6.1",
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
+          "integrity": "sha1-dHIq8y6WFOnCh6jQu95IteLxomM="
         },
         "supports-color": {
           "version": "5.4.0",
@@ -5935,7 +5935,7 @@
     "invariant": {
       "version": "2.2.4",
       "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.4.tgz",
-      "integrity": "sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==",
+      "integrity": "sha1-YQ88ksk1nOHbYW5TgAjSP/NRWOY=",
       "requires": {
         "loose-envify": "1.3.1"
       }
@@ -5958,7 +5958,7 @@
     "ipfs-api": {
       "version": "17.2.4",
       "resolved": "https://registry.npmjs.org/ipfs-api/-/ipfs-api-17.2.4.tgz",
-      "integrity": "sha512-GFNy3Cj7EkzCrdyaQpvctHmtwtghzIDPTtW6XTqj+vybSwk2swyEMKaMHimqi8c8N+5+x5wfLpeUyRUhcZ9lDA==",
+      "integrity": "sha1-gTCl+pjhWyr49qJ7cUQs66/ImyQ=",
       "requires": {
         "async": "2.6.1",
         "bs58": "4.0.1",
@@ -6013,7 +6013,7 @@
     "ipfs-block": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/ipfs-block/-/ipfs-block-0.6.1.tgz",
-      "integrity": "sha512-28dgGsb2YsYnFs+To4cVBX8e/lTCb8eWDzGhN5csj3a/sHMOYrHeK8+Ez0IV67CI3lqKGuG/ZD01Cmd6JUvKrQ==",
+      "integrity": "sha1-uTBT6eqV917SkHgX/79V2ZKgatE=",
       "requires": {
         "cids": "0.5.3"
       }
@@ -6029,7 +6029,7 @@
     "ipld-dag-pb": {
       "version": "0.11.4",
       "resolved": "https://registry.npmjs.org/ipld-dag-pb/-/ipld-dag-pb-0.11.4.tgz",
-      "integrity": "sha512-A514Bt4z44bxhPQVzmBFMJsV3res92eBaDX0snzVsLLasBPNh4Z7He8N2mwSeAX9bJNywRBlJbHMQPwC45rqXw==",
+      "integrity": "sha1-sPrlaB+tVpcTLjJdbC/xe18Mtqg=",
       "requires": {
         "async": "2.6.1",
         "bs58": "4.0.1",
@@ -6102,7 +6102,7 @@
     "is-buffer": {
       "version": "1.1.6",
       "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
-      "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w=="
+      "integrity": "sha1-76ouqdqg16suoTqXsritUf776L4="
     },
     "is-builtin-module": {
       "version": "1.0.0",
@@ -6219,7 +6219,7 @@
     "is-ipfs": {
       "version": "0.3.2",
       "resolved": "https://registry.npmjs.org/is-ipfs/-/is-ipfs-0.3.2.tgz",
-      "integrity": "sha512-82V1j4LMkYy7H4seQQzOWqo7FiW3I64/1/ryo3dhtWKfOvm7ZolLMRQQfGKs4OXWauh5rAkPnamVcRISHwhmpQ==",
+      "integrity": "sha1-xGULg442/QFR3liWsv8xn+iTYYI=",
       "requires": {
         "bs58": "4.0.1",
         "cids": "0.5.3",
@@ -6290,7 +6290,7 @@
     "is-odd": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/is-odd/-/is-odd-2.0.0.tgz",
-      "integrity": "sha512-OTiixgpZAT1M4NHgS5IguFp/Vz2VI3U7Goh4/HA1adtwyLtSBrxYlcSYkhpAE07s4fKEcjrFxyvtQBND4vFQyQ==",
+      "integrity": "sha1-dkZiRnH9fqVYzNmieVGC8pWPGyQ=",
       "requires": {
         "is-number": "4.0.0"
       },
@@ -6298,7 +6298,7 @@
         "is-number": {
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/is-number/-/is-number-4.0.0.tgz",
-          "integrity": "sha512-rSklcAIlf1OmFdyAqbnWTLVelsQ58uvZ66S/ZyawjWqIviTWCjg2PzVGw8WUA+nNuPTqb4wgA+NszrJ+08LlgQ=="
+          "integrity": "sha1-ACbjf1RU1z41bf5lZGmYZ8an8P8="
         }
       }
     },
@@ -6334,7 +6334,7 @@
     "is-plain-object": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-2.0.4.tgz",
-      "integrity": "sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==",
+      "integrity": "sha1-LBY7P6+xtgbZ0Xko8FwqHDjgdnc=",
       "requires": {
         "isobject": "3.0.1"
       }
@@ -6412,7 +6412,7 @@
     "is-windows": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/is-windows/-/is-windows-1.0.2.tgz",
-      "integrity": "sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA=="
+      "integrity": "sha1-0YUOuXkezRjmGCzhKjDzlmNLsZ0="
     },
     "isarray": {
       "version": "1.0.0",
@@ -6623,7 +6623,7 @@
     "json-loader": {
       "version": "0.5.7",
       "resolved": "https://registry.npmjs.org/json-loader/-/json-loader-0.5.7.tgz",
-      "integrity": "sha512-QLPs8Dj7lnf3e3QYS1zkCo+4ZwqOiF9d/nZnYozTISxXWCfNs9yuky5rJw4/W34s7POaNlbZmQGaB5NiXCbP4w=="
+      "integrity": "sha1-3KFKcCNf+C8KyaOr62DTN6NlGF0="
     },
     "json-parse-better-errors": {
       "version": "1.0.2",
@@ -6929,7 +6929,7 @@
     "libp2p-crypto": {
       "version": "0.12.1",
       "resolved": "https://registry.npmjs.org/libp2p-crypto/-/libp2p-crypto-0.12.1.tgz",
-      "integrity": "sha512-1/z8rxZ0DcQNreZhEsl7PnLr7DWOioSvYbKBLGkRwNRiNh1JJLgh0PdTySBb44wkrOGT+TxcGRd7iq3/X6Wxwg==",
+      "integrity": "sha1-SocNJpujFQ3+AU5PmuoeVQdgFcg=",
       "requires": {
         "asn1.js": "5.0.1",
         "async": "2.6.1",
@@ -8004,7 +8004,7 @@
     "miller-rabin": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/miller-rabin/-/miller-rabin-4.0.1.tgz",
-      "integrity": "sha512-115fLhvZVqWwHPbClyntxEVfVDfl9DLLTuJvq3g2O/Oxi8AiNouAHvDSzHS0viUJc+V5vm3eq91Xwqn9dp4jRA==",
+      "integrity": "sha1-8IA1HIZbDcViqEYpZtqlNUPHik0=",
       "requires": {
         "bn.js": "4.11.8",
         "brorand": "1.1.0"
@@ -8013,7 +8013,7 @@
     "mime": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/mime/-/mime-1.4.1.tgz",
-      "integrity": "sha512-KI1+qOZu5DcW6wayYHSzR/tXKCDC5Om4s1z2QJjDULzLcmf3DvzS7oluY4HCTrc+9FiKmWUgeNLg7W3uIQvxtQ=="
+      "integrity": "sha1-Eh+evEnjdm8xGnbh+hyAA8SwOqY="
     },
     "mime-db": {
       "version": "1.12.0",
@@ -8033,7 +8033,7 @@
     "mimic-fn": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-1.2.0.tgz",
-      "integrity": "sha512-jf84uxzwiuiIVKiOLpfYk7N46TSy8ubTonmneY9vrpHNAnp0QBt2BxWV9dO3/j+BoVAb+a5G6YDPW3M5HOdMWQ=="
+      "integrity": "sha1-ggyGo5M0ZA6ZUWkovQP8qIBX0CI="
     },
     "mimic-response": {
       "version": "1.0.0",
@@ -8061,7 +8061,7 @@
     "minimatch": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
-      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+      "integrity": "sha1-UWbihkV/AzBgZL5Ul+jbsMPTIIM=",
       "requires": {
         "brace-expansion": "1.1.11"
       }
@@ -8090,7 +8090,7 @@
     "minizlib": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-1.1.0.tgz",
-      "integrity": "sha512-4T6Ur/GctZ27nHfpt9THOdRZNgyJ9FZchYO1ceg5S8Q3DNLCKYy44nCZzgCJgcvx2UM8czmqak5BCxJMrq37lA==",
+      "integrity": "sha1-EeE2WM5GvDpwomeqxYNZ0eDCnOs=",
       "requires": {
         "minipass": "2.3.3"
       }
@@ -8098,7 +8098,7 @@
     "mixin-deep": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/mixin-deep/-/mixin-deep-1.3.1.tgz",
-      "integrity": "sha512-8ZItLHeEgaqEvd5lYBXfm4EZSFCX29Jb9K+lAHhDKzReKBQKj3R+7NOF6tjqYi9t4oI8VUfaWITJQm86wnXGNQ==",
+      "integrity": "sha1-pJ5yaNzhoNlpjkUybFYm3zVD0P4=",
       "requires": {
         "for-in": "1.0.2",
         "is-extendable": "1.0.1"
@@ -8107,7 +8107,7 @@
         "is-extendable": {
           "version": "1.0.1",
           "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
-          "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
+          "integrity": "sha1-p0cPnkJnM9gb2B4RVSZOOjUHyrQ=",
           "requires": {
             "is-plain-object": "2.0.4"
           }
@@ -8248,7 +8248,7 @@
     "multibase": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/multibase/-/multibase-0.4.0.tgz",
-      "integrity": "sha512-fnYvZJWDn3eSJ7EeWvS8zbOpRwuyPHpDggSnqGXkQMvYED5NdO9nyqnZboGvAT+r/60J8KZ09tW8YJHkS22sFw==",
+      "integrity": "sha1-G9tiyC3gEU+CKh2HUby+6RzS77o=",
       "requires": {
         "base-x": "3.0.4"
       },
@@ -8274,7 +8274,7 @@
     "multihashes": {
       "version": "0.4.13",
       "resolved": "https://registry.npmjs.org/multihashes/-/multihashes-0.4.13.tgz",
-      "integrity": "sha512-HwJGEKPCpLlNlgGQA56CYh/Wsqa+c4JAq8+mheIgw7OK5T4QvNJqgp6TH8gZ4q4l1aiWeNat/H/MrFXmTuoFfQ==",
+      "integrity": "sha1-0QvXG9UdJKqJTipvFFcUa7e6wSU=",
       "requires": {
         "bs58": "4.0.1",
         "varint": "5.0.0"
@@ -8301,7 +8301,7 @@
     "multihashing-async": {
       "version": "0.4.8",
       "resolved": "https://registry.npmjs.org/multihashing-async/-/multihashing-async-0.4.8.tgz",
-      "integrity": "sha512-LCc4lfxmTJOHKIjZjFNgvmfB6nXS/ErLInT9uwU8udFrRm2PH+aTPk3mfCREKmCiSHOlCWiv2O8rlnBx+OjlMw==",
+      "integrity": "sha1-QVcrJaj8aOsxi4ViQJ/dchpyfqE=",
       "requires": {
         "async": "2.6.1",
         "blakejs": "1.1.0",
@@ -8367,7 +8367,7 @@
     "nanomatch": {
       "version": "1.2.9",
       "resolved": "https://registry.npmjs.org/nanomatch/-/nanomatch-1.2.9.tgz",
-      "integrity": "sha512-n8R9bS8yQ6eSXaV6jHUpKzD8gLsin02w1HSFiegwrs9E098Ylhw5jdyKPaYqvHknHaSCKTPp7C8dGCQ0q9koXA==",
+      "integrity": "sha1-h59xUMstq3pHElkGbBBO7m4Pp8I=",
       "requires": {
         "arr-diff": "4.0.0",
         "array-unique": "0.3.2",
@@ -8581,7 +8581,7 @@
     "node-libs-browser": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/node-libs-browser/-/node-libs-browser-2.1.0.tgz",
-      "integrity": "sha512-5AzFzdoIMb89hBGMZglEegffzgRg+ZFoUmisQ8HI4j1KDdpx13J0taNp2y9xPbur6W61gepGDDotGBVQ7mfUCg==",
+      "integrity": "sha1-X5QmPUBPbkR2fXJpAf/wVHjWAN8=",
       "requires": {
         "assert": "1.4.1",
         "browserify-zlib": "0.2.0",
@@ -8758,7 +8758,7 @@
     "normalize-package-data": {
       "version": "2.4.0",
       "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.4.0.tgz",
-      "integrity": "sha512-9jjUFbTPfEy3R/ad/2oNbKtW9Hgovl5O1FvFWKkKblNXoN/Oou6+9+KKohPK13Yc3/TyunyWhJp6gvRNR/PPAw==",
+      "integrity": "sha1-EvlaMH1YNSB1oEkHuErIvpisAS8=",
       "requires": {
         "hosted-git-info": "2.6.0",
         "is-builtin-module": "1.0.0",
@@ -9064,7 +9064,7 @@
     "os-locale": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-2.1.0.tgz",
-      "integrity": "sha512-3sslG3zJbEYcaC4YVAvDorjGxc7tv6KVATnLPZONiljsUncvihe9BQoVCEs0RZ1kmf4Hk9OBqlZfJZWI4GanKA==",
+      "integrity": "sha1-QrwpAKa1uL0XN2yOiCtlr8zyS/I=",
       "requires": {
         "execa": "0.7.0",
         "lcid": "1.0.0",
@@ -9161,7 +9161,7 @@
     "pako": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.6.tgz",
-      "integrity": "sha512-lQe48YPsMJAig+yngZ87Lus+NF+3mtu7DVOBu6b/gHO1YpKwIj5AWjZ/TOS7i46HD/UixzWb1zeWDZfGZ3iYcg=="
+      "integrity": "sha1-AQEhG6pwxLykoPY/Igbpe3368lg="
     },
     "parse-asn1": {
       "version": "5.1.1",
@@ -9321,7 +9321,7 @@
     "peer-info": {
       "version": "0.11.6",
       "resolved": "https://registry.npmjs.org/peer-info/-/peer-info-0.11.6.tgz",
-      "integrity": "sha512-xrVNiAF1IhVJNGEg5P2UQN+subaEkszT8YkC3zdy06MK0vTH3cMHB+HH+ZURkoSLssc3HbK58ecXeKpQ/4zq5w==",
+      "integrity": "sha1-BICwAw0t+P1PCYebJppxWyvSuhI=",
       "requires": {
         "lodash.uniqby": "4.7.0",
         "multiaddr": "3.1.0",
@@ -9409,7 +9409,7 @@
     "postcss": {
       "version": "5.2.18",
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-5.2.18.tgz",
-      "integrity": "sha512-zrUjRRe1bpXKsX1qAJNJjqZViErVuyEkMTRrwu4ud4sbTtIBRmtaYDrHmcGgmrbsW3MHfmtIf+vJumgQn+PrXg==",
+      "integrity": "sha1-ut+hSX1GJE9jkPWLMZgw2RB4U8U=",
       "requires": {
         "chalk": "1.1.3",
         "js-base64": "2.4.5",
@@ -9592,7 +9592,7 @@
         "ansi-styles": {
           "version": "3.2.1",
           "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+          "integrity": "sha1-QfuyAkPlCxK+DwS43tvwdSDOhB0=",
           "requires": {
             "color-convert": "1.9.2"
           }
@@ -9625,7 +9625,7 @@
         "source-map": {
           "version": "0.6.1",
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
+          "integrity": "sha1-dHIq8y6WFOnCh6jQu95IteLxomM="
         },
         "supports-color": {
           "version": "5.4.0",
@@ -9649,7 +9649,7 @@
         "ansi-styles": {
           "version": "3.2.1",
           "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+          "integrity": "sha1-QfuyAkPlCxK+DwS43tvwdSDOhB0=",
           "requires": {
             "color-convert": "1.9.2"
           }
@@ -9682,7 +9682,7 @@
         "source-map": {
           "version": "0.6.1",
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
+          "integrity": "sha1-dHIq8y6WFOnCh6jQu95IteLxomM="
         },
         "supports-color": {
           "version": "5.4.0",
@@ -9706,7 +9706,7 @@
         "ansi-styles": {
           "version": "3.2.1",
           "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+          "integrity": "sha1-QfuyAkPlCxK+DwS43tvwdSDOhB0=",
           "requires": {
             "color-convert": "1.9.2"
           }
@@ -9739,7 +9739,7 @@
         "source-map": {
           "version": "0.6.1",
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
+          "integrity": "sha1-dHIq8y6WFOnCh6jQu95IteLxomM="
         },
         "supports-color": {
           "version": "5.4.0",
@@ -9763,7 +9763,7 @@
         "ansi-styles": {
           "version": "3.2.1",
           "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+          "integrity": "sha1-QfuyAkPlCxK+DwS43tvwdSDOhB0=",
           "requires": {
             "color-convert": "1.9.2"
           }
@@ -9796,7 +9796,7 @@
         "source-map": {
           "version": "0.6.1",
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
+          "integrity": "sha1-dHIq8y6WFOnCh6jQu95IteLxomM="
         },
         "supports-color": {
           "version": "5.4.0",
@@ -9943,7 +9943,7 @@
     "private": {
       "version": "0.1.8",
       "resolved": "https://registry.npmjs.org/private/-/private-0.1.8.tgz",
-      "integrity": "sha512-VvivMrbvd2nKkiG38qjULzlc+4Vx4wm/whI9pQD35YrARNnhxeiRktSOhSukRLFNlzg6Br/cJPet5J/u19r/mg=="
+      "integrity": "sha1-I4Hts2ifelPWUxkAYPz4ItLzaP8="
     },
     "process": {
       "version": "0.5.2",
@@ -9953,7 +9953,7 @@
     "process-nextick-args": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.0.tgz",
-      "integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw=="
+      "integrity": "sha1-o31zL0JxtKsa0HDTVQjoKQeI/6o="
     },
     "progress": {
       "version": "2.0.0",
@@ -9988,7 +9988,7 @@
     "promisify-es6": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/promisify-es6/-/promisify-es6-1.0.3.tgz",
-      "integrity": "sha512-N9iVG+CGJsI4b4ZGazjwLnxErD2d9Pe4DPvvXSxYA9tFNu8ymXME4Qs5HIQ0LMJpNM7zj+m0NlNnNeqFpKzqnA=="
+      "integrity": "sha1-sBJmjE3zyWXOE9qsKzpNFyapY0Y="
     },
     "promptly": {
       "version": "2.2.0",
@@ -10009,12 +10009,12 @@
     "protocol-buffers-schema": {
       "version": "3.3.2",
       "resolved": "https://registry.npmjs.org/protocol-buffers-schema/-/protocol-buffers-schema-3.3.2.tgz",
-      "integrity": "sha512-Xdayp8sB/mU+sUV4G7ws8xtYMGdQnxbeIfLjyO9TZZRJdztBGhlmbI5x1qcY4TG5hBkIKGnc28i7nXxaugu88w=="
+      "integrity": "sha1-AENPYItOjfVMWeBw7+78N/tLuFk="
     },
     "protons": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/protons/-/protons-1.0.1.tgz",
-      "integrity": "sha512-+0ZKnfVs+4c43tbAQ5j0Mck8wPcLnlxUYzKQoB4iDW4ocdXGnN4P+0dDbgX1FTpoY9+7P2Tn2scJyHHqj+S/lQ==",
+      "integrity": "sha1-HBBxRMB/wtHLi2y3ZFHmqTgjdnY=",
       "requires": {
         "protocol-buffers-schema": "3.3.2",
         "safe-buffer": "5.1.2",
@@ -10081,7 +10081,7 @@
     "pump": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/pump/-/pump-1.0.3.tgz",
-      "integrity": "sha512-8k0JupWme55+9tCVE+FS5ULT3K6AbgqrGa58lTT49RpyfwwcGedHqaC5LlQNdEAumn/wFsu6aPwkuPMioy8kqw==",
+      "integrity": "sha1-Xf6DEcM7v2/BgmH580cCxHwIqVQ=",
       "requires": {
         "end-of-stream": "1.4.1",
         "once": "1.4.0"
@@ -10141,7 +10141,7 @@
     "randombytes": {
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.0.6.tgz",
-      "integrity": "sha512-CIQ5OFxf4Jou6uOKe9t1AOgqpeU5fd70A8NPdHSGeYXqXsPe6peOwI0cUl88RWZ6sP1vPMV3avd/R6cZ5/sP1A==",
+      "integrity": "sha1-0wLFIpSFiISKjTAMkytEwkIx2oA=",
       "requires": {
         "safe-buffer": "5.1.2"
       }
@@ -10149,7 +10149,7 @@
     "randomfill": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/randomfill/-/randomfill-1.0.4.tgz",
-      "integrity": "sha512-87lcbR8+MhcWcUiQ+9e+Rwx8MyR2P7qnt15ynUlbm3TU/fjbgz4GsvfSUDTemtCCtVCqb4ZcEFlyPNTh9bBTLw==",
+      "integrity": "sha1-ySGW/IarQr6YPxvzF3giSTHWFFg=",
       "requires": {
         "randombytes": "2.0.6",
         "safe-buffer": "5.1.2"
@@ -10349,12 +10349,12 @@
     "regenerator-runtime": {
       "version": "0.11.1",
       "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz",
-      "integrity": "sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg=="
+      "integrity": "sha1-vgWtf5v30i4Fb5cmzuUBf78Z4uk="
     },
     "regenerator-transform": {
       "version": "0.10.1",
       "resolved": "https://registry.npmjs.org/regenerator-transform/-/regenerator-transform-0.10.1.tgz",
-      "integrity": "sha512-PJepbvDbuK1xgIgnau7Y90cwaAmO/LCLMI2mPvaXq2heGMR3aWW5/BQvYrhJ8jgmQjXewXvBjzfqKcVOmhjZ6Q==",
+      "integrity": "sha1-HkmWg3Ix2ot/PPQRTXG1aRoGgN0=",
       "requires": {
         "babel-runtime": "6.26.0",
         "babel-types": "6.26.0",
@@ -10364,7 +10364,7 @@
     "regex-cache": {
       "version": "0.4.4",
       "resolved": "https://registry.npmjs.org/regex-cache/-/regex-cache-0.4.4.tgz",
-      "integrity": "sha512-nVIZwtCjkC9YgvWkpM55B5rBhBYRZhAaJbgcFYXXsHnbZ9UZI9nnVWYZpBlCqv9ho2eZryPnWrZGsOdPwVWXWQ==",
+      "integrity": "sha1-db3FiioUls7EihKDW8VMjVYjNt0=",
       "requires": {
         "is-equal-shallow": "0.1.3"
       }
@@ -10372,7 +10372,7 @@
     "regex-not": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/regex-not/-/regex-not-1.0.2.tgz",
-      "integrity": "sha512-J6SDjUgDxQj5NusnOtdFxDwN/+HWykR8GELwctJ7mdqhcyy1xEc4SRFHUXvxTp661YaVKAjfRLZ9cCqS6tn32A==",
+      "integrity": "sha1-H07OJ+ALC2XgJHpoEOaoXYOldSw=",
       "requires": {
         "extend-shallow": "3.0.2",
         "safe-regex": "1.1.0"
@@ -10658,7 +10658,7 @@
     "ret": {
       "version": "0.1.15",
       "resolved": "https://registry.npmjs.org/ret/-/ret-0.1.15.tgz",
-      "integrity": "sha512-TTlYpa+OL+vMMNG24xSlQGEJ3B/RzEfUlLct7b5G/ytav+wPrplCpVMFuwzXbkecJrb6IYo1iFb0S9v37754mg=="
+      "integrity": "sha1-uKSCXVvbH8P29Twrwz+BOIaBx7w="
     },
     "right-align": {
       "version": "0.1.3",
@@ -10782,7 +10782,7 @@
     "sax": {
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
-      "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw=="
+      "integrity": "sha1-KBYjTiN4vdxOU1T6tcqold9xANk="
     },
     "scandirectory": {
       "version": "2.5.0",
@@ -10797,7 +10797,7 @@
     "schema-utils": {
       "version": "0.4.5",
       "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-0.4.5.tgz",
-      "integrity": "sha512-yYrjb9TX2k/J1Y5UNy3KYdZq10xhYcF8nMpAW6o3hy6Q8WSIEf9lJHG/ePnOBfziPM3fvQwfOwa13U/Fh8qTfA==",
+      "integrity": "sha1-IYNvBgiqwXt4+ePiTa/xSlyhOj4=",
       "requires": {
         "ajv": "6.5.1",
         "ajv-keywords": "3.2.0"
@@ -10836,7 +10836,7 @@
     "secp256k1": {
       "version": "3.5.0",
       "resolved": "https://registry.npmjs.org/secp256k1/-/secp256k1-3.5.0.tgz",
-      "integrity": "sha512-e5QIJl8W7Y4tT6LHffVcZAxJjvpgE5Owawv6/XCYPQljE9aP2NFFddQ8OYMKhdLshNu88FfL3qCN3/xYkXGRsA==",
+      "integrity": "sha1-Z307io4E4aX6OBoa5DfFQge3ONA=",
       "requires": {
         "bindings": "1.3.0",
         "bip66": "1.1.5",
@@ -10874,12 +10874,12 @@
     "semver": {
       "version": "5.5.0",
       "resolved": "https://registry.npmjs.org/semver/-/semver-5.5.0.tgz",
-      "integrity": "sha512-4SJ3dm0WAwWy/NVeioZh5AntkdJoWKxHxcmyP622fOkgHa4z3R0TdBJICINyaSDE6uNwVc8gZr+ZinwZAH4xIA=="
+      "integrity": "sha1-3Eu8emyp2Rbe5dQ1FvAJK1j3uKs="
     },
     "send": {
       "version": "0.16.2",
       "resolved": "https://registry.npmjs.org/send/-/send-0.16.2.tgz",
-      "integrity": "sha512-E64YFPUssFHEFBvpbbjr44NCLtI1AohxQ8ZSiJjQLskAdKuriYEP6VyGEsRDH8ScozGpkaX1BGvhanqCwkcEZw==",
+      "integrity": "sha1-bsyh4PjBVtFBWXVZhI32RzCmu8E=",
       "requires": {
         "debug": "2.6.9",
         "depd": "1.1.2",
@@ -10899,7 +10899,7 @@
     "serve-static": {
       "version": "1.13.2",
       "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.13.2.tgz",
-      "integrity": "sha512-p/tdJrO4U387R9oMjb1oj7qSMaMfmOyd4j9hOFoxZe2baQszgHcSWjuya/CiT5kgZZKRudHNOA0pYXOl8rQ5nw==",
+      "integrity": "sha1-CV6Ecv1bRiN9tQzkhqQ/S4bGzsE=",
       "requires": {
         "encodeurl": "1.0.2",
         "escape-html": "1.0.3",
@@ -10932,7 +10932,7 @@
     "set-value": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/set-value/-/set-value-2.0.0.tgz",
-      "integrity": "sha512-hw0yxk9GT/Hr5yJEYnHNKYXkIA8mVJgd9ditYZCe16ZczcaELYYcfvaXesNACk2O8O0nTiPQcQhGUQj8JLzeeg==",
+      "integrity": "sha1-ca5KiPD+77v1LR6mBPP7MV67YnQ=",
       "requires": {
         "extend-shallow": "2.0.1",
         "is-extendable": "0.1.1",
@@ -11090,7 +11090,7 @@
     "snapdragon": {
       "version": "0.8.2",
       "resolved": "https://registry.npmjs.org/snapdragon/-/snapdragon-0.8.2.tgz",
-      "integrity": "sha512-FtyOnWN/wCHTVXOMwvSv26d+ko5vWlIDD6zoUJ7LW8vh+ZBC8QdljveRP+crNrtBwioEUWy/4dMtbBjA4ioNlg==",
+      "integrity": "sha1-ZJIufFZbDhQgS6GqfWlkJ40lGC0=",
       "requires": {
         "base": "0.11.2",
         "debug": "2.6.9",
@@ -11123,7 +11123,7 @@
     "snapdragon-node": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/snapdragon-node/-/snapdragon-node-2.1.1.tgz",
-      "integrity": "sha512-O27l4xaMYt/RSQ5TR3vpWCAB5Kb/czIcqUFOM/C4fYcLnbZUc1PkjTAMjof2pBWaSTwOUd6qUHcFGVGj7aIwnw==",
+      "integrity": "sha1-bBdfhv8UvbByRWPo88GwIaKGhTs=",
       "requires": {
         "define-property": "1.0.0",
         "isobject": "3.0.1",
@@ -11169,7 +11169,7 @@
     "snapdragon-util": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/snapdragon-util/-/snapdragon-util-3.0.1.tgz",
-      "integrity": "sha512-mbKkMdQKsjX4BAL4bRYTj21edOf8cN7XHdYUJEe+Zn99hVEYcMvKPct1IqNe7+AZPirn8BCDOQBHQZknqmKlZQ==",
+      "integrity": "sha1-+VZHlIbyrNeXAGk/b3uAXkWrVuI=",
       "requires": {
         "kind-of": "3.2.2"
       },
@@ -11381,7 +11381,7 @@
     "source-list-map": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/source-list-map/-/source-list-map-2.0.0.tgz",
-      "integrity": "sha512-I2UmuJSRr/T8jisiROLU3A3ltr+swpniSmNPI4Ml3ZCX6tVnDsuZzK7F2hl5jTqbZBWCEKlj5HRQiPExXLgE8A=="
+      "integrity": "sha1-qqR0A/eyRakvvJfqCPJQ1gh+0IU="
     },
     "source-map": {
       "version": "0.5.7",
@@ -11403,7 +11403,7 @@
     "source-map-support": {
       "version": "0.4.18",
       "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.4.18.tgz",
-      "integrity": "sha512-try0/JqxPLF9nOjvSta7tVondkP5dwgyLDjVoyMDlmjugT2lRZ1OfsrYTkCd2hkDnJTKRbO/Rl3orm8vlsUzbA==",
+      "integrity": "sha1-Aoam3ovkJkEzhZTpfM6nXwosWF8=",
       "requires": {
         "source-map": "0.5.7"
       }
@@ -11416,7 +11416,7 @@
     "spdx-correct": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.0.0.tgz",
-      "integrity": "sha512-N19o9z5cEyc8yQQPukRCZ9EUmb4HUpnrmaL/fxS2pBo2jbfcFRVuFZ/oFC+vZz0MNNk0h80iMn5/S6qGZOL5+g==",
+      "integrity": "sha1-BaW01xU6GVvJLDxCW2nzsqlSTII=",
       "requires": {
         "spdx-expression-parse": "3.0.0",
         "spdx-license-ids": "3.0.0"
@@ -11425,12 +11425,12 @@
     "spdx-exceptions": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-2.1.0.tgz",
-      "integrity": "sha512-4K1NsmrlCU1JJgUrtgEeTVyfx8VaYea9J9LvARxhbHtVtohPs/gFGG5yy49beySjlIMhhXZ4QqujIZEfS4l6Cg=="
+      "integrity": "sha1-LHrmEFbHFKW5ubKyr30xHvXHj+k="
     },
     "spdx-expression-parse": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-3.0.0.tgz",
-      "integrity": "sha512-Yg6D3XpRD4kkOmTpdgbUiEJFKghJH03fiC1OPll5h/0sO6neh2jqRDVHOQ4o/LMea0tgCkbMgea5ip/e+MkWyg==",
+      "integrity": "sha1-meEZt6XaAOBUkcn6M4t5BII7QdA=",
       "requires": {
         "spdx-exceptions": "2.1.0",
         "spdx-license-ids": "3.0.0"
@@ -11439,12 +11439,12 @@
     "spdx-license-ids": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.0.tgz",
-      "integrity": "sha512-2+EPwgbnmOIl8HjGBXXMd9NAu02vLjOO1nWw4kmeRDFyHn+M/ETfHxQUK0oXg8ctgVnl9t3rosNVsZ1jG61nDA=="
+      "integrity": "sha1-enzShHDMbToc/m1miG9rxDDTrIc="
     },
     "split-string": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/split-string/-/split-string-3.1.0.tgz",
-      "integrity": "sha512-NzNVhJDYpwceVVii8/Hu6DKfD2G+NrQHlS/V/qgv763EYudVwEcMQNxd2lh+0VrUByXN/oJkl5grOhYWvQUYiw==",
+      "integrity": "sha1-fLCd2jqGWFcFxks5pkZgOGguj+I=",
       "requires": {
         "extend-shallow": "3.0.2"
       }
@@ -11452,7 +11452,7 @@
     "split2": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/split2/-/split2-2.2.0.tgz",
-      "integrity": "sha512-RAb22TG39LhI31MbreBgIuKiIKhVsawfTgEGqKHTK87aG+ul/PB8Sqoi3I7kVdRWiCfrKxK3uo4/YUkpNvhPbw==",
+      "integrity": "sha1-GGsldbz4PoW30YRldWI47k7kJJM=",
       "requires": {
         "through2": "2.0.3"
       }
@@ -11588,7 +11588,7 @@
     "string-width": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
-      "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+      "integrity": "sha1-q5Pyeo3BPSjKyBXEYhQ6bZASrp4=",
       "requires": {
         "is-fullwidth-code-point": "2.0.0",
         "strip-ansi": "4.0.0"
@@ -11695,7 +11695,7 @@
     "style-loader": {
       "version": "0.19.1",
       "resolved": "https://registry.npmjs.org/style-loader/-/style-loader-0.19.1.tgz",
-      "integrity": "sha512-IRE+ijgojrygQi3rsqT0U4dd+UcPCqcVvauZpCnQrGAlEe+FUIyrK93bUDScamesjP08JlQNsFJU+KmPedP5Og==",
+      "integrity": "sha1-WR/8gLzv4mi3fF2evAUF13Jhn4U=",
       "requires": {
         "loader-utils": "1.1.0",
         "schema-utils": "0.3.0"
@@ -11949,7 +11949,7 @@
     "tar": {
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/tar/-/tar-3.2.1.tgz",
-      "integrity": "sha512-ZSzds1E0IqutvMU8HxjMaU8eB7urw2fGwTq88ukDOVuUIh0656l7/P7LiVPxhO5kS4flcRJQk8USG+cghQbTUQ==",
+      "integrity": "sha1-mqjkHIjwnnbBZgdbxx+T1RZuYbE=",
       "requires": {
         "chownr": "1.0.1",
         "minipass": "2.3.3",
@@ -12129,7 +12129,7 @@
     "to-regex": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/to-regex/-/to-regex-3.0.2.tgz",
-      "integrity": "sha512-FWtleNAtZ/Ki2qtqej2CXTOayOH9bHDQF+Q48VpWyDXjbYxA4Yz8iDB31zXOBUlOHHKidDbqGVrTUvQMPmBGBw==",
+      "integrity": "sha1-E8/dmzNlUvMLUfM6iuG0Knp1mc4=",
       "requires": {
         "define-property": "2.0.2",
         "extend-shallow": "3.0.2",
@@ -12260,7 +12260,7 @@
     "typedarray-to-buffer": {
       "version": "3.1.5",
       "resolved": "https://registry.npmjs.org/typedarray-to-buffer/-/typedarray-to-buffer-3.1.5.tgz",
-      "integrity": "sha512-zdu8XMNEDepKKR+XYOXAVPtWui0ly0NtohUscw+UmaHiAWT8hrV1rr//H6V+0DvJ3OQ19S979M0laLfX8rm82Q==",
+      "integrity": "sha1-qX7nqf9CaRufeD/xvFES/j/KkIA=",
       "requires": {
         "is-typedarray": "1.0.0"
       }
@@ -12520,7 +12520,7 @@
     "url-loader": {
       "version": "0.6.2",
       "resolved": "https://registry.npmjs.org/url-loader/-/url-loader-0.6.2.tgz",
-      "integrity": "sha512-h3qf9TNn53BpuXTTcpC+UehiRrl0Cv45Yr/xWayApjw6G8Bg2dGke7rIwDQ39piciWCWrC+WiqLjOh3SUp9n0Q==",
+      "integrity": "sha1-oAenEJYg6dmI0UvOZ3od7Lmpk/c=",
       "requires": {
         "loader-utils": "1.1.0",
         "mime": "1.4.1",
@@ -12586,7 +12586,7 @@
     "use": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/use/-/use-3.1.0.tgz",
-      "integrity": "sha512-6UJEQM/L+mzC3ZJNM56Q4DFGLX/evKGRg15UJHGB9X5j5Z3AFbgZvjUh2yq/UJUY4U5dh7Fal++XbNg1uzpRAw==",
+      "integrity": "sha1-FHFr8D/f79AwQK71jYtLhfOnxUQ=",
       "requires": {
         "kind-of": "6.0.2"
       }
@@ -12627,7 +12627,7 @@
     "validate-npm-package-license": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.3.tgz",
-      "integrity": "sha512-63ZOUnL4SIXj4L0NixR3L1lcjO38crAbgrTpl28t8jjrfuiOBL5Iygm+60qPs/KsZGzPNg6Smnc/oY16QTjF0g==",
+      "integrity": "sha1-gWQ7y+8b3+zUYjeT3EZIlIupgzg=",
       "requires": {
         "spdx-correct": "3.0.0",
         "spdx-expression-parse": "3.0.0"
@@ -13579,7 +13579,7 @@
     "webpack-sources": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-1.1.0.tgz",
-      "integrity": "sha512-aqYp18kPphgoO5c/+NaUvEeACtZjMESmDChuD3NBciVpah3XpMEU9VAAtIaB1BsfJWWTSdv8Vv1m3T0aRk2dUw==",
+      "integrity": "sha1-oQHrrlnWUHNU1x2AE5UKOot6WlQ=",
       "requires": {
         "source-list-map": "2.0.0",
         "source-map": "0.6.1"
@@ -13588,7 +13588,7 @@
         "source-map": {
           "version": "0.6.1",
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
+          "integrity": "sha1-dHIq8y6WFOnCh6jQu95IteLxomM="
         }
       }
     },

--- a/templates/boilerplate/config/blockchain.js
+++ b/templates/boilerplate/config/blockchain.js
@@ -1,28 +1,31 @@
 module.exports = {
   development: {
     enabled: true,
-    networkType: "custom",
-    networkId: "1337",
-    isDev: true,
-    genesisBlock: "config/development/genesis.json",
-    datadir: ".embark/development/datadir",
-    mineWhenNeeded: true,
-    nodiscover: true,
-    maxpeers: 0,
-    rpcHost: "localhost",
-    rpcPort: 8545,
-    rpcCorsDomain: "auto",
-    proxy: true,
+    networkType: "custom", // Can be: testnet, rinkeby, livenet or custom, in which case, it will use the specified networkId
+    networkId: "1337", // Network id used when networkType is custom
+    isDev: true, // Uses and ephemeral proof-of-authority network with a pre-funded developer account, mining enabled
+    genesisBlock: "config/development/genesis.json", // Genesis block to initiate on first creation of a development node
+    datadir: ".embark/development/datadir", // Data directory for the databases and keystore
+    mineWhenNeeded: true, // Uses our custom script (if isDev is false) to mine only when needed
+    nodiscover: true, // Disables the peer discovery mechanism (manual peer addition)
+    maxpeers: 0, // Maximum number of network peers (network disabled if set to 0) (default: 25)
+    rpcHost: "localhost", // HTTP-RPC server listening interface (default: "localhost")
+    rpcPort: 8545, // HTTP-RPC server listening port (default: 8545)
+    rpcCorsDomain: "auto",  // Comma separated list of domains from which to accept cross origin requests (browser enforced)
+                            // When set to "auto", Embark will automatically set the cors to the address of the webserver
+    proxy: true, // Proxy is used to present meaningful information about transactions
     account: {
-      password: "config/development/password"
+      // "address": "", // When specified, uses that address instead of the default one for the network
+      password: "config/development/password" // Password to unlock the account
     },
-    targetGasLimit: 8000000,
-    wsOrigins: "auto",
-    wsRPC: true,
-    wsHost: "localhost",
-    wsPort: 8546,
-    simulatorMnemonic: "example exile argue silk regular smile grass bomb merge arm assist farm",
-    simulatorBlocktime: 0
+    targetGasLimit: 8000000, // Target gas limit sets the artificial target gas floor for the blocks to mine
+    wsRPC: true, // Enable the WS-RPC server
+    wsOrigins: "auto",  // Origins from which to accept websockets requests
+                        // When set to "auto", Embark will automatically set the cors to the address of the webserver
+    wsHost: "localhost", // WS-RPC server listening interface (default: "localhost")
+    wsPort: 8546, // WS-RPC server listening port (default: 8546)
+    simulatorMnemonic: "example exile argue silk regular smile grass bomb merge arm assist farm", // Mnemonic  used by the simulator to generate a wallet
+    simulatorBlocktime: 0 // Specify blockTime in seconds for automatic mining. Default is 0 and no auto-mining.
   },
   testnet: {
     enabled: true,
@@ -56,4 +59,4 @@ module.exports = {
     networkId: "123",
     bootnodes: ""
   }
-}
+};

--- a/templates/boilerplate/config/communication.js
+++ b/templates/boilerplate/config/communication.js
@@ -6,7 +6,7 @@ module.exports = {
     connection: {
       host: "localhost", // Host of the blockchain node
       port: 8546, // Port of the blockchain node
-      type: "ws" // Type of connection (ws or rps)
+      type: "ws" // Type of connection (ws or rpc)
     }
   }
 };

--- a/templates/boilerplate/config/communication.js
+++ b/templates/boilerplate/config/communication.js
@@ -1,13 +1,13 @@
 module.exports = {
   default: {
     enabled: true,
-    provider: "whisper",
-    available_providers: ["whisper"],
+    provider: "whisper", // Communication provider. Currently, Embark only supports whisper
+    available_providers: ["whisper"], // Array of available providers
     connection: {
-      host: "localhost",
-      port: 8546,
-      type: "ws"
+      host: "localhost", // Host of the blockchain node
+      port: 8546, // Port of the blockchain node
+      type: "ws" // Type of connection (ws or rps)
     }
   }
-}
+};
 

--- a/templates/boilerplate/config/contracts.js
+++ b/templates/boilerplate/config/contracts.js
@@ -1,11 +1,28 @@
 module.exports = {
-  // default applies to all enviroments
+  // default applies to all environments
   default: {
-    // rpc to deploy the contracts
+    // Blockchain node to deploy the contracts
     deployment: {
-      host: "localhost",
-      port: 8545,
-      type: "rpc"
+      host: "localhost", // Host of the blockchain node
+      port: 8545, // Port of the blockchain node
+      type: "rpc" // Type of connection (ws or rpc),
+      // Accounts to use instead of the default account to populate your wallet
+      /*,accounts: [
+        {
+          privateKey: "your_private_key",
+          balance: "5 ether"  // You can set the balance of the account in the dev environment
+                              // Balances are in Wei, but you can specify the unit with its name
+        },
+        {
+          privateKeyFile: "path/to/file" // You can put more than one key, separated by , or ;
+        },
+        {
+          mnemonic: "12 word mnemonic",
+          addressIndex: "0", // Optionnal. The index to start getting the address
+          numAddresses: "1", // Optionnal. The number of addresses to get
+          hdpath: "m/44'/60'/0'/0/" // Optionnal. HD derivation path
+        }
+      ]*/
     },
     // order of connections the dapp should connect to
     dappConnection: [
@@ -21,4 +38,4 @@ module.exports = {
       //}
     }
   }
-}
+};

--- a/templates/boilerplate/config/namesystem.js
+++ b/templates/boilerplate/config/namesystem.js
@@ -1,6 +1,6 @@
 module.exports = {
-	default: {
+  default: {
     available_providers: ["ens"],
     provider: "ens"
   }
-}
+};

--- a/templates/boilerplate/config/storage.js
+++ b/templates/boilerplate/config/storage.js
@@ -9,7 +9,12 @@ module.exports = {
       port: 5001
     },
     dappConnection: [
-      {provider: "ipfs", host: "localhost", port: 5001, getUrl: "http://localhost:8080/ipfs/"}
+      {
+        provider: "ipfs",
+        host: "localhost",
+        port: 5001,
+        getUrl: "http://localhost:8080/ipfs/"
+      }
     ]
   },
   development: {
@@ -21,4 +26,4 @@ module.exports = {
       getUrl: "http://localhost:8080/ipfs/"
     }
   }
-}
+};

--- a/templates/boilerplate/config/storage.js
+++ b/templates/boilerplate/config/storage.js
@@ -16,6 +16,12 @@ module.exports = {
         getUrl: "http://localhost:8080/ipfs/"
       }
     ]
+    // Configuration to start Swarm in the same terminal as `embark run`
+    /*,account: {
+      address: "YOUR_ACCOUNT_ADDRESS", // Address of account accessing Swarm
+      password: "PATH/TO/PASSWORD/FILE" // File containing the password of the account
+    },
+    swarmPath: "PATH/TO/SWARM/EXECUTABLE" // Path to swarm executable (default: swarm)*/
   },
   development: {
     enabled: true,

--- a/templates/boilerplate/config/webserver.js
+++ b/templates/boilerplate/config/webserver.js
@@ -2,4 +2,4 @@ module.exports = {
   enabled: true,
   host: "localhost",
   port: 8000
-}
+};

--- a/templates/boilerplate/test/contract_spec.js
+++ b/templates/boilerplate/test/contract_spec.js
@@ -1,24 +1,25 @@
-//describe("SimpleStorage", function() {
-//  this.timeout(0);
-//  before(function(done) {
-//    this.timeout(0);
-//    var contractsConfig = {
-//      "SimpleStorage": {
-//        args: [100]
-//      }
-//    };
-//    EmbarkSpec.deployAll(contractsConfig, () => { done() });
-//  });
-//
-//  it("should set constructor value", async function() {
-//    let result = await SimpleStorage.methods.storedData().call();
-//    assert.equal(result, 100);
-//  });
-//
-//  it("set storage value", async function() {
-//    await SimpleStorage.methods.set(150).send();
-//    let result = await SimpleStorage.methods.get().call();
-//    assert.equal(result, 150);
-//  });
-//
-//});
+// /*global contract, config, it, assert*/
+/*const SimpleStorage = require('Embark/contracts/SimpleStorage');
+
+config({
+  contracts: {
+    "SimpleStorage": {
+      args: [100]
+    }
+  }
+});
+
+contract("SimpleStorage", function () {
+  this.timeout(0);
+
+  it("should set constructor value", async function () {
+    let result = await SimpleStorage.methods.storedData().call();
+    assert.strictEqual(parseInt(result, 10), 100);
+  });
+
+  it("set storage value", async function () {
+    await SimpleStorage.methods.set(150).send();
+    let result = await SimpleStorage.methods.get().call();
+    assert.strictEqual(parseInt(result, 10), 150);
+  });
+});*/

--- a/templates/demo/config/blockchain.js
+++ b/templates/demo/config/blockchain.js
@@ -1,28 +1,31 @@
 module.exports = {
   development: {
     enabled: true,
-    networkType: "custom",
-    networkId: "1337",
-    isDev: true,
-    genesisBlock: "config/development/genesis.json",
-    datadir: ".embark/development/datadir",
-    mineWhenNeeded: true,
-    nodiscover: true,
-    maxpeers: 0,
-    rpcHost: "localhost",
-    rpcPort: 8545,
-    rpcCorsDomain: "auto",
-    proxy: true,
+    networkType: "custom", // Can be: testnet, rinkeby, livenet or custom, in which case, it will use the specified networkId
+    networkId: "1337", // Network id used when networkType is custom
+    isDev: true, // Uses and ephemeral proof-of-authority network with a pre-funded developer account, mining enabled
+    genesisBlock: "config/development/genesis.json", // Genesis block to initiate on first creation of a development node
+    datadir: ".embark/development/datadir", // Data directory for the databases and keystore
+    mineWhenNeeded: true, // Uses our custom script (if isDev is false) to mine only when needed
+    nodiscover: true, // Disables the peer discovery mechanism (manual peer addition)
+    maxpeers: 0, // Maximum number of network peers (network disabled if set to 0) (default: 25)
+    rpcHost: "localhost", // HTTP-RPC server listening interface (default: "localhost")
+    rpcPort: 8545, // HTTP-RPC server listening port (default: 8545)
+    rpcCorsDomain: "auto",  // Comma separated list of domains from which to accept cross origin requests (browser enforced)
+                            // When set to "auto", Embark will automatically set the cors to the address of the webserver
+    proxy: true, // Proxy is used to present meaningful information about transactions
     account: {
-      password: "config/development/password"
+      // "address": "", // When specified, uses that address instead of the default one for the network
+      password: "config/development/password" // Password to unlock the account
     },
-    targetGasLimit: 8000000,
-    wsOrigins: "auto",
-    wsRPC: true,
-    wsHost: "localhost",
-    wsPort: 8546,
-    simulatorMnemonic: "example exile argue silk regular smile grass bomb merge arm assist farm",
-    simulatorBlocktime: 0
+    targetGasLimit: 8000000, // Target gas limit sets the artificial target gas floor for the blocks to mine
+    wsRPC: true, // Enable the WS-RPC server
+    wsOrigins: "auto",  // Origins from which to accept websockets requests
+                        // When set to "auto", Embark will automatically set the cors to the address of the webserver
+    wsHost: "localhost", // WS-RPC server listening interface (default: "localhost")
+    wsPort: 8546, // WS-RPC server listening port (default: 8546)
+    simulatorMnemonic: "example exile argue silk regular smile grass bomb merge arm assist farm", // Mnemonic  used by the simulator to generate a wallet
+    simulatorBlocktime: 0 // Specify blockTime in seconds for automatic mining. Default is 0 and no auto-mining.
   },
   testnet: {
     enabled: true,
@@ -56,4 +59,4 @@ module.exports = {
     networkId: "123",
     bootnodes: ""
   }
-}
+};

--- a/templates/demo/config/communication.js
+++ b/templates/demo/config/communication.js
@@ -6,7 +6,7 @@ module.exports = {
     connection: {
       host: "localhost", // Host of the blockchain node
       port: 8546, // Port of the blockchain node
-      type: "ws" // Type of connection (ws or rps)
+      type: "ws" // Type of connection (ws or rpc)
     }
   }
 };

--- a/templates/demo/config/communication.js
+++ b/templates/demo/config/communication.js
@@ -1,12 +1,12 @@
 module.exports = {
   default: {
     enabled: true,
-    provider: "whisper",
-    available_providers: ["whisper"],
+    provider: "whisper", // Communication provider. Currently, Embark only supports whisper
+    available_providers: ["whisper"], // Array of available providers
     connection: {
-      host: "localhost",
-      port: 8546,
-      type: "ws"
+      host: "localhost", // Host of the blockchain node
+      port: 8546, // Port of the blockchain node
+      type: "ws" // Type of connection (ws or rps)
     }
   }
-}
+};

--- a/templates/demo/config/contracts.js
+++ b/templates/demo/config/contracts.js
@@ -1,11 +1,28 @@
 module.exports = {
-  // default applies to all enviroments
+  // default applies to all environments
   default: {
-    // rpc to deploy the contracts
+    // Blockchain node to deploy the contracts
     deployment: {
-      host: "localhost",
-      port: 8545,
-      type: "rpc"
+      host: "localhost", // Host of the blockchain node
+      port: 8545, // Port of the blockchain node
+      type: "rpc" // Type of connection (ws or rpc),
+      // Accounts to use instead of the default account to populate your wallet
+      /*,accounts: [
+        {
+          privateKey: "your_private_key",
+          balance: "5 ether"  // You can set the balance of the account in the dev environment
+                              // Balances are in Wei, but you can specify the unit with its name
+        },
+        {
+          privateKeyFile: "path/to/file" // You can put more than one key, separated by , or ;
+        },
+        {
+          mnemonic: "12 word mnemonic",
+          addressIndex: "0", // Optionnal. The index to start getting the address
+          numAddresses: "1", // Optionnal. The number of addresses to get
+          hdpath: "m/44'/60'/0'/0/" // Optionnal. HD derivation path
+        }
+      ]*/
     },
     // order of connections the dapp should connect to
     dappConnection: [
@@ -17,8 +34,8 @@ module.exports = {
     contracts: {
       SimpleStorage: {
         fromIndex: 0,
-        args: [ 100 ]
+        args: [100]
       }
     }
   }
-}
+};

--- a/templates/demo/config/namesystem.js
+++ b/templates/demo/config/namesystem.js
@@ -3,4 +3,4 @@ module.exports = {
     available_providers: ["ens"],
     provider: "ens"
   }
-}
+};

--- a/templates/demo/config/storage.js
+++ b/templates/demo/config/storage.js
@@ -9,7 +9,12 @@ module.exports = {
       port: 5001
     },
     dappConnection: [
-      {provider: "ipfs", host: "localhost", port: 5001, getUrl: "http://localhost:8080/ipfs/"}
+      {
+        provider:"ipfs",
+        host: "localhost",
+        port: 5001,
+        getUrl: "http://localhost:8080/ipfs/"
+      }
     ]
   },
   development: {
@@ -21,4 +26,4 @@ module.exports = {
       getUrl: "http://localhost:8080/ipfs/"
     }
   }
-}
+};

--- a/templates/demo/config/storage.js
+++ b/templates/demo/config/storage.js
@@ -16,6 +16,12 @@ module.exports = {
         getUrl: "http://localhost:8080/ipfs/"
       }
     ]
+    // Configuration to start Swarm in the same terminal as `embark run`
+    /*,account: {
+      address: "YOUR_ACCOUNT_ADDRESS", // Address of account accessing Swarm
+      password: "PATH/TO/PASSWORD/FILE" // File containing the password of the account
+    },
+    swarmPath: "PATH/TO/SWARM/EXECUTABLE" // Path to swarm executable (default: swarm)*/
   },
   development: {
     enabled: true,

--- a/templates/demo/config/webserver.js
+++ b/templates/demo/config/webserver.js
@@ -2,4 +2,4 @@ module.exports = {
   enabled: true,
   host: "localhost",
   port: 8000
-}
+};

--- a/templates/demo/test/simple_storage_spec.js
+++ b/templates/demo/test/simple_storage_spec.js
@@ -1,24 +1,25 @@
-describe("SimpleStorage", function() {
+/*global contract, config, it, assert*/
+const SimpleStorage = require('Embark/contracts/SimpleStorage');
+
+config({
+  contracts: {
+    "SimpleStorage": {
+      args: [100]
+    }
+  }
+});
+
+contract("SimpleStorage", function () {
   this.timeout(0);
-  before(function(done) {
-    this.timeout(0);
-    var contractsConfig = {
-      "SimpleStorage": {
-        args: [100]
-      }
-    };
-    EmbarkSpec.deployAll(contractsConfig, () => { done() });
-  });
 
-  it("should set constructor value", async function() {
+  it("should set constructor value", async function () {
     let result = await SimpleStorage.methods.storedData().call();
-    assert.equal(result, 100);
+    assert.strictEqual(parseInt(result, 10), 100);
   });
 
-  it("set storage value", async function() {
+  it("set storage value", async function () {
     await SimpleStorage.methods.set(150).send();
     let result = await SimpleStorage.methods.get().call();
-    assert.equal(result, 150);
+    assert.strictEqual(parseInt(result, 10), 150);
   });
-
 });

--- a/templates/simple/contracts.js
+++ b/templates/simple/contracts.js
@@ -1,11 +1,28 @@
 module.exports = {
-  // default applies to all enviroments
+  // default applies to all environments
   default: {
-    // rpc to deploy the contracts
+    // Blockchain node to deploy the contracts
     deployment: {
-      host: "localhost",
-      port: 8545,
-      type: "rpc"
+      host: "localhost", // Host of the blockchain node
+      port: 8545, // Port of the blockchain node
+      type: "rpc" // Type of connection (ws or rpc),
+      // Accounts to use instead of the default account to populate your wallet
+      /*,accounts: [
+        {
+          privateKey: "your_private_key",
+          balance: "5 ether"  // You can set the balance of the account in the dev environment
+                              // Balances are in Wei, but you can specify the unit with its name
+        },
+        {
+          privateKeyFile: "path/to/file" // You can put more than one key, separated by , or ;
+        },
+        {
+          mnemonic: "12 word mnemonic",
+          addressIndex: "0", // Optionnal. The index to start getting the address
+          numAddresses: "1", // Optionnal. The number of addresses to get
+          hdpath: "m/44'/60'/0'/0/" // Optionnal. HD derivation path
+        }
+      ]*/
     },
     // order of connections the dapp should connect to
     dappConnection: [
@@ -21,4 +38,4 @@ module.exports = {
       //}
     }
   }
-}
+};

--- a/templates/simple/test/contract_spec.js
+++ b/templates/simple/test/contract_spec.js
@@ -1,24 +1,25 @@
-//describe("SimpleStorage", function() {
-//  this.timeout(0);
-//  before(function(done) {
-//    this.timeout(0);
-//    var contractsConfig = {
-//      "SimpleStorage": {
-//        args: [100]
-//      }
-//    };
-//    EmbarkSpec.deployAll(contractsConfig, () => { done() });
-//  });
-//
-//  it("should set constructor value", async function() {
-//    let result = await SimpleStorage.methods.storedData().call();
-//    assert.equal(result, 100);
-//  });
-//
-//  it("set storage value", async function() {
-//    await SimpleStorage.methods.set(150).send();
-//    let result = await SimpleStorage.methods.get().call();
-//    assert.equal(result, 150);
-//  });
-//
-//});
+// /*global contract, config, it, assert*/
+/*const SimpleStorage = require('Embark/contracts/SimpleStorage');
+
+config({
+  contracts: {
+    "SimpleStorage": {
+      args: [100]
+    }
+  }
+});
+
+contract("SimpleStorage", function () {
+  this.timeout(0);
+
+  it("should set constructor value", async function () {
+    let result = await SimpleStorage.methods.storedData().call();
+    assert.strictEqual(parseInt(result, 10), 100);
+  });
+
+  it("set storage value", async function () {
+    await SimpleStorage.methods.set(150).send();
+    let result = await SimpleStorage.methods.get().call();
+    assert.strictEqual(parseInt(result, 10), 150);
+  });
+});*/

--- a/test_apps/test_app/extensions/embark-service/index.js
+++ b/test_apps/test_app/extensions/embark-service/index.js
@@ -9,7 +9,6 @@ module.exports = function (embark) {
     return Haml.render(opts.source);
   });
 
-  embark.logger.info('patente', 'a goosee');
   embark.registerContractConfiguration({
     "default": {
       "contracts": {

--- a/test_apps/test_app/extensions/embark-service/index.js
+++ b/test_apps/test_app/extensions/embark-service/index.js
@@ -9,6 +9,7 @@ module.exports = function (embark) {
     return Haml.render(opts.source);
   });
 
+  embark.logger.info('patente', 'a goosee');
   embark.registerContractConfiguration({
     "default": {
       "contracts": {
@@ -25,16 +26,8 @@ module.exports = function (embark) {
 
   embark.registerActionForEvent("deploy:contract:beforeDeploy", (params, cb) => {
     embark.logger.info("applying beforeDeploy plugin...");
-    //console.dir(params);
-    //console.dir(cb);
-    //console.dir('------------------');
     cb();
   });
-
-  // NOTE: uncommenting this will make dappConnection stop working
-  //embark.registerClientWeb3Provider(function(options) {
-  //  return "web3 = new Web3(new Web3.providers.HttpProvider('http://" + options.rpcHost + ":" + options.rpcPort + "'));";
-  //});
 
   embark.registerConsoleCommand((cmd) => {
     if (cmd === "hello") {
@@ -45,7 +38,7 @@ module.exports = function (embark) {
   });
 
   embark.events.on("contractsDeployed", function() {
-    embark.logger.info("plugin says: your contracts have been deployed");
+    embark.logger.info("plugin says:", ' your contracts have been deployed');
   });
 
 };


### PR DESCRIPTION
Enables multiple arguments in the logger.
Removes the old plugin interception as it ended up catching all the logs of all the plugins and used only the name of the last plugin.
Now, plugins can log with multiple arguments and when using `embark.logger.x()` it will add the plugin's name (the real plugin) to the log.