### PR TITLE
Abandons all storage initialisation routines if storage is disabled i…

### DIFF
--- a/lib/modules/storage/index.js
+++ b/lib/modules/storage/index.js
@@ -17,6 +17,8 @@ class Storage {
     this._events = options.events;
     this._logger = options.logger;
 
+    if(!this._storageConfig.enabled) return;
+
     // filter list of dapp connections based on available_providers set in config
     let hasSwarm = _.contains(this._storageConfig.available_providers, 'swarm'); // don't need to eval this in every loop iteration
     // contains valid dapp storage providers


### PR DESCRIPTION
…n config.

Meant to fix IPFS services still running when creating an app with `--simple`.