### PR TITLE
don't forward host/port cli options if the options weren't specified

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -65,6 +65,17 @@ class Embark {
     self.context = options.context || [constants.contexts.run, constants.contexts.build];
     let Dashboard = require('./dashboard/dashboard.js');
 
+      let webServerConfig = {
+          enabled: options.runWebserver
+      };
+
+      if (options.serverHost) {
+          webServerConfig.host = options.serverHost;
+      }
+      if (options.serverPort) {
+          webServerConfig.port = options.serverPort;
+      }
+
     const Engine = require('./core/engine.js');
     const engine = new Engine({
       env: options.env,
@@ -76,11 +87,7 @@ class Embark {
       logLevel: options.logLevel,
       context: self.context,
       useDashboard: options.useDashboard,
-      webServerConfig: {
-        enabled: options.runWebserver,
-        host: options.serverHost,
-        port: options.serverPort
-      }
+      webServerConfig: webServerConfig
     });
     engine.init();
 


### PR DESCRIPTION
Previously, the cli options were forwarded to the engine instance unconditionally, but the way `recursiveMerge` works, that meant `undefined` was being used for `host` and/or `port` in the webserver's runtime config when the options weren't specified via cli.