### PR TITLE
log error when pipeline dies

### DIFF
--- a/lib/pipeline/pipeline.js
+++ b/lib/pipeline/pipeline.js
@@ -101,13 +101,13 @@ class Pipeline {
                 // JS files
                 async.waterfall([
                   function runWebpack(next) {
-                    let resulted = false;
+                    let built = false;
                     const webpackProcess = new ProcessLauncher({
                       modulePath: utils.joinPath(__dirname, 'webpackProcess.js'),
                       logger: self.logger,
                       events: self.events,
                       exitCallback: function (code) {
-                        if (!resulted) {
+                        if (!built) {
                           return next(`File building of ${file.filename} exited with code ${code} before the process finished`);
                         }
                         if (code) {
@@ -119,7 +119,7 @@ class Pipeline {
                     webpackProcess.send({action: constants.pipeline.build, file, importsList});
 
                     webpackProcess.once('result', constants.pipeline.built, (msg) => {
-                      resulted = true;
+                      built = true;
                       webpackProcess.kill();
                       return next(msg.error);
                     });

--- a/lib/pipeline/pipeline.js
+++ b/lib/pipeline/pipeline.js
@@ -101,15 +101,25 @@ class Pipeline {
                 // JS files
                 async.waterfall([
                   function runWebpack(next) {
+                    let resulted = false;
                     const webpackProcess = new ProcessLauncher({
                       modulePath: utils.joinPath(__dirname, 'webpackProcess.js'),
                       logger: self.logger,
-                      events: self.events
+                      events: self.events,
+                      exitCallback: function (code) {
+                        if (!resulted) {
+                          return next(`File building of ${file.filename} exited with code ${code} before the process finished`);
+                        }
+                        if (code) {
+                          self.logger(__('File building process exited with code ', code));
+                        }
+                      }
                     });
                     webpackProcess.send({action: constants.pipeline.init, options: {}});
                     webpackProcess.send({action: constants.pipeline.build, file, importsList});
 
                     webpackProcess.once('result', constants.pipeline.built, (msg) => {
+                      resulted = true;
                       webpackProcess.kill();
                       return next(msg.error);
                     });


### PR DESCRIPTION
Doesn't fix errors to the pipeline, but at least tells the user that the pipeline exited, so there will be no more hangs.