### PR TITLE
Hide ENS logs etc

### DIFF
--- a/lib/contracts/contracts.js
+++ b/lib/contracts/contracts.js
@@ -403,6 +403,9 @@ class ContractsManager {
 
     for (let className in this.contracts) {
       let contract = this.contracts[className];
+      if (contract.silent) {
+        continue;
+      }
 
       let contractData;
 

--- a/lib/contracts/contracts.js
+++ b/lib/contracts/contracts.js
@@ -148,7 +148,12 @@ class ContractsManager {
           }
 
           if (contract.code === "") {
-            self.logger.info(__("assuming %s to be an interface", className));
+            const message = __("assuming %s to be an interface", className);
+            if (contract.silent) {
+              self.logger.trace(message);
+            } else {
+              self.logger.info(message);
+            }
             contract.deploy = false;
           }
         }

--- a/lib/modules/blockchain_connector/index.js
+++ b/lib/modules/blockchain_connector/index.js
@@ -71,7 +71,7 @@ class BlockchainConnector {
             if (!networkId && constants.blockchain.networkIds[self.blockchainConfig.networkType]) {
               networkId = constants.blockchain.networkIds[self.blockchainConfig.networkType];
             }
-            if (id !== networkId) {
+            if (id.toString() !== networkId.toString()) {
               self.logger.warn(__('Connected to a blockchain node on network {{realId}} while your config specifies {{configId}}', {realId: id, configId: networkId}));
               self.logger.warn(__('Make sure you started the right blockchain node'));
             }

--- a/lib/modules/deployment/contract_deployer.js
+++ b/lib/modules/deployment/contract_deployer.js
@@ -145,6 +145,7 @@ class ContractDeployer {
     let contractParams = (contract.realArgs || contract.args).slice();
     let deploymentAccount = self.blockchain.defaultAccount();
     let deployObject;
+    const logFunction = contract.silent ? self.logger.trace.bind(self.logger) : self.logger.info.bind(self.logger);
 
     async.waterfall([
       // TODO: can potentially go to a beforeDeploy plugin
@@ -235,7 +236,8 @@ class ContractDeployer {
       },
       function deployTheContract(next) {
         let estimatedCost = contract.gas * contract.gasPrice;
-        self.logger.info(__("deploying") + " " + contract.className.bold.cyan + " " + __("with").green + " " + contract.gas + " " + __("gas at the price of").green + " " + contract.gasPrice + " " + __("Wei, estimated cost:").green + " " + estimatedCost + " Wei".green);
+        logFunction(__("deploying") + " " + contract.className.bold.cyan + " " + __("with").green + " " + contract.gas + " " + __("gas at the price of").green + " " + contract.gasPrice + " " + __("Wei, estimated cost:").green + " " + estimatedCost + " Wei".green);
+
 
         self.blockchain.deployContractFromObject(deployObject, {
           from: contract.deploymentAccount,
@@ -247,7 +249,7 @@ class ContractDeployer {
             self.events.emit("deploy:contract:error", contract);
             return next(new Error("error deploying =" + contract.className + "= due to error: " + error.message));
           }
-          self.logger.info(contract.className.bold.cyan + " " + __("deployed at").green + " " + receipt.contractAddress.bold.cyan + " " + __("using").green + " " + receipt.gasUsed + " " + __("gas").green);
+          logFunction(contract.className.bold.cyan + " " + __("deployed at").green + " " + receipt.contractAddress.bold.cyan + " " + __("using").green + " " + receipt.gasUsed + " " + __("gas").green);
           contract.deployedAddress = receipt.contractAddress;
           contract.transactionHash = receipt.transactionHash;
           receipt.className = contract.className;

--- a/lib/modules/ens/index.js
+++ b/lib/modules/ens/index.js
@@ -210,7 +210,13 @@ class ENS {
   configureContracts() {
     const config = {
       "default": {
-        "gas": "auto"
+        "gas": "auto",
+        "contracts": {
+          "ENS": {
+            "deploy": false,
+            "silent": true
+          }
+        }
       },
       "development": {
         "contracts": {

--- a/lib/modules/ens/index.js
+++ b/lib/modules/ens/index.js
@@ -216,10 +216,12 @@ class ENS {
         "contracts": {
           "ENSRegistry": {
             "deploy": true,
+            "silent": true,
             "args": []
           },
           "Resolver": {
             "deploy": true,
+            "silent": true,
             "args": ["$ENSRegistry"]
           },
           "FIFSRegistrar": {
@@ -230,7 +232,8 @@ class ENS {
       "ropsten": {
         "contracts": {
           "ENSRegistry": {
-            "address": "0x112234455c3a32fd11230c42e7bccd4a84e02010"
+            "address": "0x112234455c3a32fd11230c42e7bccd4a84e02010",
+            "silent": true
           },
           "Resolver": {
             "deploy": false
@@ -243,7 +246,8 @@ class ENS {
       "rinkeby": {
         "contracts": {
           "ENSRegistry": {
-            "address": "0xe7410170f87102DF0055eB195163A03B7F2Bff4A"
+            "address": "0xe7410170f87102DF0055eB195163A03B7F2Bff4A",
+            "silent": true
           },
           "Resolver": {
             "deploy": false
@@ -256,7 +260,8 @@ class ENS {
       "livenet": {
         "contracts": {
           "ENSRegistry": {
-            "address": "0x314159265dd8dbb310642f98f50c066173c1259b"
+            "address": "0x314159265dd8dbb310642f98f50c066173c1259b",
+            "silent": true
           },
           "Resolver": {
             "deploy": false
@@ -273,6 +278,7 @@ class ENS {
       const rootNode = namehash.hash(this.registration.rootDomain);
       config.development.contracts['FIFSRegistrar'] = {
         "deploy": true,
+        "silent": true,
         "args": ["$ENSRegistry", rootNode],
         "onDeploy": [
           `ENSRegistry.methods.setOwner('${rootNode}', web3.eth.defaultAccount).send().then(() => {

--- a/lib/modules/specialconfigs/index.js
+++ b/lib/modules/specialconfigs/index.js
@@ -63,10 +63,11 @@ class SpecialConfigs {
     });
   }
 
-  runOnDeployCode(onDeployCode, callback) {
+  runOnDeployCode(onDeployCode, callback, silent) {
     const self = this;
+    const logFunction = silent ? self.logger.trace.bind(self.logger) : self.logger.info.bind(self.logger);
     async.each(onDeployCode, (cmd, eachCb) => {
-      self.logger.info("==== executing: " + cmd);
+      logFunction("==== executing: " + cmd);
       self.events.request('runcode:eval', cmd, (err) => {
         if (err && err.message.indexOf("invalid opcode") >= 0) {
           self.logger.error('the transaction was rejected; this usually happens due to a throw or a require, it can also happen due to an invalid operation');
@@ -85,8 +86,9 @@ class SpecialConfigs {
       if (!contract.onDeploy) {
         return cb();
       }
-
-      self.logger.info(__('executing onDeploy commands'));
+      if (!contract.silent) {
+        self.logger.info(__('executing onDeploy commands'));
+      }
 
       let onDeployCmds = contract.onDeploy;
 
@@ -97,7 +99,7 @@ class SpecialConfigs {
           return cb(new Error("error running onDeploy for " + contract.className.cyan));
         }
 
-        self.runOnDeployCode(onDeployCode, cb);
+        self.runOnDeployCode(onDeployCode, cb, contract.silent);
       });
     });
   }


### PR DESCRIPTION
## Overview
ENS contracts created a lot of logs that are annoying to a user since he didn't really add those contracts himself. 
Added `silent: true` to the contract config. When set, it hides the logs for that contract and doesn't show it in the dashboard.
When loglevel is trace, it still shows the logs.

### Questions
Would it be better as `hidden` or `silent`? We usually use `silent` and it makes sense for logs, but since it's also used for the dashboard maybe `hidden` is better?

I didn't hide the Proxy logs for the ENS contracts / silent contracts. Would it be better? I feel that when EmbarkJS calls register, it's very nice to have the proxy displaying it. But for the initial register, maybe less helpful.

