### PR TITLE
Access to deploymentAccount from a contract:deploy:beforeDeploy plugin. Accept "random" as privateKey configuration.

### DIFF
--- a/lib/modules/deployment/contract_deployer.js
+++ b/lib/modules/deployment/contract_deployer.js
@@ -143,7 +143,6 @@ class ContractDeployer {
     let self = this;
     let accounts = [];
     let contractParams = (contract.realArgs || contract.args).slice();
-    let contractCode = contract.code;
     let deploymentAccount = self.blockchain.defaultAccount();
     let deployObject;
 
@@ -171,10 +170,12 @@ class ContractDeployer {
           }
 
           deploymentAccount = deploymentAccount || accounts[0];
+          contract.deploymentAccount = deploymentAccount;
           next();
         });
       },
       function doLinking(next) {
+        let contractCode = contract.code;
         self.events.request('contracts:list', (_err, contracts) => {
           for (let contractObj of contracts) {
             let filename = contractObj.filename;
@@ -196,7 +197,7 @@ class ContractDeployer {
             }
             contractCode = contractCode.replace(new RegExp(toReplace, "g"), deployedAddress);
           }
-          // saving code changes back to contract object
+          // saving code changes back to the contract object
           contract.code = contractCode;
           next();
         });
@@ -205,6 +206,7 @@ class ContractDeployer {
         self.plugins.emitAndRunActionsForEvent('deploy:contract:beforeDeploy', {contract: contract}, next);
       },
       function createDeployObject(next) {
+        let contractCode   = contract.code;
         let contractObject = self.blockchain.ContractObject({abi: contract.abiDefinition});
 
         try {
@@ -236,7 +238,7 @@ class ContractDeployer {
         self.logger.info(__("deploying") + " " + contract.className.bold.cyan + " " + __("with").green + " " + contract.gas + " " + __("gas at the price of").green + " " + contract.gasPrice + " " + __("Wei, estimated cost:").green + " " + estimatedCost + " Wei".green);
 
         self.blockchain.deployContractFromObject(deployObject, {
-          from: deploymentAccount,
+          from: contract.deploymentAccount,
           gas: contract.gas,
           gasPrice: contract.gasPrice
         }, function(error, receipt) {

--- a/lib/modules/ens/index.js
+++ b/lib/modules/ens/index.js
@@ -14,9 +14,11 @@ class ENS {
     this.registration = this.namesConfig.register || {};
     this.embark = embark;
 
-    this.addENSToEmbarkJS();
-    this.configureContracts();
-    this.registerEvents();
+    if (!!this.namesConfig.enabled) {
+      this.addENSToEmbarkJS();
+      this.configureContracts();
+      this.registerEvents();
+    }
   }
 
   registerEvents() {

--- a/lib/modules/ens/index.js
+++ b/lib/modules/ens/index.js
@@ -14,7 +14,7 @@ class ENS {
     this.registration = this.namesConfig.register || {};
     this.embark = embark;
 
-    if (!!this.namesConfig.enabled) {
+    if (this.namesConfig.enabled) {
       this.addENSToEmbarkJS();
       this.configureContracts();
       this.registerEvents();

--- a/lib/utils/accountParser.js
+++ b/lib/utils/accountParser.js
@@ -47,6 +47,12 @@ class AccountParser {
     if (accountConfig.balance) {
       hexBalance = AccountParser.getHexBalance(accountConfig.balance, web3);
     }
+
+    if (accountConfig.privateKey === 'random') {
+      let randomAccount = web3.eth.accounts.create();
+      accountConfig.privateKey = randomAccount.privateKey;
+    }
+
     if (accountConfig.privateKey) {
       if (!accountConfig.privateKey.startsWith('0x')) {
         accountConfig.privateKey = '0x' + accountConfig.privateKey;


### PR DESCRIPTION
[*] Enabling contract:deploy:beforeDeploy plugins to access deploymentAccount value by adding it into the contract object.
[*] Allow user to specify "random" as privateKey configuration. In such case embark generates some random privateKey for the account.