### PR TITLE
Features/bin entry ganache cli

### DIFF
--- a/lib/cmds/simulator.js
+++ b/lib/cmds/simulator.js
@@ -44,8 +44,9 @@ class Simulator {
       cmds.push("-b \"" + (simulatorBlocktime) +"\"");
     }
 
-    const program = ganache ? 'ganache-cli' : 'testrpc';
-    console.log(`running: ${program} ${cmds.join(' ')}`);
+    const programName = ganache ? 'ganache-cli' : 'testrpc';
+    const program = ganache ? ganache : testrpc;
+    console.log(`running: ${programName} ${cmds.join(' ')}`);
     shelljs.exec(`${program} ${cmds.join(' ')}`, {async : true});
 
     if(useProxy){

--- a/lib/cmds/simulator.js
+++ b/lib/cmds/simulator.js
@@ -13,7 +13,7 @@ class Simulator {
     let cmds = [];
 
     const testrpc = shelljs.which('testrpc');
-    const ganache = shelljs.which('ganache-cli');
+    const ganache = shelljs.which('ganache-cli') || shelljs.which('embark-ganache-cli');
     if (!testrpc && !ganache) {
       this.logger.warn(__('%s is not installed on your machine', 'Ganache CLI (TestRPC)'));
       this.logger.info(__('You can install it by running: %s', 'npm -g install ganache-cli'));

--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
     "fulltest": "npm run lint && npm run test && npm run testdapp_1 && npm run testdapp_2"
   },
   "bin": {
-    "embark": "./bin/embark"
+    "embark": "./bin/embark",
+    "embark-ganache-cli": "./node_modules/.bin/ganache-cli"
   },
   "main": "./lib/index.js",
   "directories": {


### PR DESCRIPTION
Enable globally installed Embark package to be able to find its own `ganache-cli` on the PATH.