### PR TITLE
Fix deployment getting stuck

### DIFF
--- a/lib/contracts/blockchain.js
+++ b/lib/contracts/blockchain.js
@@ -244,15 +244,18 @@ class Blockchain {
     let hash;
     let calledBacked = false;
 
-    function callback() {
+    function callback(err, receipt) {
       if (calledBacked) {
         return;
+      }
+      if (!err && !receipt.contractAddress) {
+        return; // Not deployed yet. Need to wait
       }
       if (interval) {
         clearInterval(interval);
       }
       calledBacked = true;
-      cb(...arguments);
+      cb(err, receipt);
     }
 
     // This interval is there to compensate for the event that sometimes doesn't get triggered when using WebSocket

--- a/lib/contracts/blockchain.js
+++ b/lib/contracts/blockchain.js
@@ -240,13 +240,55 @@ class Blockchain {
   }
 
   deployContractFromObject(deployContractObject, params, cb) {
+    const self = this;
+    let hash;
+    let calledBacked = false;
+
+    function callback() {
+      if (calledBacked) {
+        return;
+      }
+      if (interval) {
+        clearInterval(interval);
+      }
+      calledBacked = true;
+      cb(...arguments);
+    }
+
+    // This interval is there to compensate for the event that sometimes doesn't get triggered when using WebSocket
+    // FIXME The issue somehow only happens when the blockchain node is started in the same terminal
+    const interval = setInterval(() => {
+      if (!hash) {
+        return; // Wait until we receive the hash
+      }
+      self.web3.eth.getTransactionReceipt(hash, (err, receipt) => {
+        if (!err && !receipt) {
+          return; // Transaction is not yet complete
+        }
+        callback(err, receipt);
+      });
+    }, 500);
+
     deployContractObject.send({
       from: params.from, gas: params.gas, gasPrice: params.gasPrice
-    }).on('receipt', function(receipt) {
-      if (receipt.contractAddress !== undefined) {
-        cb(null, receipt);
+    }, function (err, transactionHash) {
+      if (err) {
+        return callback(err);
       }
-    }).on('error', cb);
+      hash = transactionHash;
+    })
+      .on('receipt', function (receipt) {
+        if (receipt.contractAddress !== undefined) {
+          callback(null, receipt);
+        }
+      })
+      .then(function (_contract) {
+        if (!hash) {
+          return; // Somehow we didn't get the receipt yet... Interval will catch it
+        }
+        self.web3.eth.getTransactionReceipt(hash, callback);
+      })
+      .catch(callback);
   }
 
   assertNodeConnection(noLogs, cb) {


### PR DESCRIPTION
This bug only happened when using a WebSocket provider AND having the blockchain node in the same terminal (eg: run starting the node). 
I have no idea why, but the receipt event just sometimes doesn't get triggered, nor did the `then` trigger.
As a quick fix/patch, I added a backup interval that will check if the receipt is there.