### PR TITLE
Fix profile command

### DIFF
--- a/lib/modules/profiler/index.js
+++ b/lib/modules/profiler/index.js
@@ -55,7 +55,7 @@ class Profiler {
       let contractName = cmd.split(' ')[1];
       if (cmdName === 'profile') {
         self.events.request('contracts:contract', contractName, (contract) => {
-          if (!contract.deployedAddress) {
+          if (!contract || !contract.deployedAddress) {
             self.logger.info("--  couldn't profile " + contractName + " - it's not deployed or could be an interface");
             return "";
           }


### PR DESCRIPTION
In case the contract don't exist or the profile
command don't have argument, embark don't crash
and return an error