### PR TITLE
Fix log interception and enable multi-argument logging #2

### DIFF
--- a/lib/core/logger.js
+++ b/lib/core/logger.js
@@ -11,57 +11,57 @@ class Logger {
   }
 }
 
-Logger.prototype.writeToFile = function (txt) {
+Logger.prototype.writeToFile = function () {
   if (!this.logFile) {
     return;
   }
 
-  fs.appendFileSync(this.logFile, "\n" + txt);
+  fs.appendFileSync(this.logFile, "\n" + Array.from(arguments).join(' '));
 };
 
-Logger.prototype.error = function (txt) {
-  if (!txt || !(this.shouldLog('error'))) {
+Logger.prototype.error = function () {
+  if (!arguments.length || !(this.shouldLog('error'))) {
     return;
   }
-  this.events.emit("log", "error", txt);
-  this.logFunction(txt.red);
-  this.writeToFile("[error]: " + txt);
+  this.events.emit("log", "error", ...arguments);
+  this.logFunction(...Array.from(arguments).map(t => t.red));
+  this.writeToFile("[error]: ", ...arguments);
 };
 
-Logger.prototype.warn = function (txt) {
-  if (!txt || !(this.shouldLog('warn'))) {
+Logger.prototype.warn = function () {
+  if (!arguments.length || !(this.shouldLog('warn'))) {
     return;
   }
-  this.events.emit("log", "warning", txt);
-  this.logFunction(txt.yellow);
-  this.writeToFile("[warning]: " + txt);
+  this.events.emit("log", "warning", ...arguments);
+  this.logFunction(...Array.from(arguments).map(t => t.yellow));
+  this.writeToFile("[warning]: ", ...arguments);
 };
 
-Logger.prototype.info = function (txt) {
-  if (!txt || !(this.shouldLog('info'))) {
+Logger.prototype.info = function () {
+  if (!arguments.length || !(this.shouldLog('info'))) {
     return;
   }
-  this.events.emit("log", "info", txt);
-  this.logFunction(txt.green);
-  this.writeToFile("[info]: " + txt);
+  this.events.emit("log", "info", ...arguments);
+  this.logFunction(...Array.from(arguments).map(t => t.green));
+  this.writeToFile("[info]: ", ...arguments);
 };
 
-Logger.prototype.debug = function (txt) {
-  if (!txt || !(this.shouldLog('debug'))) {
+Logger.prototype.debug = function () {
+  if (!arguments.length || !(this.shouldLog('debug'))) {
     return;
   }
-  this.events.emit("log", "debug", txt);
-  this.logFunction(txt);
-  this.writeToFile("[debug]: " + txt);
+  this.events.emit("log", "debug", ...arguments);
+  this.logFunction(...arguments);
+  this.writeToFile("[debug]: ", ...arguments);
 };
 
-Logger.prototype.trace = function (txt) {
-  if (!txt || !(this.shouldLog('trace'))) {
+Logger.prototype.trace = function () {
+  if (!arguments.length || !(this.shouldLog('trace'))) {
     return;
   }
-  this.events.emit("log", "trace", txt);
-  this.logFunction(txt);
-  this.writeToFile("[trace]: " + txt);
+  this.events.emit("log", "trace", ...arguments);
+  this.logFunction(...arguments);
+  this.writeToFile("[trace]: ", ...arguments);
 };
 
 Logger.prototype.dir = function (txt) {

--- a/lib/core/plugin.js
+++ b/lib/core/plugin.js
@@ -29,7 +29,8 @@ var Plugin = function(options) {
   this.afterContractsDeployActions = [];
   this.onDeployActions = [];
   this.eventActions = {};
-  this.logger = options.logger;
+  this._loggerObject = options.logger;
+  this.logger = this._loggerObject; // Might get changed if we do intercept
   this.events = options.events;
   this.config = options.config;
   this.env = options.env;
@@ -43,6 +44,22 @@ var Plugin = function(options) {
   if (!Array.isArray(this.acceptedContext)) {
     this.acceptedContext = [this.acceptedContext];
   }
+};
+
+Plugin.prototype._log = function(type) {
+  this._loggerObject[type](this.name + ':', ...[].slice.call(arguments, 1));
+};
+
+Plugin.prototype.setUpLogger = function () {
+  this.logger = {
+    log: this._log.bind(this, 'log'),
+    warn: this._log.bind(this, 'warn'),
+    error: this._log.bind(this, 'error'),
+    info: this._log.bind(this, 'info'),
+    debug: this._log.bind(this, 'debug'),
+    trace: this._log.bind(this, 'trace'),
+    dir: this._log.bind(this, 'dir')
+  };
 };
 
 Plugin.prototype.isContextValid = function() {
@@ -65,7 +82,7 @@ Plugin.prototype.loadPlugin = function() {
   }
   this.loaded = true;
   if (this.shouldInterceptLogs) {
-    this.interceptLogs(this.pluginModule);
+    this.setUpLogger();
   }
   (this.pluginModule.call(this, this));
 };
@@ -83,37 +100,6 @@ Plugin.prototype.pathToFile = function(filename) {
     throw new Error('pluginPath not defined for plugin: ' + this.name);
   }
   return utils.joinPath(this.pluginPath, filename);
-};
-
-Plugin.prototype.interceptLogs = function(context) {
-  var self = this;
-  // TODO: this is a bit nasty, figure out a better way
-  context.console = context.console || console;
-
-  //context.console.error  = function(txt) {
-  //  // TODO: logger should support an array instead of a single argument
-  //  //self.logger.error.apply(self.logger, arguments);
-  //  self.logger.error(self.name + " > " + txt);
-  //};
-  context.console.log  = function(txt) {
-    self.logger.info(self.name + " > " + txt);
-  };
-  context.console.warn  = function(txt) {
-    self.logger.warn(self.name + " > " + txt);
-  };
-  context.console.info  = function(txt) {
-    self.logger.info(self.name + " > " + txt);
-  };
-  context.console.debug  = function(txt) {
-    // TODO: ue JSON.stringify
-    self.logger.debug(self.name + " > " + txt);
-  };
-  context.console.trace  = function(txt) {
-    self.logger.trace(self.name + " > " + txt);
-  };
-  context.console.dir  = function(txt) {
-    self.logger.dir(txt);
-  };
 };
 
 // TODO: add deploy provider

--- a/lib/dashboard/monitor.js
+++ b/lib/dashboard/monitor.js
@@ -77,8 +77,8 @@ class Dashboard {
     this.screen.render();
   }
 
-  logEntry(text) {
-    this.logText.log(text);
+  logEntry() {
+    this.logText.log(...arguments);
     this.screen.render();
   }
 

--- a/test_apps/test_app/extensions/embark-service/index.js
+++ b/test_apps/test_app/extensions/embark-service/index.js
@@ -9,7 +9,6 @@ module.exports = function (embark) {
     return Haml.render(opts.source);
   });
 
-  embark.logger.info('patente', 'a goosee');
   embark.registerContractConfiguration({
     "default": {
       "contracts": {

--- a/test_apps/test_app/extensions/embark-service/index.js
+++ b/test_apps/test_app/extensions/embark-service/index.js
@@ -9,6 +9,7 @@ module.exports = function (embark) {
     return Haml.render(opts.source);
   });
 
+  embark.logger.info('patente', 'a goosee');
   embark.registerContractConfiguration({
     "default": {
       "contracts": {
@@ -25,16 +26,8 @@ module.exports = function (embark) {
 
   embark.registerActionForEvent("deploy:contract:beforeDeploy", (params, cb) => {
     embark.logger.info("applying beforeDeploy plugin...");
-    //console.dir(params);
-    //console.dir(cb);
-    //console.dir('------------------');
     cb();
   });
-
-  // NOTE: uncommenting this will make dappConnection stop working
-  //embark.registerClientWeb3Provider(function(options) {
-  //  return "web3 = new Web3(new Web3.providers.HttpProvider('http://" + options.rpcHost + ":" + options.rpcPort + "'));";
-  //});
 
   embark.registerConsoleCommand((cmd) => {
     if (cmd === "hello") {
@@ -45,7 +38,7 @@ module.exports = function (embark) {
   });
 
   embark.events.on("contractsDeployed", function() {
-    embark.logger.info("plugin says: your contracts have been deployed");
+    embark.logger.info("plugin says:", ' your contracts have been deployed');
   });
 
 };


### PR DESCRIPTION
Enables multiple arguments in the logger.
Removes the old plugin interception as it ended up catching all the logs of all the plugins and used only the name of the last plugin.
Now, plugins can log with multiple arguments and when using embark.logger.x() it will add the plugin's name (the real plugin) to the log.