### PR TITLE
propagate `embark run` cli webserver options to config and service

### DIFF
--- a/lib/core/config.js
+++ b/lib/core/config.js
@@ -12,7 +12,7 @@ var Config = function(options) {
   this.blockchainConfig = {};
   this.contractsConfig  = {};
   this.pipelineConfig   = {};
-  this.webServerConfig  = {};
+  this.webServerConfig  = options.webServerConfig;
   this.chainTracker     = {};
   this.assetFiles = {};
   this.contractsFiles = [];
@@ -314,7 +314,14 @@ Config.prototype.loadWebServerConfigFile = function() {
 
   let configFilePath = this._getFileOrOject(this.configDir, 'webserver', 'webserver');
 
-  this.webServerConfig = this._mergeConfig(configFilePath, configObject, false);
+  let webServerConfig = this._mergeConfig(configFilePath, configObject, false);
+
+  if (this.webServerConfig) {
+    // cli falgs to `embark run` should override configFile and defaults (configObject)
+    this.webServerConfig = utils.recursiveMerge(webServerConfig, this.webServerConfig);
+  } else {
+    this.webServerConfig = webServerConfig;
+  }
 };
 
 Config.prototype.loadEmbarkConfigFile = function() {

--- a/lib/core/engine.js
+++ b/lib/core/engine.js
@@ -16,6 +16,7 @@ class Engine {
     this.events = options.events;
     this.context = options.context;
     this.useDashboard = options.useDashboard;
+    this.webServerConfig = options.webServerConfig;
   }
 
   init(_options) {
@@ -26,7 +27,7 @@ class Engine {
     let options = _options || {};
     this.events = options.events || this.events || new Events();
     this.logger = options.logger || new Logger({logLevel: options.logLevel || this.logLevel || 'debug', events: this.events, logFile: this.logFile});
-    this.config = new Config({env: this.env, logger: this.logger, events: this.events, context: this.context});
+    this.config = new Config({env: this.env, logger: this.logger, events: this.events, context: this.context, webServerConfig: this.webServerConfig});
     this.config.loadConfigFiles({embarkConfig: this.embarkConfig, interceptLogs: this.interceptLogs});
     this.plugins = this.config.plugins;
     this.isDev = this.config && this.config.blockchainConfig && (this.config.blockchainConfig.isDev || this.config.blockchainConfig.default);
@@ -248,8 +249,8 @@ class Engine {
     this.watch.start();
   }
 
-  webServerService() {
-    this.registerModule('webserver');
+  webServerService(_options) {
+    this.registerModule('webserver', _options);
   }
 
   storageService(_options) {

--- a/lib/index.js
+++ b/lib/index.js
@@ -75,7 +75,12 @@ class Embark {
       logFile: options.logFile,
       logLevel: options.logLevel,
       context: self.context,
-      useDashboard: options.useDashboard
+      useDashboard: options.useDashboard,
+      webServerConfig: {
+        enabled: options.runWebserver,
+        host: options.serverHost,
+        port: options.serverPort
+      }
     });
     engine.init();
 


### PR DESCRIPTION
These changes result in cli options `--host` and `--port` being picked up by the service starter and the rutime config builder, and in turn the code that adjusts the CORS settings.