### PR TITLE
Feature/console connect to ipc

### DIFF
--- a/cmd/cmd_controller.js
+++ b/cmd/cmd_controller.js
@@ -107,6 +107,7 @@ class EmbarkController {
             plugins: engine.plugins,
             version: engine.version,
             events: engine.events,
+            logger: engine.logger,
             ipc: engine.ipc
           }).startConsole();
           return callback();
@@ -342,6 +343,7 @@ class EmbarkController {
           plugins: engine.plugins,
           version: engine.version,
           events: engine.events,
+          logger: engine.logger,
           ipc: engine.ipc
         });
         repl.start(callback);

--- a/cmd/cmd_controller.js
+++ b/cmd/cmd_controller.js
@@ -294,6 +294,9 @@ class EmbarkController {
         });
       },
       function web3IPC(callback) {
+        // Do specific work in case we are connected to a socket:
+        //  - Setup Web3
+        //  - Apply history
         if(!engine.ipc.connected || engine.ipc.isServer()) {
           return callback();
         }
@@ -314,6 +317,7 @@ class EmbarkController {
         });
       },
       function deploy(callback) {
+        // Skip if we are connected to a websocket, the server will do it
         if(engine.ipc.connected && engine.ipc.isClient()) {
           return callback();
         }
@@ -322,6 +326,7 @@ class EmbarkController {
         });
       },
       function waitForWriteFinish(callback) {
+        // Skip if we are connected to a websocket, the server will do it
         if(engine.ipc.connected && engine.ipc.isClient()) {
           return callback();
         }

--- a/cmd/dashboard/console.js
+++ b/cmd/dashboard/console.js
@@ -42,7 +42,7 @@ class Console {
       if(typeof pluginResult !== 'object'){
         if (pluginResult !== false && pluginResult !== 'false' && pluginResult !== undefined) {
           this.logger.warn("[DEPRECATED] In future versions of embark, we expect the console command to return an object " +
-            "having 2 functions: match and process.");
+            "having 2 functions: match and process. The documentation with example can be found here: https://embark.status.im/docs/plugin_reference.html#embark-registerConsoleCommand-callback-options");
           return callback(null, pluginResult);
         }
       } else if (pluginResult.match()) {

--- a/cmd/dashboard/console.js
+++ b/cmd/dashboard/console.js
@@ -5,6 +5,7 @@ class Console {
     this.events = options.events;
     this.plugins = options.plugins;
     this.version = options.version;
+    this.logger = options.logger;
     this.ipc = options.ipc;
 
     if (this.ipc.isServer()) {
@@ -38,7 +39,13 @@ class Console {
     var pluginCmds = this.plugins.getPluginsProperty('console', 'console');
     for (let pluginCmd of pluginCmds) {
       let pluginResult = pluginCmd.call(this, cmd, {});
-      if (pluginResult.match()) {
+      if(typeof pluginResult !== 'object'){
+        if (pluginResult !== false && pluginResult !== 'false' && pluginResult !== undefined) {
+          this.logger.warn("[DEPRECATED] In future versions of embark, we expect the console command to return an object " +
+            "having 2 functions: match and process.");
+          return callback(null, pluginResult);
+        }
+      } else if (pluginResult.match()) {
         return pluginResult.process(callback);
       }
     }

--- a/cmd/dashboard/console.js
+++ b/cmd/dashboard/console.js
@@ -5,11 +5,11 @@ class Console {
     this.events = options.events;
     this.plugins = options.plugins;
     this.version = options.version;
-    this.contractsConfig = options.contractsConfig;
-  }
+    this.ipc = options.ipc;
 
-  runCode(code) {
-    this.events.request('runcode:eval', code);
+    if (this.ipc.isServer()) {
+      this.ipc.on('console:executeCmd', this.executeCmd.bind(this));
+    }
   }
 
   processEmbarkCmd (cmd) {
@@ -37,26 +37,25 @@ class Console {
   executeCmd(cmd, callback) {
     var pluginCmds = this.plugins.getPluginsProperty('console', 'console');
     for (let pluginCmd of pluginCmds) {
-      let pluginOutput = pluginCmd.call(this, cmd, {});
-      if (pluginOutput !== false && pluginOutput !== 'false' && pluginOutput !== undefined) return callback(pluginOutput);
+      let pluginResult = pluginCmd.call(this, cmd, {});
+      if (pluginResult.match()) {
+        return pluginResult.process(callback);
+      }
     }
 
     let output = this.processEmbarkCmd(cmd);
     if (output) {
-      return callback(output);
+      return callback(null, output);
     }
 
     try {
-      this.events.request('runcode:eval', cmd, (err, result) => {
-        callback(result);
-      });
+      this.events.request('runcode:eval', cmd, callback, true);
     }
     catch (e) {
-      if (e.message.indexOf('not defined') > 0) {
-        return callback(("error: " + e.message).red + ("\n" + __("Type") + " " + "help".bold + " " + __("to see the list of available commands")).cyan);
-      } else {
-        return callback(e.message);
+      if (this.ipc.connected && this.ipc.isClient()) {
+        return this.ipc.request('console:executeCmd', cmd, callback);
       }
+      return callback(e.message);
     }
   }
 }

--- a/cmd/dashboard/console.js
+++ b/cmd/dashboard/console.js
@@ -55,7 +55,7 @@ class Console {
       if (this.ipc.connected && this.ipc.isClient()) {
         return this.ipc.request('console:executeCmd', cmd, callback);
       }
-      return callback(e.message);
+      callback(e.message);
     }
   }
 }

--- a/cmd/dashboard/dashboard.js
+++ b/cmd/dashboard/dashboard.js
@@ -11,6 +11,7 @@ class Dashboard {
     this.plugins = options.plugins;
     this.version = options.version;
     this.env = options.env;
+    this.ipc = options.ipc;
 
     this.events.on('firstDeploymentDone', this.checkWindowSize.bind(this));
     this.events.on('outputDone', this.checkWindowSize.bind(this));
@@ -32,7 +33,8 @@ class Dashboard {
         console = new Console({
           events: self.events,
           plugins: self.plugins,
-          version: self.version
+          version: self.version,
+          ipc: self.ipc
         });
         callback();
       },

--- a/cmd/dashboard/dashboard.js
+++ b/cmd/dashboard/dashboard.js
@@ -34,7 +34,8 @@ class Dashboard {
           events: self.events,
           plugins: self.plugins,
           version: self.version,
-          ipc: self.ipc
+          ipc: self.ipc,
+          logger: self.logger
         });
         callback();
       },

--- a/cmd/dashboard/monitor.js
+++ b/cmd/dashboard/monitor.js
@@ -368,7 +368,7 @@ class Monitor {
   executeCmd(cmd, cb) {
     const self = this;
     self.logText.log('console> '.bold.green + cmd);
-    self.console.executeCmd(cmd, function (result) {
+    self.console.executeCmd(cmd, function (_, result) {
       self.logText.log(result);
       if (cb) {
         cb(result);

--- a/cmd/dashboard/monitor.js
+++ b/cmd/dashboard/monitor.js
@@ -368,7 +368,7 @@ class Monitor {
   executeCmd(cmd, cb) {
     const self = this;
     self.logText.log('console> '.bold.green + cmd);
-    self.console.executeCmd(cmd, function (_, result) {
+    self.console.executeCmd(cmd, function (_err, result) {
       self.logText.log(result);
       if (cb) {
         cb(result);

--- a/cmd/dashboard/repl.js
+++ b/cmd/dashboard/repl.js
@@ -5,6 +5,7 @@ const Console = require('./console.js');
 
 class REPL {
   constructor(options) {
+    this.logger = options.logger;
     this.env = options.env;
     this.plugins = options.plugins;
     this.events = options.events;
@@ -17,7 +18,8 @@ class REPL {
       events: this.events,
       plugins: this.plugins,
       version: this.version,
-      ipc: this.ipc
+      ipc: this.ipc,
+      logger: this.logger
     });
   }
 

--- a/cmd/dashboard/repl.js
+++ b/cmd/dashboard/repl.js
@@ -8,17 +8,21 @@ class REPL {
     this.env = options.env;
     this.plugins = options.plugins;
     this.events = options.events;
+    this.version = options.version;
+    this.ipc = options.ipc;
+  }
+
+  startConsole(){
     this.console = new Console({
       events: this.events,
       plugins: this.plugins,
-      version: options.version
+      version: this.version,
+      ipc: this.ipc
     });
   }
 
   enhancedEval(cmd, context, filename, callback) {
-    this.console.executeCmd(cmd.trim(), (result) => {
-      callback(null, result);
-    });
+    this.console.executeCmd(cmd.trim(), callback);
   }
 
   enhancedWriter(output) {
@@ -30,6 +34,7 @@ class REPL {
   }
 
   start(done) {
+    this.startConsole();
     this.replServer = repl.start({
       prompt: "Embark (" + this.env + ") > ",
       useGlobal: true,

--- a/lib/core/engine.js
+++ b/lib/core/engine.js
@@ -17,6 +17,7 @@ class Engine {
     this.context = options.context;
     this.useDashboard = options.useDashboard;
     this.webServerConfig = options.webServerConfig;
+    this.ipcRole = options.ipcRole;
   }
 
   init(_options) {
@@ -34,6 +35,11 @@ class Engine {
 
     if (this.interceptLogs || this.interceptLogs === undefined) {
       utils.interceptLogs(console, this.logger);
+    }
+
+    this.ipc = new IPC({logger: this.logger, ipcRole: this.ipcRole});
+    if (this.ipc.isServer()) {
+      this.ipc.serve();
     }
   }
 
@@ -125,7 +131,8 @@ class Engine {
     this.codeRunner = new CodeRunner({
       plugins: this.plugins,
       events: this.events,
-      logger: this.logger
+      logger: this.logger,
+      ipc: this.ipc
     });
   }
 
@@ -156,18 +163,13 @@ class Engine {
     let self = this;
 
     this.registerModule('compiler', {plugins: self.plugins});
-
-    this.ipc = new IPC({logger: this.logger, ipcRole: options.ipcRole});
-    if (this.ipc.isServer()) {
-      this.ipc.serve();
-    }
-
-    this.registerModule('solidity', {ipc: this.ipc, useDashboard: this.useDashboard});
+    this.registerModule('solidity', {ipc: self.ipc, useDashboard: this.useDashboard});
     this.registerModule('vyper');
     this.registerModule('profiler');
     this.registerModule('deploytracker');
     this.registerModule('specialconfigs');
-    this.registerModule('console_listener', {ipc: this.ipc});
+    this.registerModule('specialconfigs');
+    this.registerModule('console_listener', {ipc: self.ipc});
     this.registerModule('contracts_manager');
     this.registerModule('deployment', {plugins: this.plugins, onlyCompile: options.onlyCompile});
 

--- a/lib/core/ipc.js
+++ b/lib/core/ipc.js
@@ -52,7 +52,7 @@ class IPC {
         return;
       }
       let reply = function(_err, replyData) {
-        self.reply(socket, 'compile', replyData);
+        self.reply(socket, action, replyData);
       };
       done(data.message, reply, socket);
     });
@@ -60,6 +60,14 @@ class IPC {
 
   reply(client, action, data) {
     ipc.server.emit(client, 'message', {action: action, message: data});
+  }
+
+  listenTo(action, callback) {
+    ipc.of['embark'].on(action, callback);
+  }
+
+  broadcast(action, data) {
+    ipc.server.broadcast(action, data);
   }
 
   once(action, cb) {

--- a/lib/core/modules/coderunner/codeRunner.js
+++ b/lib/core/modules/coderunner/codeRunner.js
@@ -6,27 +6,50 @@ class CodeRunner {
     this.plugins = options.plugins;
     this.logger = options.logger;
     this.events = options.events;
-
+    this.ipc = options.ipc;
+    this.commands = [];
+    let self = this;
     // necessary to init the context
     RunCode.initContext();
 
+    if (this.ipc.isServer()) {
+      this.ipc.on('runcode:getCommands', (_, callback) => {
+        let result = {web3Config: RunCode.getWeb3Config(), commands: self.commands};
+        callback(null, result);
+      });
+    }
+
+    if (this.ipc.isClient() && this.ipc.connected) {
+      this.ipc.listenTo('runcode:newCommand', function (command) {
+        if (command.varName) {
+          self.events.emit("runcode:register", command.varName, command.code);
+        } else {
+          self.events.request("runcode:eval", command.code);
+        }
+      });
+    }
+
     this.events.on("runcode:register", (varName, code) => {
+      if (self.ipc.isServer() && varName !== 'web3') {
+        self.commands.push({varName, code});
+        self.ipc.broadcast("runcode:newCommand", {varName, code});
+      }
       RunCode.registerVar(varName, code);
     });
 
-    this.events.setCommandHandler('runcode:eval', (code, cb) => {
+    this.events.setCommandHandler('runcode:eval', (code, cb, dashboard = false) => {
       if (!cb) {
         cb = function() {};
       }
-      try {
-        let result = RunCode.doEval(code);
-        cb(null, result);
-      } catch (e) {
-        cb(e);
+      let result = RunCode.doEval(code);
+      if (!dashboard && self.ipc.isServer()) {
+        self.commands.push({code});
+        self.ipc.broadcast("runcode:newCommand", {code});
       }
-
+      cb(null, result);
     });
   }
+
 }
 
 module.exports = CodeRunner;

--- a/lib/core/modules/coderunner/codeRunner.js
+++ b/lib/core/modules/coderunner/codeRunner.js
@@ -13,7 +13,7 @@ class CodeRunner {
     RunCode.initContext();
 
     if (this.ipc.isServer()) {
-      this.ipc.on('runcode:getCommands', (_, callback) => {
+      this.ipc.on('runcode:getCommands', (_err, callback) => {
         let result = {web3Config: RunCode.getWeb3Config(), commands: self.commands};
         callback(null, result);
       });

--- a/lib/core/modules/coderunner/runCode.js
+++ b/lib/core/modules/coderunner/runCode.js
@@ -23,8 +23,13 @@ function registerVar(varName, code) {
   __mainContext[varName] = code;
 }
 
+function getWeb3Config() {
+  return {defaultAccount:__mainContext.web3.eth.defaultAccount, provider: __mainContext.web3.currentProvider};
+}
+
 module.exports = {
-  doEval: doEval,
-  registerVar: registerVar,
-  initContext: initContext
+  doEval,
+  registerVar,
+  initContext,
+  getWeb3Config
 };

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,4 +1,3 @@
-
 let version = require('../package.json').version;
 
 class Embark {
@@ -20,7 +19,6 @@ class Embark {
     this.config.loadConfigFiles(options);
     this.plugins = this.config.plugins;
   }
-
 }
 
 module.exports = Embark;

--- a/lib/modules/library_manager/index.js
+++ b/lib/modules/library_manager/index.js
@@ -38,14 +38,16 @@ class LibraryManager {
   registerCommands() {
     const self = this;
     this.embark.registerConsoleCommand((cmd, _options) => {
-      if (cmd === "versions" || cmd === __('versions')) {
-        let text = [__('versions in use') + ':'];
-        for (let lib in self.versions) {
-          text.push(lib + ": " + self.versions[lib]);
+      return {
+        match: () => cmd === "versions" || cmd === __('versions'),
+        process: (callback) => {
+          let text = [__('versions in use') + ':'];
+          for (let lib in self.versions) {
+            text.push(lib + ": " + self.versions[lib]);
+          }
+          callback(null, text.join('\n'));
         }
-        return text.join('\n');
-      }
-      return false;
+      };
     });
   }
 

--- a/lib/modules/profiler/index.js
+++ b/lib/modules/profiler/index.js
@@ -11,7 +11,7 @@ class Profiler {
     this.registerConsoleCommand();
   }
 
-  profile(contractName, contract) {
+  profile(contractName, contract, callback) {
     const self = this;
     let table = new asciiTable(contractName);
     table.setHeading('Function', 'Payable', 'Mutability', 'Inputs', 'Outputs', 'Gas Estimates');
@@ -33,7 +33,7 @@ class Profiler {
             table.addRow(abiMethod.name, abiMethod.payable, abiMethod.stateMutability, self.formatParams(abiMethod.inputs), self.formatParams(abiMethod.outputs), gastimates[abiMethod.name]);
         }
       });
-      self.logger.info(table.toString());
+      callback(null, table.toString());
     });
   }
 
@@ -53,18 +53,18 @@ class Profiler {
     self.embark.registerConsoleCommand((cmd, _options) => {
       let cmdName = cmd.split(' ')[0];
       let contractName = cmd.split(' ')[1];
-      if (cmdName === 'profile') {
-        self.events.request('contracts:contract', contractName, (contract) => {
-          if (!contract || !contract.deployedAddress) {
-            self.logger.info("--  couldn't profile " + contractName + " - it's not deployed or could be an interface");
-            return "";
-          }
-          self.logger.info("--  profile for " + contractName);
-          this.profile(contractName, contract);
-        });
-          return "";
-      }
-      return false;
+
+      return {
+        match: () => cmdName === 'profile',
+        process: (callback) => {
+          self.events.request('contracts:contract', contractName, (contract) => {
+            if (!contract || !contract.deployedAddress) {
+              return "--  couldn't profile " + contractName + " - it's not deployed or could be an interface";
+            }
+            this.profile(contractName, contract, callback);
+          });
+        }
+      };
     });
   }
 }

--- a/lib/modules/profiler/index.js
+++ b/lib/modules/profiler/index.js
@@ -17,9 +17,7 @@ class Profiler {
     table.setHeading('Function', 'Payable', 'Mutability', 'Inputs', 'Outputs', 'Gas Estimates');
     self.gasEstimator.estimateGas(contractName, function(err, gastimates, name) {
       if (err) {
-        self.logger.error('error found in method: ', name);
-        self.logger.error(JSON.stringify(err));
-        return;
+        return callback(null, "error found in method: " + name + " error: " + JSON.stringify(err));
       }
       contract.abiDefinition.forEach((abiMethod) => {
         switch(abiMethod.type) {
@@ -59,7 +57,7 @@ class Profiler {
         process: (callback) => {
           self.events.request('contracts:contract', contractName, (contract) => {
             if (!contract || !contract.deployedAddress) {
-              return "--  couldn't profile " + contractName + " - it's not deployed or could be an interface";
+              return callback(null, "--  couldn't profile " + contractName + " - it's not deployed or could be an interface");
             }
             this.profile(contractName, contract, callback);
           });

--- a/lib/modules/webserver/index.js
+++ b/lib/modules/webserver/index.js
@@ -17,13 +17,14 @@ class WebServer {
     this.port = options.port || this.webServerConfig.port;
 
     this.events.emit("status", __("Starting Server"));
-    this.server = new Server({logger: this.logger, host: this.host, port: this.port});
+    this.server = new Server({host: this.host, port: this.port});
 
     this.setServiceCheck();
     this.listenToCommands();
     this.registerConsoleCommands();
 
-    this.server.start();
+    let self = this;
+    this.server.start((_err, message) => self.logger.info(message));
   }
 
   setServiceCheck() {
@@ -43,8 +44,8 @@ class WebServer {
   }
 
   listenToCommands() {
-    this.events.setCommandHandler('start-webserver', () => { this.server.start(); });
-    this.events.setCommandHandler('stop-webserver',  () => { this.server.stop();  });
+    this.events.setCommandHandler('start-webserver', (callback) => this.server.start(callback));
+    this.events.setCommandHandler('stop-webserver',  (callback) => this.server.stop(callback));
   }
 
   registerConsoleCommands() {
@@ -52,20 +53,14 @@ class WebServer {
     self.embark.registerConsoleCommand((cmd, _options) => {
       return {
         match: () => cmd === "webserver start",
-        process: (callback) => {
-          self.events.request("start-webserver");
-          callback(null, "OK");
-        }
-      };
+        process: (callback) => self.events.request("start-webserver", callback)
+      }
     });
 
     self.embark.registerConsoleCommand((cmd, _options) => {
       return {
         match: () => cmd === "webserver stop",
-        process: (callback) => {
-          self.events.request("stop-webserver");
-          callback(null, "OK");
-        }
+        process: (callback) => self.events.request("stop-webserver", callback)
       };
     });
   }

--- a/lib/modules/webserver/index.js
+++ b/lib/modules/webserver/index.js
@@ -50,18 +50,25 @@ class WebServer {
   registerConsoleCommands() {
     const self = this;
     self.embark.registerConsoleCommand((cmd, _options) => {
-      if (cmd === 'webserver start') {
-        self.events.request("start-webserver");
-        return " ";
-      }
-      if (cmd === 'webserver stop') {
-        self.events.request("stop-webserver");
-        return __("stopping webserver") + "...";
-      }
-      return false;
+      return {
+        match: () => cmd === "webserver start",
+        process: (callback) => {
+          self.events.request("start-webserver");
+          callback(null, "OK");
+        }
+      };
+    });
+
+    self.embark.registerConsoleCommand((cmd, _options) => {
+      return {
+        match: () => cmd === "webserver stop",
+        process: (callback) => {
+          self.events.request("stop-webserver");
+          callback(null, "OK");
+        }
+      };
     });
   }
-
 }
 
 module.exports = WebServer;

--- a/lib/modules/webserver/index.js
+++ b/lib/modules/webserver/index.js
@@ -54,7 +54,7 @@ class WebServer {
       return {
         match: () => cmd === "webserver start",
         process: (callback) => self.events.request("start-webserver", callback)
-      }
+      };
     });
 
     self.embark.registerConsoleCommand((cmd, _options) => {

--- a/lib/modules/webserver/server.js
+++ b/lib/modules/webserver/server.js
@@ -9,19 +9,14 @@ class Server {
     this.dist = options.dist || 'dist/';
     this.port = options.port || 8000;
     this.hostname = dockerHostSwap(options.host) || defaultHost;
-    this.logger = options.logger;
   }
 
   start(callback) {
     if (this.server && this.server.listening) {
-      this.logger.warn(__("a webserver is already running at") +
-                       " " +
-                       ("http://" + canonicalHost(this.hostname) +
-                        ":" + this.port).bold.underline.green);
-      if (callback) {
-        callback();
-      }
-      return;
+      let message = __("a webserver is already running at") + " " +
+                      ("http://" + canonicalHost(this.hostname) +
+                      ":" + this.port).bold.underline.green;
+      return callback(null, message);
     }
     let serve = serveStatic(this.dist, {'index': ['index.html', 'index.htm']});
 
@@ -29,28 +24,20 @@ class Server {
       serve(req, res, finalhandler(req, res));
     }).withShutdown();
 
-    this.logger.info(__("webserver available at") +
-                     " " +
-                     ("http://" + canonicalHost(this.hostname) +
-                      ":" + this.port).bold.underline.green);
+    let message = __("webserver available at") +
+                    " " +
+                    ("http://" + canonicalHost(this.hostname) +
+                    ":" + this.port).bold.underline.green;
     this.server.listen(this.port, this.hostname);
-    if (callback) {
-      callback();
-    }
+    callback(null, message);
   }
 
   stop(callback) {
     if (!this.server || !this.server.listening) {
-      this.logger.warn(__("no webserver is currently running"));
-      if (callback) {
-        callback();
-      }
-      return;
+      return callback(null, __("no webserver is currently running"));
     }
     this.server.shutdown(function() {
-      if (callback) {
-        callback();
-      }
+      callback(null, __("Webserver stopped"));
     });
   }
 

--- a/lib/tests/test.js
+++ b/lib/tests/test.js
@@ -116,8 +116,7 @@ class Test {
       web3: this.web3
     });
     this.engine.startService("deployment", {
-      trackContracts: false,
-      ipcRole: 'client'
+      trackContracts: false
     });
     this.events.request('deploy:setGasLimit', 6000000);
   }
@@ -127,7 +126,8 @@ class Test {
       env: this.options.env || 'test',
       // TODO: config will need to detect if this is a obj
       embarkConfig: this.options.embarkConfig || 'embark.json',
-      interceptLogs: false
+      interceptLogs: false,
+      ipcRole: 'client'
     });
 
     this.engine.init({

--- a/test/console.js
+++ b/test/console.js
@@ -1,19 +1,21 @@
 /*globals describe, it*/
 let Console = require('../cmd/dashboard/console.js');
 let Plugins = require('../lib/core/plugins.js');
+let IPC = require('../lib/core/ipc.js');
 let assert = require('assert');
 let version = require('../package.json').version;
 
 describe('embark.Console', function() {
+  let ipc = new IPC({ipcRole: 'none'});
   let plugins = new Plugins({plugins: {}});
-  let console = new Console({plugins: plugins, version: version});
+  let console = new Console({plugins, version, ipc});
 
   describe('#executeCmd', function() {
 
     describe('command: help', function() {
 
       it('it should provide a help text', function(done) {
-        console.executeCmd('help', function(output) {
+        console.executeCmd('help', function(_err, output) {
           let lines = output.split('\n');
           assert.equal(lines[0], 'Welcome to Embark ' + version);
           assert.equal(lines[2], 'possible commands are:');


### PR DESCRIPTION
## Overview
**TL;DR**
When embark run is started, the console connect to it.

How it works:
The main process (embark run), broadcast changes to the context to all the clients.
When a new client is connecting, it fetches all the previous changes tot he context.
Web3 is the only exception as it contains circular dependencies and cannot be pass via message.

Additional changes:
- On console command, there is now a match and process function, that allows to not try all of them and based the answer on null but on a boolean
- Console command now use a callback, that allows the profile command to returns something instead of  using the logger which breaks the REPL.
- When starting the dashboard without UI a Console is still started in the background such that message can pass