### PR TITLE
Registrar deployment

### DIFF
--- a/lib/core/config.js
+++ b/lib/core/config.js
@@ -265,7 +265,10 @@ Config.prototype.loadNameSystemConfigFile = function() {
     "default": {
       "available_providers": ["ens"],
       "provider": "ens",
-      "enabled": true
+      "enabled": true,
+      "register": {
+        "rootDomain": "embark"
+      }
     }
   };
 

--- a/lib/modules/ens/contracts/FIFSRegistrar.sol
+++ b/lib/modules/ens/contracts/FIFSRegistrar.sol
@@ -1,0 +1,36 @@
+pragma solidity ^0.4.18;
+
+import './ENS.sol';
+
+/**
+ * A registrar that allocates subdomains to the first person to claim them.
+ */
+contract FIFSRegistrar {
+    ENS ens;
+    bytes32 rootNode;
+
+    modifier only_owner(bytes32 subnode) {
+        address currentOwner = ens.owner(keccak256(rootNode, subnode));
+        require(currentOwner == 0 || currentOwner == msg.sender);
+        _;
+    }
+
+    /**
+     * Constructor.
+     * @param ensAddr The address of the ENS registry.
+     * @param node The node that this registrar administers.
+     */
+    function FIFSRegistrar(ENS ensAddr, bytes32 node) public {
+        ens = ensAddr;
+        rootNode = node;
+    }
+
+    /**
+     * Register a name, or change the owner of an existing registration.
+     * @param subnode The hash of the label to register.
+     * @param owner The address of the new owner.
+     */
+    function register(bytes32 subnode, address owner) public only_owner(subnode) {
+        ens.setSubnodeOwner(rootNode, subnode, owner);
+    }
+}

--- a/lib/modules/ens/index.js
+++ b/lib/modules/ens/index.js
@@ -1,5 +1,6 @@
 const fs = require('../../core/fs.js');
 const utils = require('../../utils/utils.js');
+const namehash = require('eth-ens-namehash');
 
 class ENS {
   constructor(embark, _options) {
@@ -7,12 +8,13 @@ class ENS {
     this.logger = embark.logger;
     this.events = embark.events;
     this.namesConfig = embark.config.namesystemConfig;
+    this.registration = this.namesConfig.register;
     this.embark = embark;
-    this.ensRegistry = null;
-    this.ensResolver = null;
 
     this.addENSToEmbarkJS();
     this.configureENSRegistry();
+    this.configureRootRegistrar();
+
     self.embark.registerActionForEvent("contracts:deploy:afterAll", (cb) => {      
       self.events.request('contracts:contract', "ENSRegistry", (contract) => {
         let config = {
@@ -55,6 +57,7 @@ class ENS {
 
   configureENSRegistry() {
     const self = this;
+
     self.embark.registerContractConfiguration({
       "default": {
         "gas": "auto",
@@ -65,24 +68,38 @@ class ENS {
       },
       "ropsten": {
         "ENSRegistry": {
-          "address": "0x112234455c3a32fd11230c42e7bccd4a84e02010",
-          "args": []
+          "address": "0x112234455c3a32fd11230c42e7bccd4a84e02010"
         }
       },
       "rinkeby": {
         "ENSRegistry": {
-          "address": "0xe7410170f87102DF0055eB195163A03B7F2Bff4A",
-          "args": []
+          "address": "0xe7410170f87102DF0055eB195163A03B7F2Bff4A"
         }
       },
       "livenet": {
         "ENSRegistry": {
-          "address": "0x314159265dd8dbb310642f98f50c066173c1259b",
-          "args": []
+          "address": "0x314159265dd8dbb310642f98f50c066173c1259b"
         }
       }
     });
+
     self.embark.events.request("config:contractsFiles:add", self.embark.pathToFile('./contracts/ENSRegistry.sol'));
+  }
+
+  configureRootRegistrar() {
+    const self = this;
+    let rootNode = namehash.hash(self.registration.rootDomain);
+    self.embark.registerContractConfiguration({
+      "default": {
+        "gas": "auto",
+        "FIFSRegistrar": {
+          "deploy": true,
+          "args": ["$ENSRegistry", rootNode],
+          "onDeploy": ["ENSRegistry.methods.setOwner(0, FIFSRegistrar.options.address).send()"]
+        }
+      }
+    });
+    self.embark.events.request("config:contractsFiles:add", self.embark.pathToFile('./contracts/FIFSRegistrar.sol'));
   }
 
   addSetProvider(config) {

--- a/lib/modules/ens/index.js
+++ b/lib/modules/ens/index.js
@@ -61,24 +61,32 @@ class ENS {
     self.embark.registerContractConfiguration({
       "default": {
         "gas": "auto",
-        "ENSRegistry": {
-          "deploy": true,
-          "args": []
+        "contracts": {
+          "ENSRegistry": {
+            "deploy": true,
+            "args": []
+          }
         }
       },
       "ropsten": {
-        "ENSRegistry": {
-          "address": "0x112234455c3a32fd11230c42e7bccd4a84e02010"
+        "contracts": {
+          "ENSRegistry": {
+            "address": "0x112234455c3a32fd11230c42e7bccd4a84e02010"
+          }
         }
       },
       "rinkeby": {
-        "ENSRegistry": {
-          "address": "0xe7410170f87102DF0055eB195163A03B7F2Bff4A"
+        "contracts": {
+          "ENSRegistry": {
+            "address": "0xe7410170f87102DF0055eB195163A03B7F2Bff4A"
+          }
         }
       },
       "livenet": {
-        "ENSRegistry": {
-          "address": "0x314159265dd8dbb310642f98f50c066173c1259b"
+        "contracts": {
+          "ENSRegistry": {
+            "address": "0x314159265dd8dbb310642f98f50c066173c1259b"
+          }
         }
       }
     });
@@ -92,10 +100,12 @@ class ENS {
     self.embark.registerContractConfiguration({
       "default": {
         "gas": "auto",
-        "FIFSRegistrar": {
-          "deploy": true,
-          "args": ["$ENSRegistry", rootNode],
-          "onDeploy": ["ENSRegistry.methods.setOwner(0, FIFSRegistrar.options.address).send()"]
+        "contracts": {
+          "FIFSRegistrar": {
+            "deploy": true,
+            "args": ["$ENSRegistry", rootNode],
+            "onDeploy": ["ENSRegistry.methods.setOwner(0, FIFSRegistrar.options.address).send()"]
+          }
         }
       }
     });

--- a/lib/modules/ens/index.js
+++ b/lib/modules/ens/index.js
@@ -107,7 +107,10 @@ class ENS {
             "onDeploy": ["ENSRegistry.methods.setOwner(0, FIFSRegistrar.options.address).send()"]
           }
         }
-      }
+      },
+      "ropsten": {},
+      "rinkeby": {},
+      "livenet": {}
     });
     self.embark.events.request("config:contractsFiles:add", self.embark.pathToFile('./contracts/FIFSRegistrar.sol'));
   }

--- a/test_apps/test_app/config/namesystem.json
+++ b/test_apps/test_app/config/namesystem.json
@@ -1,0 +1,10 @@
+{
+  "default": {
+    "enabled": true,
+    "available_providers": ["ens"],
+    "provider": "ens",
+    "register": {
+      "rootDomain": "embark"
+    }
+  }
+}


### PR DESCRIPTION
Deploys the registrar for ENS which is necessary to begin registration of contracts. Starting with a FIFS Registrar, might go to various types of Registrars in the future. Root name is used to denote the root node of the name system. 