### PR TITLE
Fix for `embark build --contracts` writing into the pipeline

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -194,7 +194,9 @@ class Embark {
         engine.startService("libraryManager");
         engine.startService("codeRunner");
         engine.startService("web3");
-        engine.startService("pipeline");
+        if(!options.onlyCompile){
+          engine.startService("pipeline");
+        }
         engine.startService("deployment", {onlyCompile: options.onlyCompile});
         engine.startService("storage");
         engine.startService("codeGenerator");
@@ -209,6 +211,9 @@ class Embark {
         engine.logger.info("Finished deploying".underline);
         // Necessary log for simple projects. This event is trigger to soon because there is no file
         // Also, not exiting straight after the deploy leaves time for async afterDeploys to finish
+        if(options.onlyCompile){
+          return callback();
+        }
         engine.logger.info("If you have no files to build, you can exit now with CTRL+C");
         engine.events.on('outputDone', callback);
       }

--- a/lib/index.js
+++ b/lib/index.js
@@ -194,7 +194,7 @@ class Embark {
         engine.startService("libraryManager");
         engine.startService("codeRunner");
         engine.startService("web3");
-        if(!options.onlyCompile){
+        if (!options.onlyCompile) {
           engine.startService("pipeline");
         }
         engine.startService("deployment", {onlyCompile: options.onlyCompile});
@@ -208,24 +208,30 @@ class Embark {
         });
       },
       function waitForWriteFinish(callback) {
+        if (options.onlyCompile) {
+          engine.logger.info("Finished compiling".underline);
+          return callback(null, true);
+        }
         engine.logger.info("Finished deploying".underline);
-        // Necessary log for simple projects. This event is trigger to soon because there is no file
-        // Also, not exiting straight after the deploy leaves time for async afterDeploys to finish
-        if(options.onlyCompile){
+        if (!engine.config.assetFiles || !Object.keys(engine.config.assetFiles).length) {
           return callback();
         }
-        engine.logger.info("If you have no files to build, you can exit now with CTRL+C");
-        engine.events.on('outputDone', callback);
+        engine.events.on('outputDone', (err) => {
+          engine.logger.info(__("finished building").underline);
+          callback(err, true);
+        });
       }
-    ], function (err, _result) {
+    ], function (err, canExit) {
       if (err) {
         engine.logger.error(err.message);
         engine.logger.debug(err.stack);
-      } else {
-        engine.logger.info(__("finished building").underline);
       }
-      // needed due to child processes
-      process.exit();
+
+      if (canExit || !engine.config.contractsConfig.afterDeploy || !engine.config.contractsConfig.afterDeploy.length) {
+        process.exit();
+      }
+      engine.logger.info(__('Waiting for after deploy to finish...'));
+      engine.logger.info(__('You can exit with CTRL+C when after deploy completes'));
     });
   }
 


### PR DESCRIPTION
`embark build --contracts` was writing to the pipeline with or without the `--contracts` flag. Needed to add a condition to check if the flag was present before loading the pipeline. Additionally, finish the build process a tad earlier depending on whether or not the `--contracts` flag was set.