### PR TITLE
shim script for ganache-cli-embark

### DIFF
--- a/bin/ganache-cli
+++ b/bin/ganache-cli
@@ -1,0 +1,7 @@
+#!/usr/bin/env node
+
+const path = require('path');
+const shelljs = require('shelljs');
+
+const ganache = path.join(__dirname, '../node_modules/.bin/ganache-cli');
+shelljs.exec(`${ganache} ${process.argv.slice(2).join(' ')}`, {async : true});

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   },
   "bin": {
     "embark": "./bin/embark",
-    "ganache-cli-embark": "./node_modules/.bin/ganache-cli"
+    "ganache-cli-embark": "./bin/ganache-cli"
   },
   "main": "./lib/index.js",
   "directories": {


### PR DESCRIPTION
Currently, the `"bin"` entry for `"ganache-cli-embark"` points into the embark repo's `node_modules/.bin` directory.  This produces a surprising result when developing on embark with the help of `npm link`:  the symlink at `node_modules/.bin/ganache-cli`  gets replaced by the script itself. Then, if a global uninstall is attempted, npm will refuse to do so because it's not sure what a non-symlink file is doing in `node_modules/.bin` (even though npm put it there!)

A good fix I found is to have the `"bin"` entry for `"ganache-cli-embark"` point to a script file (not a symlink) in `./bin`. That script in turn invokes `../node_modules/.bin/ganache-cli`, relative to `./bin`.