### PR TITLE
When communication is disabled in config, do not run the module in em…

### DIFF
--- a/lib/core/config.js
+++ b/lib/core/config.js
@@ -119,8 +119,14 @@ Config.prototype._updateBlockchainCors = function(){
   }
 
   let cors = corsParts.join(',');
-  if(blockchainConfig.rpcCorsDomain === 'auto' && cors.length) blockchainConfig.rpcCorsDomain = cors;
-  if(blockchainConfig.wsOrigins === 'auto' && cors.length) blockchainConfig.wsOrigins = cors;
+  if(blockchainConfig.rpcCorsDomain === 'auto'){ 
+    if(cors.length) blockchainConfig.rpcCorsDomain = cors;
+    else blockchainConfig.rpcCorsDomain = '';
+  }
+  if(blockchainConfig.wsOrigins === 'auto'){ 
+    if(cors.length) blockchainConfig.wsOrigins = cors;
+    else blockchainConfig.wsOrigins = '';
+  }
 };
 
 Config.prototype._mergeConfig = function(configFilePath, defaultConfig, env, enabledByDefault) {

--- a/lib/modules/whisper/index.js
+++ b/lib/modules/whisper/index.js
@@ -11,6 +11,10 @@ class Whisper {
     this.web3 = new Web3();
     this.embark = embark;
 
+    if (!this.communicationConfig.enabled) {
+      return;
+    }
+
     this.connectToProvider();
     this.setServiceCheck();
     this.addWhisperToEmbarkJS();


### PR DESCRIPTION
…bark.

Previous to this change, `Geth: WARN [06-25|16:46:26] origin 'embark' not allowed on WS-RPC interface` would appear in the logs when the module was run while disabled.

Updated the cors component so that when `rpcCorsDomain` and `wsOrigins` are set to `'auto'`, and all components are disabled `rpcCorsDomain` and `wsOrigins` are passed as a null parameter to geth as opposed to being passed as `'auto'`.