### PR TITLE
Add environment to EmbarkJS

### DIFF
--- a/lib/contracts/code_generator.js
+++ b/lib/contracts/code_generator.js
@@ -139,7 +139,7 @@ class CodeGenerator {
         web3Load = Templates.web3_connector({connectionList: connectionList, done: 'done(err);', warnAboutMetamask: isDev});
       }
 
-      result += Templates.do_when_loaded({block: web3Load});
+      result += Templates.do_when_loaded({block: web3Load, environment: this.env});
     }
 
     return result;

--- a/lib/contracts/code_templates/do-when-loaded.js.ejs
+++ b/lib/contracts/code_templates/do-when-loaded.js.ejs
@@ -1,6 +1,8 @@
 whenEnvIsLoaded(function(){
   __mainContext.__loadManagerInstance.doFirst(function(done) {
     <%- block %>
-  })
+  });
+  
+  EmbarkJS.environment = "<%- environment %>";
 });
 


### PR DESCRIPTION
A dev might run into the need of inquirying which configuration is being used during runtime, in case they want to add environment specific behaviors.


### Use case 1

Show a dialog indicating that a user is connected to the mainnet (with metamask), and using the development settings. 

```
const netId = await web3.eth.net.getId();
if(netId === 1 && EmbarkJS.environment !== 'livenet'){
     // Notify user that configuration does not match the network used
     alert("Wrong network / configuration used");
}
```

### Use case 2

Do something (like displaying additional developer options) only when running on development

```
const netId = await web3.eth.net.getId();
if(netId == 1337 && EmbarkJS.environment === 'development'){
     // ...
}
```