### PR TITLE
.embark/versions modules

### DIFF
--- a/lib/pipeline/webpackProcess.js
+++ b/lib/pipeline/webpackProcess.js
@@ -6,6 +6,7 @@ const constants = require('../constants');
 const HardSourceWebpackPlugin = require('hard-source-webpack-plugin');
 const ProcessWrapper = require('../processes/processWrapper');
 const path = require('path');
+const glob = require('glob');
 
 let webpackProcess;
 
@@ -42,142 +43,152 @@ class WebpackProcess extends ProcessWrapper {
 
   webpackRun(filename, options, includeModules, importsList, detectErrors, realCwd, callback) {
     const self = this;
-    let defaultOptions = {
-      mode: self.env === 'production' ? 'production' : 'none',
-      // devtool: self.env === 'development' ? 'source-map' : false,
-      // pipeline would need to copy .map files to dist/ target dir
-      // note: generating full source maps ('source-map') roughly doubles build time
-      entry: fs.dappPath(filename),
-      output: {
-        globalObject: 'typeof self !== \'undefined\' ? self : this',
-        libraryExport: 'default',
-        libraryTarget: 'umd',
-        path: fs.dappPath('.embark'),
-        filename: filename,
-        umdNamedDefine: true
-      },
-      // profile: true,
-      // stats: 'verbose',
-      // note: generating and writing to disk verbose stats increases build time
-      resolve: {
-        alias: importsList,
-        modules: [
-          fs.embarkPath('node_modules'),
-          fs.dappPath('node_modules')
-        ]
-      },
-      plugins: [
-        new HardSourceWebpackPlugin({
-          cacheDirectory: fs.dappPath('node_modules/.cache/hard-source'),
-          // ufglify (wp mode: production) will still save its cache in embark's node_modules/.cache/
-          environmentHash: {
-            root: fs.dappPath()
-          }
-        }),
-        new HardSourceWebpackPlugin.ExcludeModulePlugin(
-          [{test: /app[\\/]|contracts[\\/]/}]
-        )
-      ]
-    };
-
-    let webpackOptions = utils.recursiveMerge(defaultOptions, options);
-
-    if (includeModules) {
-      webpackOptions.module = {
-        rules: [
-          {
-            test: /\.css$/,
-            use: [{loader: "style-loader"}, {loader: "css-loader"}]
-          },
-          {
-            test: /\.scss$/,
-            use: [{loader: "style-loader"}, {loader: "css-loader"}]
-          },
-          {
-            test: /\.(png|woff|woff2|eot|ttf|svg)$/,
-            loader: 'url-loader?limit=100000'
-          },
-          {
-            test: /\.js$/,
-            loader: "babel-loader",
-            exclude: /(node_modules|bower_components)/,
-            options: {
-              presets: [
-                [
-                  "@babel/preset-env", {
-                    modules: false,
-                    targets: {
-                      browsers: ["last 1 version", "not dead", "> 0.2%"]
-                    }
-                  }
-                ],
-                "@babel/preset-react"
-              ].map(pkg => {
-                if (Array.isArray(pkg)) {
-                  let _pkg = pkg[0];
-                  pkg[0] = require.resolve(_pkg);
-                  return pkg;
-                } else {
-                  return require.resolve(pkg);
-                }
-              }),
-              plugins: [
-                "@babel/plugin-transform-runtime",
-                "babel-plugin-webpack-aliases"
-              ].map(require.resolve),
-              compact: false
+    glob(fs.dappPath('.embark/versions') + '/*/*', (err, files) => {
+      let versions;
+      if (err) {
+        console.error(err);
+        versions = [];
+      } else {
+        versions = files;
+      }
+      let defaultOptions = {
+        mode: self.env === 'production' ? 'production' : 'none',
+        // devtool: self.env === 'development' ? 'source-map' : false,
+        // pipeline would need to copy .map files to dist/ target dir
+        // note: generating full source maps ('source-map') roughly doubles build time
+        entry: fs.dappPath(filename),
+        output: {
+          globalObject: 'typeof self !== \'undefined\' ? self : this',
+          libraryExport: 'default',
+          libraryTarget: 'umd',
+          path: fs.dappPath('.embark'),
+          filename: filename,
+          umdNamedDefine: true
+        },
+        // profile: true,
+        // stats: 'verbose',
+        // note: generating and writing to disk verbose stats increases build time
+        resolve: {
+          alias: importsList,
+          modules: [
+            fs.dappPath('node_modules'),
+            ...versions,
+            fs.embarkPath('node_modules')
+          ]
+        },
+        plugins: [
+          new HardSourceWebpackPlugin({
+            cacheDirectory: fs.dappPath('node_modules/.cache/hard-source'),
+            // ufglify (wp mode: production) will still save its cache in embark's node_modules/.cache/
+            environmentHash: {
+              root: fs.dappPath()
             }
-          }
+          }),
+          new HardSourceWebpackPlugin.ExcludeModulePlugin(
+            [{test: /app[\\/]|contracts[\\/]/}]
+          )
         ]
       };
 
-      let dappBabelrc = path.join(realCwd, '.babelrc');
-      if (fs.existsSync(dappBabelrc)) {
-        webpackOptions.module.rules[3].options.extends = dappBabelrc;
-      }
-    }
+      let webpackOptions = utils.recursiveMerge(defaultOptions, options);
 
-    webpack(webpackOptions).run((err, stats) => {
-      async.waterfall([
-        function checkStatsError(next) {
-          if (err) {
-            console.error(err);
-            return next(err);
-          }
-          if (!detectErrors) {
-            return next();
-          }
-          if (stats.hasErrors()) {
-            return next(
-              stats.toJson(webpackOptions.stats).errors.join("\n")
-            );
-          }
-          next();
-        }//,
-        // function writeStatsReport(next) {
-        //   if (detectErrors) {
-        //     self._log('info', 'writing file '+ ('.embark/stats.report').bold.dim);
-        //   }
-        //   fs.writeFile(
-        //     path.join(fs.dappPath('.embark'), 'stats.report'),
-        //     stats.toString(webpackOptions.stats),
-        //     next
-        //   );
-        // },
-        // function writeStatsJSON(next) {
-        //   if (detectErrors) {
-        //     self._log('info','writing file '+ ('.embark/stats.json').bold.dim);
-        //   }
-        //   fs.writeFile(
-        //     path.join(fs.dappPath('.embark'), 'stats.json'),
-        //     JSON.stringify(stats.toJson(webpackOptions.stats)),
-        //     next
-        //   );
-        // }
-        // note: to visualize the stats info in a browser, do...
-        // `npx webpack-bundle-analyzer <dapp_dir>/.embark/stats.json`
-      ], (err) => {
-        callback(err);
+      if (includeModules) {
+        webpackOptions.module = {
+          rules: [
+            {
+              test: /\.css$/,
+              use: [{loader: "style-loader"}, {loader: "css-loader"}]
+            },
+            {
+              test: /\.scss$/,
+              use: [{loader: "style-loader"}, {loader: "css-loader"}]
+            },
+            {
+              test: /\.(png|woff|woff2|eot|ttf|svg)$/,
+              loader: 'url-loader?limit=100000'
+            },
+            {
+              test: /\.js$/,
+              loader: "babel-loader",
+              exclude: /(node_modules|bower_components|\.embark\/versions)/,
+              options: {
+                presets: [
+                  [
+                    "@babel/preset-env", {
+                      modules: false,
+                      targets: {
+                        browsers: ["last 1 version", "not dead", "> 0.2%"]
+                      }
+                    }
+                  ],
+                  "@babel/preset-react"
+                ].map(pkg => {
+                  if (Array.isArray(pkg)) {
+                    let _pkg = pkg[0];
+                    pkg[0] = require.resolve(_pkg);
+                    return pkg;
+                  } else {
+                    return require.resolve(pkg);
+                  }
+                }),
+                plugins: [
+                  "babel-plugin-webpack-aliases",
+                  "@babel/plugin-transform-runtime"
+                ].map(require.resolve),
+                compact: false
+              }
+            }
+          ]
+        };
+
+        let dappBabelrc = path.join(realCwd, '.babelrc');
+        if (fs.existsSync(dappBabelrc)) {
+          webpackOptions.module.rules[3].options.extends = dappBabelrc;
+        }
+      }
+
+      webpack(webpackOptions).run((err, stats) => {
+        async.waterfall([
+          function checkStatsError(next) {
+            if (err) {
+              console.error(err);
+              return next(err);
+            }
+            if (!detectErrors) {
+              return next();
+            }
+            if (stats.hasErrors()) {
+              return next(
+                stats.toJson(webpackOptions.stats).errors.join("\n")
+              );
+            }
+            next();
+          }//,
+          // function writeStatsReport(next) {
+          //   if (detectErrors) {
+          //     self._log('info', 'writing file '+ ('.embark/stats.report').bold.dim);
+          //   }
+          //   fs.writeFile(
+          //     path.join(fs.dappPath('.embark'), 'stats.report'),
+          //     stats.toString(webpackOptions.stats),
+          //     next
+          //   );
+          // },
+          // function writeStatsJSON(next) {
+          //   if (detectErrors) {
+          //     self._log('info','writing file '+ ('.embark/stats.json').bold.dim);
+          //   }
+          //   fs.writeFile(
+          //     path.join(fs.dappPath('.embark'), 'stats.json'),
+          //     JSON.stringify(stats.toJson(webpackOptions.stats)),
+          //     next
+          //   );
+          // }
+          // note: to visualize the stats info in a browser, do...
+          // `npx webpack-bundle-analyzer <dapp_dir>/.embark/stats.json`
+        ], (err) => {
+          callback(err);
+        });
       });
     });
   }

--- a/package.json
+++ b/package.json
@@ -21,10 +21,10 @@
     "url": "https://github.com/embark-framework/embark.git"
   },
   "dependencies": {
-    "@babel/core": "7.0.0-beta.54",
-    "@babel/plugin-transform-runtime": "7.0.0-beta.54",
-    "@babel/preset-env": "7.0.0-beta.54",
-    "@babel/preset-react": "7.0.0-beta.54",
+    "@babel/core": "^7.0.0-beta.54",
+    "@babel/plugin-transform-runtime": "^7.0.0-beta.54",
+    "@babel/preset-env": "^7.0.0-beta.54",
+    "@babel/preset-react": "^7.0.0-beta.54",
     "ascii-table": "0.0.9",
     "async": "^2.0.1",
     "babel-loader": "^8.0.0-beta.4",

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "follow-redirects": "^1.2.4",
     "fs-extra": "^2.0.0",
     "ganache-cli": "6.1.0",
+    "glob": "^7.1.2",
     "globule": "^1.1.0",
     "hard-source-webpack-plugin": "^0.11.1",
     "http-proxy": "^1.17.0",

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "@babel/plugin-transform-runtime": "^7.0.0-beta.54",
     "@babel/preset-env": "^7.0.0-beta.54",
     "@babel/preset-react": "^7.0.0-beta.54",
+    "@babel/runtime": "^7.0.0-beta.54",
     "ascii-table": "0.0.9",
     "async": "^2.0.1",
     "babel-loader": "^8.0.0-beta.4",

--- a/test_apps/test_app/package.json
+++ b/test_apps/test_app/package.json
@@ -10,7 +10,7 @@
   "license": "ISC",
   "homepage": "",
   "devDependencies": {
-    "babel-code-frame": "^6.26.0"
+    "@babel/code-frame": "^7.0.0-beta.54"
   },
   "dependencies": {
     "bootstrap": "^3.3.6",


### PR DESCRIPTION
With webpack 4 and babel 7, as discovered through trial and error, it's important to:

1. configure webpack so that modules organized under `.embark/versions` take precedence over embark's own `node_modules`.
2. configure babel to exclude modules in `.embark/versions` from the sources it will transpile.
3. specify the webpack aliases plugin for babel ahead of other babel plugins.

With regard to (1), especially, I'm somewhat puzzled how things were managing to work under webpack 3 and babel 6. It's possible we were getting lucky owing to a subtle interaction between webpack, babel and module lookup that just happened to work out favorably.

The test_app's babel-related devdep has also been bumped to the babel 7 equivalent, and I changed embark's babel deps to specify caret ranges. Also `@babel/runtime` has been added as a dependency of embark, given how dapps at present are intertwined with embark's own dependencies, with respect to the pipeline. Previously, it was being picked up on account of `embarkjs` (an embark dep) having `@babel/runtime` as a dep; that works, but transitive dependencies can be brittle, better to make the dependency explicit.