### PR TITLE
remove contracts manager dependency from tests

### DIFF
--- a/lib/contracts/contracts.js
+++ b/lib/contracts/contracts.js
@@ -24,6 +24,10 @@ class ContractsManager {
       cb(self.compileError, self.listContracts());
     });
 
+    self.events.setCommandHandler('contracts:all', (cb) => {
+      cb(self.compileError, self.contracts);
+    });
+
     self.events.setCommandHandler('contracts:dependencies', (cb) => {
       cb(self.compileError, self.contractDependencies);
     });

--- a/lib/contracts/contracts.js
+++ b/lib/contracts/contracts.js
@@ -43,6 +43,14 @@ class ContractsManager {
       });
     });
 
+    self.events.setCommandHandler("contracts:reset:dependencies", (cb) => {
+      for (let className in self.contracts) {
+        self.contracts[className].dependencyCount = null;
+      }
+      self.contractDependencies = {};
+      cb();
+    });
+
     self.events.on("deploy:contract:error", (_contract) => {
       self.events.emit('contractsState', self.contractsState());
     });

--- a/lib/tests/test.js
+++ b/lib/tests/test.js
@@ -39,8 +39,7 @@ class Test {
     this.firstRunConfig = true;
     this.error = false;
     this.contracts = {};
-    this.builtContracts = {};
-    this.compiledContracts = {};
+    this.firstDeployment = true;
     this.logsSubscription = null;
     this.needConfig = true;
     this.web3 = new Web3();
@@ -236,25 +235,17 @@ class Test {
         self.checkDeploymentOptions(options, next);
       },
       function compileContracts(next) {
-        if (Object.keys(self.builtContracts).length > 0) {
+        if (!self.firstDeployment) {
           return next();
         }
         console.info('Compiling contracts'.cyan);
         self.engine.events.request("contracts:build", false, (err) => {
-          self.builtContracts = cloneDeep(self.engine.contractsManager.contracts);
-          let className;
-          for (className in self.builtContracts) {
-            self.builtContracts[className].dependencyCount = null;
-          }
-          self.compiledContracts = cloneDeep(self.engine.contractsManager.compiledContracts);
-          next();
+          self.firstDeployment = false;
+          next(err);
         });
       },
       function resetContracts(next) {
-        self.engine.contractsManager.contracts = cloneDeep(self.builtContracts);
-        self.engine.contractsManager.compiledContracts = cloneDeep(self.compiledContracts);
-        self.engine.contractsManager.contractDependencies = {};
-        next();
+        self.engine.events.request("contracts:reset:dependencies", next);
       },
       function deploy(next) {
         self._deploy(options, (err, accounts) => {

--- a/lib/tests/test.js
+++ b/lib/tests/test.js
@@ -4,7 +4,6 @@ const TestLogger = require('./test_logger.js');
 const Web3 = require('web3');
 const constants = require('../constants');
 const Events = require('../core/events');
-const cloneDeep = require('clone-deep');
 const AccountParser = require('../utils/accountParser');
 // TODO: breaks module isolation; tests need to be refactored to use the engine and avoid this
 const Provider = require('../modules/blockchain_connector/provider.js');

--- a/lib/tests/test.js
+++ b/lib/tests/test.js
@@ -240,7 +240,7 @@ class Test {
           return next();
         }
         console.info('Compiling contracts'.cyan);
-        self.engine.contractsManager.build(() => {
+        self.engine.events.request("contracts:build", false, (err) => {
           self.builtContracts = cloneDeep(self.engine.contractsManager.contracts);
           let className;
           for (className in self.builtContracts) {
@@ -311,32 +311,35 @@ class Test {
         });
       },
       function createContractObject(accounts, next) {
-        async.each(Object.keys(self.engine.contractsManager.contracts), (contractName, eachCb) => {
-          const contract = self.engine.contractsManager.contracts[contractName];
-          if (!self.contracts[contractName]) {
-            self.contracts[contractName] = {};
-          }
+        self.engine.events.request('contracts:all', (err, contracts) => {
 
-          let newContract = new EmbarkJS.Contract({
-            abi: contract.abiDefinition,
-            address: contract.deployedAddress,
-            from: self.web3.eth.defaultAccount,
-            gas: 6000000,
-            web3: self.web3
+          async.each(contracts, (contract, eachCb) => {
+            if (!self.contracts[contract.className]) {
+              self.contracts[contract.className] = {};
+            }
+
+            let newContract = new EmbarkJS.Contract({
+              abi: contract.abiDefinition,
+              address: contract.deployedAddress,
+              from: self.web3.eth.defaultAccount,
+              gas: 6000000,
+              web3: self.web3
+            });
+
+            if (newContract.options) {
+              newContract.options.from = self.web3.eth.defaultAccount;
+              newContract.options.data = contract.code;
+              newContract.options.gas = 6000000;
+            }
+
+            Object.setPrototypeOf(self.contracts[contract.className], newContract);
+            Object.assign(self.contracts[contract.className], newContract);
+
+            eachCb();
+          }, (err) => {
+            next(err, accounts);
           });
 
-          if (newContract.options) {
-            newContract.options.from = self.web3.eth.defaultAccount;
-            newContract.options.data = contract.code;
-            newContract.options.gas = 6000000;
-          }
-
-          Object.setPrototypeOf(self.contracts[contractName], newContract);
-          Object.assign(self.contracts[contractName], newContract);
-
-          eachCb();
-        }, (err) => {
-          next(err, accounts);
         });
       }
     ], function (err, accounts) {


### PR DESCRIPTION
TLDR: removes direct references to contractManager, so we can move it to a module