### PR TITLE
Enabling contract:deploy:beforeDeploy plugins to access deploymentAccount

### DIFF
--- a/lib/modules/deployment/contract_deployer.js
+++ b/lib/modules/deployment/contract_deployer.js
@@ -143,7 +143,6 @@ class ContractDeployer {
     let self = this;
     let accounts = [];
     let contractParams = (contract.realArgs || contract.args).slice();
-    let contractCode = contract.code;
     let deploymentAccount = self.blockchain.defaultAccount();
     let deployObject;
 
@@ -171,10 +170,12 @@ class ContractDeployer {
           }
 
           deploymentAccount = deploymentAccount || accounts[0];
+          contract.deploymentAccount = deploymentAccount;
           next();
         });
       },
       function doLinking(next) {
+        let contractCode = contract.code;
         self.events.request('contracts:list', (_err, contracts) => {
           for (let contractObj of contracts) {
             let filename = contractObj.filename;
@@ -196,7 +197,7 @@ class ContractDeployer {
             }
             contractCode = contractCode.replace(new RegExp(toReplace, "g"), deployedAddress);
           }
-          // saving code changes back to contract object
+          // saving code changes back to the contract object
           contract.code = contractCode;
           next();
         });
@@ -205,6 +206,7 @@ class ContractDeployer {
         self.plugins.emitAndRunActionsForEvent('deploy:contract:beforeDeploy', {contract: contract}, next);
       },
       function createDeployObject(next) {
+        let contractCode   = contract.code;
         let contractObject = self.blockchain.ContractObject({abi: contract.abiDefinition});
 
         try {
@@ -236,7 +238,7 @@ class ContractDeployer {
         self.logger.info(__("deploying") + " " + contract.className.bold.cyan + " " + __("with").green + " " + contract.gas + " " + __("gas at the price of").green + " " + contract.gasPrice + " " + __("Wei, estimated cost:").green + " " + estimatedCost + " Wei".green);
 
         self.blockchain.deployContractFromObject(deployObject, {
-          from: deploymentAccount,
+          from: contract.deploymentAccount,
           gas: contract.gas,
           gasPrice: contract.gasPrice
         }, function(error, receipt) {


### PR DESCRIPTION
## Overview
Enabling contract:deploy:beforeDeploy plugins to access deploymentAccount.
Previously known as #673 .

### Questions
<If relevant, write a list of questions that you would like to discuss related to the changes that you have made.>

### Review
<use @mentions for quick questions, specific feedback, and progress updates.>
