### PR TITLE
Applying simulatorAccounts configuration for "embark simulator" command

### DIFF
--- a/lib/cmds/simulator.js
+++ b/lib/cmds/simulator.js
@@ -32,21 +32,14 @@ class Simulator {
       cmds.push("--mnemonic \"" + (simulatorMnemonic) +"\"");
     }
 
-    // the simulatorAccounts configuration overrides a mnemonic
+    // as ganache-cli documentation explains, the simulatorAccounts configuration overrides a mnemonic
     let simulatorAccounts = this.blockchainConfig.simulatorAccounts || options.simulatorAccounts;
     if (simulatorAccounts && simulatorAccounts.length > 0) {
-      simulatorAccounts.forEach((account, index) => {
-        let hexBalance = '0x8AC7230489E80000'; // 10 ether;
-        if (account.hexBalance) { // TODO: ensure it is 0x-prefixed hex
-          if (account.hexBalance.match(/0x[a-f0-9]+/i)) {
-            hexBalance = account.hexBalance;
-          } else {
-            this.logger.warn('Balance provided for the account #' + index + ' is not a valid hex number. Using 10 ether as a default.');
-          }
-        } else {
-          this.logger.warn('No balance has been provided for the account #' + index + '. Using 10 ether as a default.');
-        }
-        let cmd = '--account="' + account.privateKey + ','+hexBalance + '"';
+      let web3 = new (require('web3'))();
+      let AccountParser = require('../utils/accountParser.js');
+      let parsedAccounts = AccountParser.parseAccountsConfig(simulatorAccounts, web3, this.logger);
+      parsedAccounts.forEach((account) => {
+        let cmd = '--account="' + account.privateKey + ','+account.hexBalance + '"';
         cmds.push(cmd);
       });
     }

--- a/lib/cmds/simulator.js
+++ b/lib/cmds/simulator.js
@@ -32,6 +32,25 @@ class Simulator {
       cmds.push("--mnemonic \"" + (simulatorMnemonic) +"\"");
     }
 
+    // the simulatorAccounts configuration overrides a mnemonic
+    let simulatorAccounts = this.blockchainConfig.simulatorAccounts || options.simulatorAccounts;
+    if (simulatorAccounts && simulatorAccounts.length > 0) {
+      simulatorAccounts.forEach((account, index) => {
+        let hexBalance = '0x8AC7230489E80000'; // 10 ether;
+        if (account.hexBalance) { // TODO: ensure it is 0x-prefixed hex
+          if (account.hexBalance.match(/0x[a-f0-9]+/i)) {
+            hexBalance = account.hexBalance;
+          } else {
+            this.logger.warn('Balance provided for the account #' + index + ' is not a valid hex number. Using 10 ether as a default.');
+          }
+        } else {
+          this.logger.warn('No balance has been provided for the account #' + index + '. Using 10 ether as a default.');
+        }
+        let cmd = '--account="' + account.privateKey + ','+hexBalance + '"';
+        cmds.push(cmd);
+      });
+    }
+
     // adding blocktime only if it is defined in the blockchainConfig or options
     let simulatorBlocktime = this.blockchainConfig.simulatorBlocktime || options.simulatorBlocktime;
     if (simulatorBlocktime) {

--- a/lib/modules/deployment/contract_deployer.js
+++ b/lib/modules/deployment/contract_deployer.js
@@ -143,7 +143,6 @@ class ContractDeployer {
     let self = this;
     let accounts = [];
     let contractParams = (contract.realArgs || contract.args).slice();
-    let contractCode = contract.code;
     let deploymentAccount = self.blockchain.defaultAccount();
     let deployObject;
 
@@ -171,10 +170,12 @@ class ContractDeployer {
           }
 
           deploymentAccount = deploymentAccount || accounts[0];
+          contract.deploymentAccount = deploymentAccount;
           next();
         });
       },
       function doLinking(next) {
+        let contractCode = contract.code;
         self.events.request('contracts:list', (_err, contracts) => {
           for (let contractObj of contracts) {
             let filename = contractObj.filename;
@@ -196,7 +197,7 @@ class ContractDeployer {
             }
             contractCode = contractCode.replace(new RegExp(toReplace, "g"), deployedAddress);
           }
-          // saving code changes back to contract object
+          // saving code changes back to the contract object
           contract.code = contractCode;
           next();
         });
@@ -205,6 +206,7 @@ class ContractDeployer {
         self.plugins.emitAndRunActionsForEvent('deploy:contract:beforeDeploy', {contract: contract}, next);
       },
       function createDeployObject(next) {
+        let contractCode   = contract.code;
         let contractObject = self.blockchain.ContractObject({abi: contract.abiDefinition});
 
         try {
@@ -236,7 +238,7 @@ class ContractDeployer {
         self.logger.info(__("deploying") + " " + contract.className.bold.cyan + " " + __("with").green + " " + contract.gas + " " + __("gas at the price of").green + " " + contract.gasPrice + " " + __("Wei, estimated cost:").green + " " + estimatedCost + " Wei".green);
 
         self.blockchain.deployContractFromObject(deployObject, {
-          from: deploymentAccount,
+          from: contract.deploymentAccount,
           gas: contract.gas,
           gasPrice: contract.gasPrice
         }, function(error, receipt) {

--- a/lib/modules/ens/index.js
+++ b/lib/modules/ens/index.js
@@ -16,9 +16,10 @@ class ENS {
 
     if (this.namesConfig === {} ||
       this.namesConfig.enabled !== true ||
-      this.namesConfig.available_providers.indexOf('ens') < 0 ||
-      this.namesConfig.provider !== 'ens') {
+      this.namesConfig.available_providers.indexOf('ens') < 0) {
       return;
+    } else if (this.namesConfig.provider !== 'ens') {
+      this.providerNotENS = true;
     }
 
     this.addENSToEmbarkJS();
@@ -186,6 +187,9 @@ class ENS {
 
   addENSToEmbarkJS() {
     const self = this;
+    if (self.providerNotENS) {
+      return;
+    }
 
     // get namehash, import it into file
     self.events.request("version:get:eth-ens-namehash", function (EnsNamehashVersion) {

--- a/lib/modules/ens/index.js
+++ b/lib/modules/ens/index.js
@@ -18,9 +18,8 @@ class ENS {
       this.namesConfig.enabled !== true ||
       this.namesConfig.available_providers.indexOf('ens') < 0) {
       return;
-    } else if (this.namesConfig.provider !== 'ens') {
-      this.providerNotENS = true;
     }
+    this.doSetENSProvider = this.namesConfig.provider === 'ens';
 
     this.addENSToEmbarkJS();
     this.configureContracts();
@@ -63,7 +62,10 @@ class ENS {
         resolverAbi: results[2].abiDefinition,
         resolverAddress: results[2].deployedAddress
       };
-      self.addSetProvider(config);
+
+      if (self.doSetENSProvider) {
+        self.addSetProvider(config);
+      }
 
       if (!self.env === 'development' || !self.registration || !self.registration.subdomains || !Object.keys(self.registration.subdomains).length) {
         return cb();
@@ -187,9 +189,6 @@ class ENS {
 
   addENSToEmbarkJS() {
     const self = this;
-    if (self.providerNotENS) {
-      return;
-    }
 
     // get namehash, import it into file
     self.events.request("version:get:eth-ens-namehash", function (EnsNamehashVersion) {

--- a/lib/modules/ens/index.js
+++ b/lib/modules/ens/index.js
@@ -14,6 +14,13 @@ class ENS {
     this.registration = this.namesConfig.register || {};
     this.embark = embark;
 
+    if (this.namesConfig === {} ||
+      this.namesConfig.enabled !== true ||
+      this.namesConfig.available_providers.indexOf('ens') < 0 ||
+      this.namesConfig.provider !== 'ens') {
+      return;
+    }
+
     this.addENSToEmbarkJS();
     this.configureContracts();
     this.registerEvents();
@@ -179,14 +186,6 @@ class ENS {
 
   addENSToEmbarkJS() {
     const self = this;
-    // TODO: make this a shouldAdd condition
-    if (this.namesConfig === {}) {
-      return;
-    }
-
-    if ((this.namesConfig.available_providers.indexOf('ens') < 0) && (this.namesConfig.provider !== 'ens' || this.namesConfig.enabled !== true)) {
-      return;
-    }
 
     // get namehash, import it into file
     self.events.request("version:get:eth-ens-namehash", function (EnsNamehashVersion) {

--- a/lib/utils/accountParser.js
+++ b/lib/utils/accountParser.js
@@ -47,6 +47,12 @@ class AccountParser {
     if (accountConfig.balance) {
       hexBalance = AccountParser.getHexBalance(accountConfig.balance, web3);
     }
+
+    if (accountConfig.privateKey === 'random') {
+      let randomAccount = web3.eth.accounts.create();
+      accountConfig.privateKey = randomAccount.privateKey;
+    }
+
     if (accountConfig.privateKey) {
       if (!accountConfig.privateKey.startsWith('0x')) {
         accountConfig.privateKey = '0x' + accountConfig.privateKey;


### PR DESCRIPTION
## Overview
This PR allows user to configure option "simulatorAccounts" in the blockchain.json in the following format:
```
"someEnvironment": {
// skipped //
    "simulatorMnemonic": "something something something something something something ",
    "simulatorBlocktime": 35,
    "simulatorAccounts": [
      {
        "privateKey":  "0xaaaaa",
        "hexBalance":    "0x56BC75E2D60000000"
      },
      {
        "privateKey": "0xbbbbb"
// default of 10 ether will be applied if hexBalance is invalid or missing
      }
```
Then it would be used when running "embark simulator someEnvironment" .
