### PR TITLE
More Parallel deploy

### DIFF
--- a/lib/modules/contracts_manager/index.js
+++ b/lib/modules/contracts_manager/index.js
@@ -41,9 +41,6 @@ class ContractsManager {
     });
 
     self.events.setCommandHandler("contracts:reset:dependencies", (cb) => {
-      for (let className in self.contracts) {
-        self.contracts[className].dependencyCount = null;
-      }
       self.contractDependencies = {};
       cb();
     });
@@ -287,43 +284,6 @@ class ContractsManager {
             });
             self.contractDependencies[className] = Object.keys(o);
           }
-        }
-        callback();
-      },
-      function setDependencyCount(callback) {
-        let className;
-
-        function getDependencyCount(contractName, cycleDetector) {
-          if (!self.contracts[contractName]) {
-            return 0;
-          }
-          if (self.contracts[contractName].dependencyCount || self.contracts[contractName].dependencyCount === 0) {
-            // Already have that count
-            return self.contracts[contractName].dependencyCount;
-          }
-          if (!self.contractDependencies[contractName] || !self.contractDependencies[contractName].length) {
-            self.contracts[contractName].dependencyCount = 0;
-            return 0;
-          }
-          let total = self.contractDependencies[contractName].length;
-          self.contractDependencies[contractName].some(dependencyName => {
-            if (cycleDetector.indexOf(dependencyName) > -1) {
-              // We are in a cycle because of the dependency, set both to Infinity
-              self.contracts[dependencyName].dependencyCount = Infinity;
-              total = Infinity;
-              return true;
-            }
-            cycleDetector.push(dependencyName);
-            total += getDependencyCount(dependencyName, cycleDetector);
-          });
-          self.contracts[contractName].dependencyCount = total;
-          return total;
-        }
-
-        let cycleDetector;
-        for (className in self.contracts) {
-          cycleDetector = [];
-          getDependencyCount(className, cycleDetector);
         }
         callback();
       }

--- a/lib/modules/deployment/index.js
+++ b/lib/modules/deployment/index.js
@@ -1,8 +1,7 @@
 let async = require('async');
 
 const ContractDeployer = require('./contract_deployer.js');
-const utils = require('../../utils/utils.js');
-//require("../utils/debug_util.js")(__filename, async);
+const cloneDeep = require('clone-deep');
 
 class DeployManager {
   constructor(embark, options) {
@@ -43,25 +42,37 @@ class DeployManager {
   deployAll(done) {
     let self = this;
 
-    self.events.request('contracts:list', (err, contracts) => {
-      if (err) {
-        return done(err);
-      }
+    self.events.request('contracts:dependencies', (err, contractDependencies) => {
+      self.events.request('contracts:list', (err, contracts) => {
+        if (err) {
+          return done(err);
+        }
 
-      self.logger.info(__("deploying contracts"));
-      self.events.emit("deploy:beforeAll");
+        self.logger.info(__("deploying contracts"));
+        self.events.emit("deploy:beforeAll");
 
-      const contractsPerDependencyCount = utils.groupBy(contracts, 'dependencyCount');
-      async.eachSeries(contractsPerDependencyCount,
-        function (parallelGroups, callback) {
-          async.each(parallelGroups, (contract, eachCb) => {
+        const contractDeploys = {};
+        contracts.forEach(contract => {
+          function deploy(result, callback) {
+            if (typeof result === 'function') {
+              callback = result;
+            }
             contract._gasLimit = self.gasLimit;
             self.events.request('deploy:contract', contract, (err) => {
-              eachCb(err);
+              callback(err);
             });
-          }, callback);
-        },
-        function (err, _results) {
+          }
+
+          const className = contract.className;
+          if (!contractDependencies[className] || contractDependencies[className].length === 0) {
+            contractDeploys[className] = deploy;
+            return;
+          }
+          contractDeploys[className] = cloneDeep(contractDependencies[className]);
+          contractDeploys[className].push(deploy);
+        });
+
+        async.auto(contractDeploys, function(err, _results) {
           if (err) {
             self.logger.error(__("error deploying contracts"));
             self.logger.error(err.message);
@@ -73,8 +84,8 @@ class DeployManager {
           }
           self.logger.info(__("finished deploying contracts"));
           done(err);
-        }
-      );
+        });
+      });
     });
   }
 
@@ -102,11 +113,11 @@ class DeployManager {
       },
 
       // TODO: shouldn't be necessary
-      function checkCompileOnly(callback){
-        if(self.onlyCompile){
+      function checkCompileOnly(callback) {
+        if (self.onlyCompile) {
           self.events.emit('contractsDeployed');
           return done();
-        } 
+        }
         return callback();
       },
 


### PR DESCRIPTION
Use async.auto to deploy the contract in a parallel manner. 
Async.auto makes sure the dependencies are processed first.
Also remove dependencyCount as it is not needed anymore.

Stats: https://docs.google.com/spreadsheets/d/1cjtY6yBmi1Qu8ASdBn3SA4-jsWpg2GlL6aiu5J3FeY0/edit?usp=sharing