### PR TITLE
spec exact version of ethereumjs-wallet

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "embarkjs": "^0.3.0",
     "eth-ens-namehash": "^2.0.8",
     "eth-lib": "^0.2.8",
-    "ethereumjs-wallet": "^0.6.0",
+    "ethereumjs-wallet": "0.6.0",
     "file-loader": "^1.1.5",
     "finalhandler": "^1.1.1",
     "follow-redirects": "^1.2.4",


### PR DESCRIPTION
Yesterday, a new version of ethereumjs-wallet was published (`0.6.1`), and embark will pick it up on a fresh install owing to our use of a caret range: `"^0.6.0"`.

Normally that wouldn't be a problem, but `0.6.1` has a breaking change, probably not intended by its authors: https://github.com/ethereumjs/ethereumjs-wallet/issues/64.

Until they fix the problem or clarify the breaking change was intentional, we can specify an exact version in embark's pkg.json.