### PR TITLE
fix ganache-cli resolution

### DIFF
--- a/lib/modules/blockchain_process/simulator.js
+++ b/lib/modules/blockchain_process/simulator.js
@@ -1,4 +1,5 @@
 const path = require('path');
+const pkgUp = require('pkg-up');
 let shelljs = require('shelljs');
 let proxy = require('./proxy');
 const Ipc = require('../../core/ipc');
@@ -14,7 +15,16 @@ class Simulator {
   run(options) {
     let cmds = [];
 
-    const ganache = path.join(__dirname, '../../../node_modules/.bin/ganache-cli');
+    const ganache_main = require.resolve('ganache-cli');
+    const ganache_json = pkgUp.sync(path.dirname(ganache_main));
+    const ganache_root = path.dirname(ganache_json);
+    const ganache_bin = require(ganache_json).bin;
+    let ganache;
+    if (typeof ganache_bin === 'string') {
+      ganache = path.join(ganache_root, ganache_bin);
+    } else {
+      ganache = path.join(ganache_root, ganache_bin['ganache-cli']);
+    }
 
     let useProxy = this.blockchainConfig.proxy || false;
     let host = (dockerHostSwap(options.host || this.blockchainConfig.rpcHost) || defaultHost);

--- a/package-lock.json
+++ b/package-lock.json
@@ -8977,6 +8977,14 @@
         "find-up": "^2.1.0"
       }
     },
+    "pkg-up": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/pkg-up/-/pkg-up-2.0.0.tgz",
+      "integrity": "sha1-yBmscoBZpGHKscOImivjxJoATX8=",
+      "requires": {
+        "find-up": "^2.1.0"
+      }
+    },
     "pluralize": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/pluralize/-/pluralize-7.0.0.tgz",

--- a/package.json
+++ b/package.json
@@ -67,6 +67,7 @@
     "ora": "^2.1.0",
     "os-locale": "^2.1.0",
     "parse-json": "^4.0.0",
+    "pkg-up": "^2.0.0",
     "promptly": "^2.1.0",
     "propose": "0.0.5",
     "request": "^2.85.0",


### PR DESCRIPTION
## Overview

I accidentally discovered a corner-case that breaks our method of [ganache-cli resolution](https://github.com/embark-framework/embark/blob/develop/lib/modules/blockchain_process/simulator.js#L17) on embark's develop branch. Embark's `3.1.x` series is immune as it's still using the [`shelljs.which` approach](https://github.com/embark-framework/embark/blob/3_1_0/lib/cmds/simulator.js#L17).

It happens that if ganache-cli and embark are installed globally ***at the same time***:

```
npm install -g embark-framework/embark#develop ganache-cli@6.1.0
```

And if the ganache-cli being installed satisfies embark's dependency (version/range match), then during  install npm will dedupe the dependency such that ganache-cli doesn't end up in embark's `node_modules`. Our resolution, relative to embark's `node_modules`, is then broken.

This behavior was discovered owing to the [embark-docker container's performing simultaneous global installation](https://github.com/embark-framework/embark-docker/blob/master/Dockerfile#L124-L125).  Even if that's changed, any dapp author on his local machine might choose to install them simultaneously, so changing embark-docker isn't a real solution.

### Fixing it

This PR implements a resolution method that will work whether ganache-cli is in embark's `node_modules` or is a sibling of embark. I have verified it works in either case.

It has been discussed previously that it would be better, overall, to fire up our own ganache server directly. In that case, `require('gachace-cli')` would find the ganache-cli's `main` whether it's in embark's `node_modules` or a sibling of `embark`, but the global dedupe behavior described above might still be in effect (it's simply how npm behaves with simultaneous install), so we would need to rely on `require`'s lookup and not attempt to load it from embark's `node_modules`, as it might not be there.

If we want to launch a ganache cli server programmatically, we will need to include within embark a server config builder that works like ganache-cli's [cli.js](https://github.com/trufflesuite/ganache-cli/blob/develop/cli.js#L66), and then pass a config to the `server` function exported by ganache-cli's [`main`](https://github.com/trufflesuite/ganache-cli/blob/develop/lib.js#L9).

Since I've verified this PR works, and it's simpler than putting together the config builder, I think we should go ahead with this approach now and implement the custom-server approach later.