### PR TITLE
Fixed __mainContext error

### DIFF
--- a/lib/contracts/code_generator.js
+++ b/lib/contracts/code_generator.js
@@ -106,16 +106,14 @@ class CodeGenerator {
     let result = "";
     let providerPlugins;
 
-    // TODO: check contractsConfig for enabled
-    if (self.blockchainConfig === {} || self.blockchainConfig.enabled === false) {
-      return "";
-    }
-
     result += Templates.utils();
-
     result += Templates.main_context();
     result += Templates.load_manager();
     result += Templates.define_when_env_loaded();
+    
+    if (self.blockchainConfig === {} || self.blockchainConfig.enabled === false) {
+      return result;
+    }
 
     if (this.plugins) {
       providerPlugins = this.plugins.getPluginsFor('clientWeb3Provider');
@@ -128,8 +126,12 @@ class CodeGenerator {
     } else {
       let web3Load;
 
+      if (this.contractsConfig === {} || this.contractsConfig.enabled === false) {
+        return result;
+      }
+
       if (isDeployment) {
-        let connection = "http://" + this.contractsConfig.deployment.host + ":" + this.contractsConfig.deployment.port;
+        let connection = utils.buildUrlFromConfig(this.contractsConfig.deployment);
         web3Load = Templates.define_web3_simple({url: connection, done: 'done();'});
       } else {
         let connectionList = "[" + this.contractsConfig.dappConnection.map((x) => '"' + x + '"').join(',') + "]";


### PR DESCRIPTION
There was a condition checking if blockchain config was disabled and if so, do not generate any provider code, which is where the `__mainContext` was being defined. This was changed to generate the `__mainContext` code first, then if blockchain is disabled, return the already generated code.