### PR TITLE
Fix proxy error message "Error forwarding requests to blockchain/simulator [Object(object)]"

### DIFF
--- a/lib/core/proxy.js
+++ b/lib/core/proxy.js
@@ -68,7 +68,7 @@ exports.serve = function(ipc, host, port, ws){
     });
 
     proxy.on('error', function (e) {
-        console.error(__("Error forwarding requests to blockchain/simulator"), e);
+        console.error(__("Error forwarding requests to blockchain/simulator"), e.message);
     });
 
     proxy.on('proxyRes', (proxyRes) => {


### PR DESCRIPTION
Proxy error message "Error forwarding requests to blockchain/simulator [Object(object)]" was showing in console. Have replace [Object(object)] with  `error.message`