### PR TITLE
Fix scope of the callback

### DIFF
--- a/lib/modules/swarm/index.js
+++ b/lib/modules/swarm/index.js
@@ -93,9 +93,9 @@ class Swarm {
     return storageProcessesLauncher.launchProcess('swarm', callback);
   }
 
-  registerUploadCommand(cb) {
+  registerUploadCommand() {
     const self = this;
-    this.embark.registerUploadCommand('swarm', () => {
+    this.embark.registerUploadCommand('swarm', (cb) => {
       let upload_swarm = new UploadSwarm({
         buildDir: self.buildDir || 'dist/',
         storageConfig: self.storageConfig,


### PR DESCRIPTION
See IPFS:
```
registerUploadCommand() {
    const self = this;
    this.embark.registerUploadCommand('ipfs', (cb) => {
      let upload_ipfs = new UploadIPFS({
        buildDir: self.buildDir || 'dist/',
        storageConfig: self.storageConfig,
        configIpfsBin: self.storageConfig.ipfs_bin || "ipfs"
      });

      upload_ipfs.deploy(cb);
    });
  }
```

<img width="361" alt="screen shot 2018-07-27 at 13 04 44" src="https://user-images.githubusercontent.com/491074/43320320-01d5d6f4-91a0-11e8-9b2a-63d5f45b7b3b.png">
