### PR TITLE
Display gas cost instead of duration for tests

### DIFF
--- a/lib/cmd.js
+++ b/lib/cmd.js
@@ -184,12 +184,13 @@ class Cmd {
   test() {
     program
       .command('test [file]')
+      .option('-d , --gasDetails', __('When set, will print the gas cost for each contract'))
       .option('--locale [locale]', __('language to use (default: en)'))
       .option('--loglevel [loglevel]', __('level of logging to display') + ' ["error", "warn", "info", "debug", "trace"]', /^(error|warn|info|debug|trace)$/i, 'warn')
       .description(__('run tests'))
       .action(function (file, options) {
         i18n.setOrDetectLocale(options.locale);
-        embark.runTests({file, loglevel: options.loglevel});
+        embark.runTests({file, loglevel: options.loglevel, gasDetails: options.gasDetails});
       });
   }
 

--- a/lib/contracts/contract_deployer.js
+++ b/lib/contracts/contract_deployer.js
@@ -242,6 +242,7 @@ class ContractDeployer {
           self.logger.info(contract.className.bold.cyan + " " + __("deployed at").green + " " + receipt.contractAddress.bold.cyan);
           contract.deployedAddress = receipt.contractAddress;
           contract.transactionHash = receipt.transactionHash;
+          receipt.className = contract.className;
           self.events.emit("deploy:contract:receipt", receipt);
           self.events.emit("deploy:contract:deployed", contract);
 

--- a/lib/tests/reporter.js
+++ b/lib/tests/reporter.js
@@ -9,10 +9,12 @@ class EmbarkSpec extends Base {
     self.embarkEvents = options.reporterOptions.events;
     let indents = 0;
     let n = 0;
+    self.stats.gasCost = 0;
 
     function onContractReceipt(receipt) {
-      console.log(receipt.className, receipt.gasUsed);
+      self.stats.gasCost += receipt.gasUsed;
     }
+
     self.embarkEvents.on("deploy:contract:receipt", onContractReceipt);
 
     function indent() {
@@ -62,10 +64,47 @@ class EmbarkSpec extends Base {
       console.log(indent() + color('fail', '  %d) %s'), ++n, test.title);
     });
 
-    runner.once('end', function() {
+    runner.once('end', function () {
+      runner.removeAllListeners();
       self.embarkEvents.removeListener("deploy:contract:receipt", onContractReceipt);
       self.epilogue();
     });
+  }
+
+  epilogue() {
+    const stats = this.stats;
+    let fmt;
+
+    console.log();
+
+    // passes
+    fmt = color('bright pass', ' ') +
+      color('green', ' %d passing') +
+      color('light', ' (%s gas)');
+
+    console.log(fmt,
+      stats.passes || 0,
+      stats.gasCost);
+
+    // pending
+    if (stats.pending) {
+      fmt = color('pending', ' ') +
+        color('pending', ' %d pending');
+
+      console.log(fmt, stats.pending);
+    }
+
+    // failures
+    if (stats.failures) {
+      fmt = color('fail', '  %d failing');
+
+      console.log(fmt, stats.failures);
+
+      Base.list(this.failures);
+      console.log();
+    }
+
+    console.log();
   }
 }
 

--- a/lib/tests/reporter.js
+++ b/lib/tests/reporter.js
@@ -8,6 +8,7 @@ class EmbarkSpec extends Base {
     const self = this;
     self.embarkEvents = options.reporterOptions.events;
     self.gasDetails = options.reporterOptions.gasDetails;
+    self.gasLimit = options.reporterOptions.gasLimit;
     let indents = 0;
     let n = 0;
     self.stats.gasCost = 0;
@@ -18,7 +19,7 @@ class EmbarkSpec extends Base {
         const fmt = color('bright pass', ' ') +
           color('green', ' %s') +
           ' deployed for ' +
-          color('green', '%s') +
+          color(self.getGasColor(receipt.gasUsed), '%s') +
           color('light', ' gas');
 
         console.log(fmt, receipt.className, receipt.gasUsed);
@@ -84,6 +85,16 @@ class EmbarkSpec extends Base {
     });
   }
 
+  getGasColor(gasCost) {
+    if (gasCost <= this.gasLimit/10) {
+      return 'fast';
+    }
+    if (gasCost <= 3 * (this.gasLimit/4)) {
+      return 'medium';
+    }
+    return 'slow';
+  }
+
   epilogue() {
     const stats = this.stats;
     let fmt;
@@ -93,7 +104,7 @@ class EmbarkSpec extends Base {
     // passes
     fmt = color('bright pass', ' ') +
       color('green', ' %d passing') +
-      color('light', ' (%s gas)');
+      color(this.getGasColor(stats.gasCost), ' (%s gas)');
 
     console.log(fmt,
       stats.passes || 0,

--- a/lib/tests/reporter.js
+++ b/lib/tests/reporter.js
@@ -7,12 +7,22 @@ class EmbarkSpec extends Base {
 
     const self = this;
     self.embarkEvents = options.reporterOptions.events;
+    self.gasDetails = options.reporterOptions.gasDetails;
     let indents = 0;
     let n = 0;
     self.stats.gasCost = 0;
 
     function onContractReceipt(receipt) {
       self.stats.gasCost += receipt.gasUsed;
+      if (self.gasDetails) {
+        const fmt = color('bright pass', ' ') +
+          color('green', ' %s') +
+          ' deployed for ' +
+          color('green', '%s') +
+          color('light', ' gas');
+
+        console.log(fmt, receipt.className, receipt.gasUsed);
+      }
     }
 
     self.embarkEvents.on("deploy:contract:receipt", onContractReceipt);
@@ -27,6 +37,9 @@ class EmbarkSpec extends Base {
 
     runner.on('suite', function (suite) {
       ++indents;
+      if (self.gasDetails) {
+        console.log();
+      }
       console.log(color('suite', '%s%s'), indent(), suite.title);
     });
 

--- a/lib/tests/reporter.js
+++ b/lib/tests/reporter.js
@@ -1,0 +1,72 @@
+const Base = require('mocha/lib/reporters/base');
+const color = Base.color;
+
+class EmbarkSpec extends Base {
+  constructor(runner, options) {
+    super(runner, options);
+
+    const self = this;
+    self.embarkEvents = options.reporterOptions.events;
+    let indents = 0;
+    let n = 0;
+
+    function onContractReceipt(receipt) {
+      console.log(receipt.className, receipt.gasUsed);
+    }
+    self.embarkEvents.on("deploy:contract:receipt", onContractReceipt);
+
+    function indent() {
+      return Array(indents).join('  ');
+    }
+
+    runner.on('start', function () {
+      console.log();
+    });
+
+    runner.on('suite', function (suite) {
+      ++indents;
+      console.log(color('suite', '%s%s'), indent(), suite.title);
+    });
+
+    runner.on('suite end', function () {
+      --indents;
+      if (indents === 1) {
+        console.log();
+      }
+    });
+
+    runner.on('pending', function (test) {
+      const fmt = indent() + color('pending', '  - %s');
+      console.log(fmt, test.title);
+    });
+
+    runner.on('pass', function (test) {
+      let fmt;
+      if (test.speed === 'fast') {
+        fmt =
+          indent() +
+          color('checkmark', '  ' + Base.symbols.ok) +
+          color('pass', ' %s');
+        console.log(fmt, test.title);
+      } else {
+        fmt =
+          indent() +
+          color('checkmark', '  ' + Base.symbols.ok) +
+          color('pass', ' %s') +
+          color(test.speed, ' (%dms)');
+        console.log(fmt, test.title, test.duration);
+      }
+    });
+
+    runner.on('fail', function (test) {
+      console.log(indent() + color('fail', '  %d) %s'), ++n, test.title);
+    });
+
+    runner.once('end', function() {
+      self.embarkEvents.removeListener("deploy:contract:receipt", onContractReceipt);
+      self.epilogue();
+    });
+  }
+}
+
+module.exports = EmbarkSpec;

--- a/lib/tests/run_tests.js
+++ b/lib/tests/run_tests.js
@@ -101,7 +101,11 @@ module.exports = {
       function executeForAllFiles(files, next) {
         async.eachLimit(files, 1, (file, eachCb) => {
           const mocha = new Mocha();
-          mocha.reporter(EmbarkSpec, {events: global.embark.engine.events, gasDetails: options.gasDetails});
+          mocha.reporter(EmbarkSpec, {
+            events: global.embark.engine.events,
+            gasDetails: options.gasDetails,
+            gasLimit: global.embark.engine.deployManager.gasLimit
+          });
           mocha.addFile(file);
 
           mocha.suite.timeout(0);

--- a/lib/tests/run_tests.js
+++ b/lib/tests/run_tests.js
@@ -114,6 +114,7 @@ module.exports = {
 
           mocha.run(function (fails) {
             failures += fails;
+            mocha.suite.removeAllListeners();
             // Mocha prints the error already
             eachCb();
           });

--- a/lib/tests/run_tests.js
+++ b/lib/tests/run_tests.js
@@ -4,6 +4,7 @@ const Mocha = require('mocha');
 const path = require('path');
 const assert = require('assert');
 const Test = require('./test');
+const EmbarkSpec = require('./reporter');
 
 function getFilesFromDir(filePath, cb) {
   fs.readdir(filePath, (err, files) => {
@@ -100,6 +101,7 @@ module.exports = {
       function executeForAllFiles(files, next) {
         async.eachLimit(files, 1, (file, eachCb) => {
           const mocha = new Mocha();
+          mocha.reporter(EmbarkSpec, {events: global.embark.engine.events});
           mocha.addFile(file);
 
           mocha.suite.timeout(0);

--- a/lib/tests/run_tests.js
+++ b/lib/tests/run_tests.js
@@ -101,7 +101,7 @@ module.exports = {
       function executeForAllFiles(files, next) {
         async.eachLimit(files, 1, (file, eachCb) => {
           const mocha = new Mocha();
-          mocha.reporter(EmbarkSpec, {events: global.embark.engine.events});
+          mocha.reporter(EmbarkSpec, {events: global.embark.engine.events, gasDetails: options.gasDetails});
           mocha.addFile(file);
 
           mocha.suite.timeout(0);

--- a/lib/tests/test.js
+++ b/lib/tests/test.js
@@ -93,6 +93,8 @@ class Test {
       trackContracts: false
       //ipcRole: 'client' // disabled for now due to issues with ipc file
     });
+    this.engine.deployManager.gasLimit = 6000000;
+    this.engine.contractsManager.gasLimit = 6000000;
   }
 
   init(callback) {
@@ -271,8 +273,6 @@ class Test {
         }).catch((err) => { next(err); });
       },
       function deploy(accounts, next) {
-        self.engine.deployManager.gasLimit = 6000000;
-        self.engine.contractsManager.gasLimit = 6000000;
         self.engine.deployManager.fatalErrors = true;
         self.engine.deployManager.deployOnlyOnConfig = true;
         self.engine.events.request('deploy:contracts', () => {


### PR DESCRIPTION
Shows the gas cost of deploying contracts and can also show the individual gas costs of each contract using the new option (-d --gasDetails)

Using that option gives something like this:
![image](https://user-images.githubusercontent.com/11926403/42058570-d4011c38-7aee-11e8-826e-8a2c3464d9b6.png)

Currently only gets the gas cost of contracts deploying using `config()` as those using `contract.deploy()` don't trigger the receipt event. Will need to look at it more. 