### PR TITLE
Allow user to specify "random" as privateKey configuration.

### DIFF
--- a/lib/utils/accountParser.js
+++ b/lib/utils/accountParser.js
@@ -47,6 +47,12 @@ class AccountParser {
     if (accountConfig.balance) {
       hexBalance = AccountParser.getHexBalance(accountConfig.balance, web3);
     }
+
+    if (accountConfig.privateKey === 'random') {
+      let randomAccount = web3.eth.accounts.create();
+      accountConfig.privateKey = randomAccount.privateKey;
+    }
+
     if (accountConfig.privateKey) {
       if (!accountConfig.privateKey.startsWith('0x')) {
         accountConfig.privateKey = '0x' + accountConfig.privateKey;


### PR DESCRIPTION
## Overview
Allow user to specify "random" as privateKey configuration. In such case embark generates some random privateKey for the account.
Previously known as PR #673 

### Review
Q (@emizzle) > What's the benefit of generating a random private key for contract deployment?
A (hodlbank) > when we are running embark test we use twenty-something accounts for testing various things. It is convenient to use random privateKeys instead of creating and copy-pasting them all into the configuration.
