### PR TITLE
Bug fix/sync modepatch

### DIFF
--- a/lib/cmds/blockchain/blockchain.js
+++ b/lib/cmds/blockchain/blockchain.js
@@ -45,6 +45,7 @@ var Blockchain = function(options) {
     vmdebug: this.blockchainConfig.vmdebug || false,
     targetGasLimit: this.blockchainConfig.targetGasLimit || false,
     syncMode: this.blockchainConfig.syncMode,
+    syncmode: this.blockchainConfig.syncmode,
     verbosity: this.blockchainConfig.verbosity
   };
 

--- a/lib/cmds/blockchain/geth_commands.js
+++ b/lib/cmds/blockchain/geth_commands.js
@@ -20,8 +20,8 @@ class GethCommands {
       cmd.push(`--datadir=${config.datadir}`);
     }
 
-    if (config.syncMode) {
-      cmd.push("--syncmode=" + config.syncMode);
+    if (config.syncMode || config.syncmode) {
+      cmd.push("--syncmode=" + (config.syncMode || config.syncmode));
     }
 
     if (config.account && config.account.password) {

--- a/templates/boilerplate/config/blockchain.js
+++ b/templates/boilerplate/config/blockchain.js
@@ -30,7 +30,7 @@ module.exports = {
   testnet: {
     enabled: true,
     networkType: "testnet",
-    light: true,
+    syncMode: "light",
     rpcHost: "localhost",
     rpcPort: 8545,
     rpcCorsDomain: "http://localhost:8000",
@@ -41,7 +41,7 @@ module.exports = {
   livenet: {
     enabled: true,
     networkType: "livenet",
-    light: true,
+    syncMode: "light",
     rpcHost: "localhost",
     rpcPort: 8545,
     rpcCorsDomain: "http://localhost:8000",

--- a/templates/demo/config/blockchain.js
+++ b/templates/demo/config/blockchain.js
@@ -30,7 +30,7 @@ module.exports = {
   testnet: {
     enabled: true,
     networkType: "testnet",
-    light: true,
+    syncMode: "light",
     rpcHost: "localhost",
     rpcPort: 8545,
     rpcCorsDomain: "http://localhost:8000",
@@ -41,7 +41,7 @@ module.exports = {
   livenet: {
     enabled: true,
     networkType: "livenet",
-    light: true,
+    syncMode: "light",
     rpcHost: "localhost",
     rpcPort: 8545,
     rpcCorsDomain: "http://localhost:8000",

--- a/test/blockchain.js
+++ b/test/blockchain.js
@@ -39,6 +39,7 @@ describe('embark.Blockchain', function () {
           wsRPC: true,
           targetGasLimit: false,
           syncMode: undefined,
+          syncmode: undefined,
           verbosity: undefined,
           proxy: true
         };
@@ -81,6 +82,7 @@ describe('embark.Blockchain', function () {
           wsRPC: true,
           targetGasLimit: false,
           syncMode: undefined,
+          syncmode: undefined,
           verbosity: undefined,
           proxy: true
         };


### PR DESCRIPTION
Add fix by @hhakala to templates and also enable using `syncMode` and `syncmode`  as geth's option is called `syncmode`.
Having to accept both a my bad as I originally wrote the param in the blockchain.json as syncMode and it got shipped in 3.1, where it should have been syncmode to be the same as geth,
