### PR TITLE
npm should not ignore templates' .gitignore files

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,1 @@
+!templates/**/.gitignore


### PR DESCRIPTION
## Overview

`npm pack` was by default ignoring the `.gitignore` files within the template directories. With this change, it doesn't ignore them.

Compare the results of:

```
npm pack embark-framework/embark#3.1.7
```
```
npm pack embark-framework/embark#develop
```
^ both of those are missing the `.gitignore` files
```
npm pack embark-framework/embark#bug_fix/templates-gitignore
```

It was easy to miss this since during development we're often working with embark installed from a clone of the github repo vs. a tarball packed by `npm`.

Post approval and merge, I will cherry pick this commit into a branch off `3_1_0`, then submit a PR for merging into `3_1_0`.