### PR TITLE
invoke embark's local ganache-cli directly

### DIFF
--- a/lib/cmds/simulator.js
+++ b/lib/cmds/simulator.js
@@ -14,13 +14,6 @@ class Simulator {
     let cmds = [];
 
     const ganache = path.join(__dirname, '../../node_modules/.bin/ganache-cli');
-    // const testrpc = shelljs.which('testrpc');
-    // const ganache = shelljs.which('ganache-cli');
-    // if (!testrpc && !ganache) {
-    //   this.logger.warn(__('%s is not installed on your machine', 'Ganache CLI (TestRPC)'));
-    //   this.logger.info(__('You can install it by running: %s', 'npm -g install ganache-cli'));
-    //   process.exit();
-    // }
 
     let useProxy = this.blockchainConfig.proxy || false;
     let host = (options.host || this.blockchainConfig.rpcHost || 'localhost');
@@ -46,8 +39,6 @@ class Simulator {
       cmds.push("-b \"" + (simulatorBlocktime) +"\"");
     }
 
-    // const programName = ganache ? 'ganache-cli' : 'testrpc';
-    // const program = ganache ? ganache : testrpc;
     const programName = 'ganache-cli';
     const program = ganache;
     console.log(`running: ${programName} ${cmds.join(' ')}`);
@@ -57,7 +48,6 @@ class Simulator {
       let ipcObject = new Ipc({ipcRole: 'client'});
       proxy.serve(ipcObject, host, port, false);
     }
-    
   }
 }
 

--- a/lib/cmds/simulator.js
+++ b/lib/cmds/simulator.js
@@ -20,9 +20,7 @@ class Simulator {
     let port = (options.port || this.blockchainConfig.rpcPort || 8545);
 
     cmds.push("-p " + (port + (useProxy ? constants.blockchain.servicePortOnProxy : 0)));
-    // if (!ganache) {
-    //   cmds.push("-h " + host);
-    // }
+    cmds.push("-h " + host);
     cmds.push("-a " + (options.numAccounts || 10));
     cmds.push("-e " + (options.defaultBalance || 100));
     cmds.push("-l " + (options.gasLimit || 8000000));

--- a/lib/cmds/simulator.js
+++ b/lib/cmds/simulator.js
@@ -27,9 +27,9 @@ class Simulator {
     let port = (options.port || this.blockchainConfig.rpcPort || 8545);
 
     cmds.push("-p " + (port + (useProxy ? constants.blockchain.servicePortOnProxy : 0)));
-    if (!ganache) {
-      cmds.push("-h " + host);
-    }
+    // if (!ganache) {
+    //   cmds.push("-h " + host);
+    // }
     cmds.push("-a " + (options.numAccounts || 10));
     cmds.push("-e " + (options.defaultBalance || 100));
     cmds.push("-l " + (options.gasLimit || 8000000));

--- a/lib/cmds/simulator.js
+++ b/lib/cmds/simulator.js
@@ -1,3 +1,4 @@
+const path = require('path');
 let shelljs = require('shelljs');
 let proxy = require('../core/proxy');
 const Ipc = require('../core/ipc');
@@ -12,7 +13,7 @@ class Simulator {
   run(options) {
     let cmds = [];
 
-    const ganache = shelljs.which('ganache-cli-embark');
+    const ganache = path.join(__dirname, '../../node_modules/.bin/ganache-cli');
     // const testrpc = shelljs.which('testrpc');
     // const ganache = shelljs.which('ganache-cli');
     // if (!testrpc && !ganache) {

--- a/package.json
+++ b/package.json
@@ -10,8 +10,7 @@
     "fulltest": "npm run lint && npm run test && npm run testdapp_1 && npm run testdapp_2"
   },
   "bin": {
-    "embark": "./bin/embark",
-    "ganache-cli-embark": "./node_modules/.bin/ganache-cli"
+    "embark": "./bin/embark"
   },
   "main": "./lib/index.js",
   "directories": {


### PR DESCRIPTION
I realized that we can avoid `shelljs.which` entirely by invoking `<embark>/node_modules/.bin/ganache-cli` directly.  An upside is that we don't need an extra `"bin"` entry, so no more `ganache-cli-embark` in the global PATH.

So, it's a better approach, and a step closer toward the optimal solution suggested by @jrainville, i.e. using `ganache-core` as a library and spinning up our own server from `require('ganache-core').server`.