### PR TITLE
fixes re: babel 7 release candidate 1

### DIFF
--- a/lib/pipeline/webpackProcess.js
+++ b/lib/pipeline/webpackProcess.js
@@ -133,8 +133,21 @@ class WebpackProcess extends ProcessWrapper {
                 }),
                 plugins: [
                   "babel-plugin-webpack-aliases",
-                  "@babel/plugin-transform-runtime"
-                ].map(require.resolve),
+                  [
+                    "@babel/plugin-transform-runtime", {
+                      corejs: 2,
+                      useESModules: true
+                    }
+                  ]
+                ].map(pkg => {
+                  if (Array.isArray(pkg)) {
+                    let _pkg = pkg[0];
+                    pkg[0] = require.resolve(_pkg);
+                    return pkg;
+                  } else {
+                    return require.resolve(pkg);
+                  }
+                }),
                 compact: false
               }
             }

--- a/package-lock.json
+++ b/package-lock.json
@@ -3952,11 +3952,11 @@
       }
     },
     "embarkjs": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/embarkjs/-/embarkjs-0.3.1.tgz",
-      "integrity": "sha512-Xru7QYod+9pp+iC8MifdEQNf0hmRxO+HtcINppPLPH7R4JNbW9viGOTYJ+G18bR7S1HIbmz3G9jWtcgkCt/euw==",
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/embarkjs/-/embarkjs-0.3.2.tgz",
+      "integrity": "sha512-XJSr4U6BOgQZX3AccTG9nc+4wAFkCMJODFNfH6wFb2IZQIt5GPgdEi822OBLLK4B9gpZ8tXDLryL5VEoRsEeQA==",
       "requires": {
-        "@babel/runtime": "^7.0.0-beta.54",
+        "@babel/runtime-corejs2": "7.0.0-rc.1",
         "async": "^2.0.1"
       }
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,29 +5,29 @@
   "requires": true,
   "dependencies": {
     "@babel/code-frame": {
-      "version": "7.0.0-beta.54",
-      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.0.0-beta.54.tgz",
-      "integrity": "sha1-ACT5b99wKKIdaOJzr9TpUyFKHq0=",
+      "version": "7.0.0-rc.1",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.0.0-rc.1.tgz",
+      "integrity": "sha512-qhQo3GqwqMUv03SxxjcEkWtlkEDvFYrBKbJUn4Dtd9amC2cLkJ3me4iYUVSBbVXWbfbVRalEeVBHzX4aQYKnBg==",
       "requires": {
-        "@babel/highlight": "7.0.0-beta.54"
+        "@babel/highlight": "7.0.0-rc.1"
       }
     },
     "@babel/core": {
-      "version": "7.0.0-beta.54",
-      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.0.0-beta.54.tgz",
-      "integrity": "sha1-JTxU0AlUA6XPp2Tn2bRYGUaS0Cs=",
+      "version": "7.0.0-rc.1",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.0.0-rc.1.tgz",
+      "integrity": "sha512-CvuSsq+LFs9N4SJG8MnNPI0hnl913HK1OqG3NEfejOKo+JqtVuxpmAFyXIDogX2x668xqFKAW6EQiCIcUHklMg==",
       "requires": {
-        "@babel/code-frame": "7.0.0-beta.54",
-        "@babel/generator": "7.0.0-beta.54",
-        "@babel/helpers": "7.0.0-beta.54",
-        "@babel/parser": "7.0.0-beta.54",
-        "@babel/template": "7.0.0-beta.54",
-        "@babel/traverse": "7.0.0-beta.54",
-        "@babel/types": "7.0.0-beta.54",
+        "@babel/code-frame": "7.0.0-rc.1",
+        "@babel/generator": "7.0.0-rc.1",
+        "@babel/helpers": "7.0.0-rc.1",
+        "@babel/parser": "7.0.0-rc.1",
+        "@babel/template": "7.0.0-rc.1",
+        "@babel/traverse": "7.0.0-rc.1",
+        "@babel/types": "7.0.0-rc.1",
         "convert-source-map": "^1.1.0",
         "debug": "^3.1.0",
         "json5": "^0.5.0",
-        "lodash": "^4.17.5",
+        "lodash": "^4.17.10",
         "resolve": "^1.3.2",
         "semver": "^5.4.1",
         "source-map": "^0.5.0"
@@ -44,13 +44,13 @@
       }
     },
     "@babel/generator": {
-      "version": "7.0.0-beta.54",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.0.0-beta.54.tgz",
-      "integrity": "sha1-wEPH7r7r/X5mXZXCgaSq/IPU4ck=",
+      "version": "7.0.0-rc.1",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.0.0-rc.1.tgz",
+      "integrity": "sha512-Ak4n780/coo+L9GZUS7V/IGJilP11t4UoWl0J9cG3jso4KkDGQcqdx4Y6gJAiXng+sDfvzUmvWfM1hZwH82J0A==",
       "requires": {
-        "@babel/types": "7.0.0-beta.54",
+        "@babel/types": "7.0.0-rc.1",
         "jsesc": "^2.5.1",
-        "lodash": "^4.17.5",
+        "lodash": "^4.17.10",
         "source-map": "^0.5.0",
         "trim-right": "^1.0.1"
       },
@@ -63,203 +63,203 @@
       }
     },
     "@babel/helper-annotate-as-pure": {
-      "version": "7.0.0-beta.54",
-      "resolved": "https://registry.npmjs.org/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.0.0-beta.54.tgz",
-      "integrity": "sha1-FiYSaj+fxO0oCslCNyx9OWU9cSE=",
+      "version": "7.0.0-rc.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.0.0-rc.1.tgz",
+      "integrity": "sha512-GOV2UExs9gAvSrZF4rcgocXXeLJplq2kL2AsCrn6DmGwMUEfo/KB7FhedN3X6cVh0gOqqKkVKXrz3Li1wQ84xQ==",
       "requires": {
-        "@babel/types": "7.0.0-beta.54"
+        "@babel/types": "7.0.0-rc.1"
       }
     },
     "@babel/helper-builder-binary-assignment-operator-visitor": {
-      "version": "7.0.0-beta.54",
-      "resolved": "https://registry.npmjs.org/@babel/helper-builder-binary-assignment-operator-visitor/-/helper-builder-binary-assignment-operator-visitor-7.0.0-beta.54.tgz",
-      "integrity": "sha1-0KGWdjW57ryv26gEkZF+5JgcEvo=",
+      "version": "7.0.0-rc.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-builder-binary-assignment-operator-visitor/-/helper-builder-binary-assignment-operator-visitor-7.0.0-rc.1.tgz",
+      "integrity": "sha512-O6/szesBinGoExLl01Qg2vb5FaOfifSilgL5GnCZLz5z3Pg9jRolN6rGzQAOa/K9Y01TAmDf1dC06AKQUv3x8g==",
       "requires": {
-        "@babel/helper-explode-assignable-expression": "7.0.0-beta.54",
-        "@babel/types": "7.0.0-beta.54"
+        "@babel/helper-explode-assignable-expression": "7.0.0-rc.1",
+        "@babel/types": "7.0.0-rc.1"
       }
     },
     "@babel/helper-builder-react-jsx": {
-      "version": "7.0.0-beta.54",
-      "resolved": "https://registry.npmjs.org/@babel/helper-builder-react-jsx/-/helper-builder-react-jsx-7.0.0-beta.54.tgz",
-      "integrity": "sha1-ytWCqxy4MfTcNOm8tMT6Lx+2yYY=",
+      "version": "7.0.0-rc.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-builder-react-jsx/-/helper-builder-react-jsx-7.0.0-rc.1.tgz",
+      "integrity": "sha512-yhZzfcpjoCnZKrJ/ObzpQmaveBictCRoiIciz0FhAY97+J1lx4Zuy+t9ZqGr3pP4U4rV7UOXyuLknbhNkWT0Ew==",
       "requires": {
-        "@babel/types": "7.0.0-beta.54",
+        "@babel/types": "7.0.0-rc.1",
         "esutils": "^2.0.0"
       }
     },
     "@babel/helper-call-delegate": {
-      "version": "7.0.0-beta.54",
-      "resolved": "https://registry.npmjs.org/@babel/helper-call-delegate/-/helper-call-delegate-7.0.0-beta.54.tgz",
-      "integrity": "sha1-9rcs/YMvsm6yqAbhjeBfiNOo8wI=",
+      "version": "7.0.0-rc.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-call-delegate/-/helper-call-delegate-7.0.0-rc.1.tgz",
+      "integrity": "sha512-3Z+shHGJTQnc61RCFVrQ3OJRmyL8uk4dWCsP8kT7G4inxv/bs6/zLOipK21VMePGpjUA4tnKxJCevMtp9ko4pw==",
       "requires": {
-        "@babel/helper-hoist-variables": "7.0.0-beta.54",
-        "@babel/traverse": "7.0.0-beta.54",
-        "@babel/types": "7.0.0-beta.54"
+        "@babel/helper-hoist-variables": "7.0.0-rc.1",
+        "@babel/traverse": "7.0.0-rc.1",
+        "@babel/types": "7.0.0-rc.1"
       }
     },
     "@babel/helper-define-map": {
-      "version": "7.0.0-beta.54",
-      "resolved": "https://registry.npmjs.org/@babel/helper-define-map/-/helper-define-map-7.0.0-beta.54.tgz",
-      "integrity": "sha1-IDbXxJNlmH8JHblwLOLztV9ndzA=",
+      "version": "7.0.0-rc.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-define-map/-/helper-define-map-7.0.0-rc.1.tgz",
+      "integrity": "sha512-yTn+nj29QrZLCINtgqFLgbrbvz6yM029ox/MpQfSS/JmrQovnEc+o5vrsW/R74QPheOHmF9ruJo58atwuk04Fw==",
       "requires": {
-        "@babel/helper-function-name": "7.0.0-beta.54",
-        "@babel/types": "7.0.0-beta.54",
-        "lodash": "^4.17.5"
+        "@babel/helper-function-name": "7.0.0-rc.1",
+        "@babel/types": "7.0.0-rc.1",
+        "lodash": "^4.17.10"
       }
     },
     "@babel/helper-explode-assignable-expression": {
-      "version": "7.0.0-beta.54",
-      "resolved": "https://registry.npmjs.org/@babel/helper-explode-assignable-expression/-/helper-explode-assignable-expression-7.0.0-beta.54.tgz",
-      "integrity": "sha1-zwZ/MzCWXCBIvwh+oG9ix22Up5I=",
+      "version": "7.0.0-rc.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-explode-assignable-expression/-/helper-explode-assignable-expression-7.0.0-rc.1.tgz",
+      "integrity": "sha512-hSa+oxKn9bfbc3Ob1U7QJsO++do2Xe8Ft640alRJpEQ3VWy7tL8ZB+2xqo0pgHKo7rITuSxERz72uZji8dTiWg==",
       "requires": {
-        "@babel/traverse": "7.0.0-beta.54",
-        "@babel/types": "7.0.0-beta.54"
+        "@babel/traverse": "7.0.0-rc.1",
+        "@babel/types": "7.0.0-rc.1"
       }
     },
     "@babel/helper-function-name": {
-      "version": "7.0.0-beta.54",
-      "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.0.0-beta.54.tgz",
-      "integrity": "sha1-MHh1UHoe2iSCoJqaTfaiVjL/s0s=",
+      "version": "7.0.0-rc.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.0.0-rc.1.tgz",
+      "integrity": "sha512-fDbWxdYYbFNzcI5jn3qsPxHI1UCXwvFk0kGytGce/FEBYEPXBqycKknC8Oqiub8DzGtmTcvnqcm/cl/qxzeuiQ==",
       "requires": {
-        "@babel/helper-get-function-arity": "7.0.0-beta.54",
-        "@babel/template": "7.0.0-beta.54",
-        "@babel/types": "7.0.0-beta.54"
+        "@babel/helper-get-function-arity": "7.0.0-rc.1",
+        "@babel/template": "7.0.0-rc.1",
+        "@babel/types": "7.0.0-rc.1"
       }
     },
     "@babel/helper-get-function-arity": {
-      "version": "7.0.0-beta.54",
-      "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.0.0-beta.54.tgz",
-      "integrity": "sha1-dXvRibB3B0oAQCjP3l8IPDBsxsQ=",
+      "version": "7.0.0-rc.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.0.0-rc.1.tgz",
+      "integrity": "sha512-5+ydaIRxT42FSDqvoXIDksCGlW1903xC73HQnQCFF1YuV7VcIf+9M4+tRZulLlYlshw7ILA+4SiYsKoDlC0Irg==",
       "requires": {
-        "@babel/types": "7.0.0-beta.54"
+        "@babel/types": "7.0.0-rc.1"
       }
     },
     "@babel/helper-hoist-variables": {
-      "version": "7.0.0-beta.54",
-      "resolved": "https://registry.npmjs.org/@babel/helper-hoist-variables/-/helper-hoist-variables-7.0.0-beta.54.tgz",
-      "integrity": "sha1-hjW+gJUTX/c/dT7RieRJ9otPQ8s=",
+      "version": "7.0.0-rc.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-hoist-variables/-/helper-hoist-variables-7.0.0-rc.1.tgz",
+      "integrity": "sha512-ttcilOh9SM9eqVlzwz2Lv7B5Dwyaa8TIhi1DDEPnC3CarpNPXFdeCOoxoV5qjHRD1klAT86gczeU4lJnSDKmgA==",
       "requires": {
-        "@babel/types": "7.0.0-beta.54"
+        "@babel/types": "7.0.0-rc.1"
       }
     },
     "@babel/helper-member-expression-to-functions": {
-      "version": "7.0.0-beta.54",
-      "resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.0.0-beta.54.tgz",
-      "integrity": "sha1-vOndxIQxexPSYVuv4rUk0NVtmd8=",
+      "version": "7.0.0-rc.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.0.0-rc.1.tgz",
+      "integrity": "sha512-o263plHxPo1TxDDUx7gHuQ96Y8QyLs2n4968KZvo2l/9rkwn2L9kcIsRVjlhpPPKTz4tWe/7ZV50zkeDorrK9g==",
       "requires": {
-        "@babel/types": "7.0.0-beta.54"
+        "@babel/types": "7.0.0-rc.1"
       }
     },
     "@babel/helper-module-imports": {
-      "version": "7.0.0-beta.54",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.0.0-beta.54.tgz",
-      "integrity": "sha1-wtjhT/A0Ilv0MTVtt370Z7jTWqw=",
+      "version": "7.0.0-rc.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.0.0-rc.1.tgz",
+      "integrity": "sha512-eA8RzanjsZw4X2Cqh3WgVG7zwf1wdSUfXvZOH8Azx1rpwE0hzJ276jDZ3gSOJShsxPVvopHa4h+c2WfEUjW4+Q==",
       "requires": {
-        "@babel/types": "7.0.0-beta.54",
-        "lodash": "^4.17.5"
+        "@babel/types": "7.0.0-rc.1",
+        "lodash": "^4.17.10"
       }
     },
     "@babel/helper-module-transforms": {
-      "version": "7.0.0-beta.54",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.0.0-beta.54.tgz",
-      "integrity": "sha1-jMV+sNtfCUXYZlJNVVq9CE4wzDU=",
+      "version": "7.0.0-rc.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.0.0-rc.1.tgz",
+      "integrity": "sha512-nz7FTFXlQ9UYp/dBjad4ZOu3Q4/1n86ysw9z9pjunqeKFNm+JHq7j5BeocFKIQAwul7QbIkSXiYm5EiteCHjiQ==",
       "requires": {
-        "@babel/helper-module-imports": "7.0.0-beta.54",
-        "@babel/helper-simple-access": "7.0.0-beta.54",
-        "@babel/helper-split-export-declaration": "7.0.0-beta.54",
-        "@babel/template": "7.0.0-beta.54",
-        "@babel/types": "7.0.0-beta.54",
-        "lodash": "^4.17.5"
+        "@babel/helper-module-imports": "7.0.0-rc.1",
+        "@babel/helper-simple-access": "7.0.0-rc.1",
+        "@babel/helper-split-export-declaration": "7.0.0-rc.1",
+        "@babel/template": "7.0.0-rc.1",
+        "@babel/types": "7.0.0-rc.1",
+        "lodash": "^4.17.10"
       }
     },
     "@babel/helper-optimise-call-expression": {
-      "version": "7.0.0-beta.54",
-      "resolved": "https://registry.npmjs.org/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.0.0-beta.54.tgz",
-      "integrity": "sha1-SvjdT/kNvSmzvPhf/0OVLirhAW4=",
+      "version": "7.0.0-rc.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.0.0-rc.1.tgz",
+      "integrity": "sha512-XOKPnL/AJz8ZyY553FsMAVt9g/mE1+RQfg5/m3X0K4+RqYviPGZlxwe5mGSd8s2kPSB6D6nZRUfvZFtmFIXEvA==",
       "requires": {
-        "@babel/types": "7.0.0-beta.54"
+        "@babel/types": "7.0.0-rc.1"
       }
     },
     "@babel/helper-plugin-utils": {
-      "version": "7.0.0-beta.54",
-      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.0.0-beta.54.tgz",
-      "integrity": "sha1-YdKpoPmj4xg4pFjeu57r173SSbQ="
+      "version": "7.0.0-rc.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.0.0-rc.1.tgz",
+      "integrity": "sha512-8ZNzqHXDhT/JjnBvrLKu8AL7NhONVIsnrfyQNm3PJNmufIER5kcIa3OxPMGWgNqox2R8WeQ6YYzYTLNXqq4kgQ=="
     },
     "@babel/helper-regex": {
-      "version": "7.0.0-beta.54",
-      "resolved": "https://registry.npmjs.org/@babel/helper-regex/-/helper-regex-7.0.0-beta.54.tgz",
-      "integrity": "sha1-isVi+FXxMvxo39ELEyVSVVrIcNk=",
+      "version": "7.0.0-rc.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-regex/-/helper-regex-7.0.0-rc.1.tgz",
+      "integrity": "sha512-QXnTXVefioGuXlRMn+MnKKUHwhmdXGKnMvFI1tdHioMnBQEbEHGnmp+aYcddLwJ3KAH/hveaSR95BuWwprW+TA==",
       "requires": {
-        "lodash": "^4.17.5"
+        "lodash": "^4.17.10"
       }
     },
     "@babel/helper-remap-async-to-generator": {
-      "version": "7.0.0-beta.54",
-      "resolved": "https://registry.npmjs.org/@babel/helper-remap-async-to-generator/-/helper-remap-async-to-generator-7.0.0-beta.54.tgz",
-      "integrity": "sha1-OaUAUqrddNQMc7fFjrljuQ+sVtM=",
+      "version": "7.0.0-rc.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-remap-async-to-generator/-/helper-remap-async-to-generator-7.0.0-rc.1.tgz",
+      "integrity": "sha512-skROQSC2fPwmrzAEPT/M7CObnWjJGpdbNLoICZDYHwDiUDe3dk5cQsU9j3tNlBhX14FaC9SjSpCJnSRpXDOWOw==",
       "requires": {
-        "@babel/helper-annotate-as-pure": "7.0.0-beta.54",
-        "@babel/helper-wrap-function": "7.0.0-beta.54",
-        "@babel/template": "7.0.0-beta.54",
-        "@babel/traverse": "7.0.0-beta.54",
-        "@babel/types": "7.0.0-beta.54"
+        "@babel/helper-annotate-as-pure": "7.0.0-rc.1",
+        "@babel/helper-wrap-function": "7.0.0-rc.1",
+        "@babel/template": "7.0.0-rc.1",
+        "@babel/traverse": "7.0.0-rc.1",
+        "@babel/types": "7.0.0-rc.1"
       }
     },
     "@babel/helper-replace-supers": {
-      "version": "7.0.0-beta.54",
-      "resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.0.0-beta.54.tgz",
-      "integrity": "sha1-kB9aFJOkEHmf06s+DA0p0YBxyJ8=",
+      "version": "7.0.0-rc.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.0.0-rc.1.tgz",
+      "integrity": "sha512-mcv+NKCazZfdEw7yBe/xROekR3qlFcy18d//mJTKnZb7xx2qFPjZAafkeIlpvzNHwd/WMTHShC4+3WjOL8FD5g==",
       "requires": {
-        "@babel/helper-member-expression-to-functions": "7.0.0-beta.54",
-        "@babel/helper-optimise-call-expression": "7.0.0-beta.54",
-        "@babel/traverse": "7.0.0-beta.54",
-        "@babel/types": "7.0.0-beta.54"
+        "@babel/helper-member-expression-to-functions": "7.0.0-rc.1",
+        "@babel/helper-optimise-call-expression": "7.0.0-rc.1",
+        "@babel/traverse": "7.0.0-rc.1",
+        "@babel/types": "7.0.0-rc.1"
       }
     },
     "@babel/helper-simple-access": {
-      "version": "7.0.0-beta.54",
-      "resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.0.0-beta.54.tgz",
-      "integrity": "sha1-X3YKGViam28H6Apl70vL1PuowlM=",
+      "version": "7.0.0-rc.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.0.0-rc.1.tgz",
+      "integrity": "sha512-mfrHVSG0Dw51ajyL3Ltz+gEYrWAy4+Kl8lb1V/QWR31H7ovha6vNZ4guev/lR4KFu+4hMHogpjh4HB4AShqeMQ==",
       "requires": {
-        "@babel/template": "7.0.0-beta.54",
-        "@babel/types": "7.0.0-beta.54",
-        "lodash": "^4.17.5"
+        "@babel/template": "7.0.0-rc.1",
+        "@babel/types": "7.0.0-rc.1",
+        "lodash": "^4.17.10"
       }
     },
     "@babel/helper-split-export-declaration": {
-      "version": "7.0.0-beta.54",
-      "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.0.0-beta.54.tgz",
-      "integrity": "sha1-ic2IM8lUgaCCesahv8zduSt1oQk=",
+      "version": "7.0.0-rc.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.0.0-rc.1.tgz",
+      "integrity": "sha512-hz6QmlnaBFYt4ra8DfRLCMgrI7yfwQ13kJtufSO5dVCasxmAng2LeeQiT6H4iN5TpFONcayp5f/2mXqHH/zn/g==",
       "requires": {
-        "@babel/types": "7.0.0-beta.54"
+        "@babel/types": "7.0.0-rc.1"
       }
     },
     "@babel/helper-wrap-function": {
-      "version": "7.0.0-beta.54",
-      "resolved": "https://registry.npmjs.org/@babel/helper-wrap-function/-/helper-wrap-function-7.0.0-beta.54.tgz",
-      "integrity": "sha1-3Bt6SDowdKNTGzZSPgMVbZEKOio=",
+      "version": "7.0.0-rc.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-wrap-function/-/helper-wrap-function-7.0.0-rc.1.tgz",
+      "integrity": "sha512-LrqRD4+jEkQGVQsCRi7bPkSmYFAUd3pv9tYAC8nsr9Y0Qfus8oycqxDj60QW4dmigRKBRRbVVLr/0kMI2pk0MA==",
       "requires": {
-        "@babel/helper-function-name": "7.0.0-beta.54",
-        "@babel/template": "7.0.0-beta.54",
-        "@babel/traverse": "7.0.0-beta.54",
-        "@babel/types": "7.0.0-beta.54"
+        "@babel/helper-function-name": "7.0.0-rc.1",
+        "@babel/template": "7.0.0-rc.1",
+        "@babel/traverse": "7.0.0-rc.1",
+        "@babel/types": "7.0.0-rc.1"
       }
     },
     "@babel/helpers": {
-      "version": "7.0.0-beta.54",
-      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.0.0-beta.54.tgz",
-      "integrity": "sha1-uGqZqA79gWaMrvMHYQuWEZdEanQ=",
+      "version": "7.0.0-rc.1",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.0.0-rc.1.tgz",
+      "integrity": "sha512-4+AkDbZ0Usr7mNH4wGX8fVx4WJzHdrcjRkJy52EIWyBAQEoKqb5HXca1VjejWtnVwaGwW7zk/h6oQ9FQPywQfA==",
       "requires": {
-        "@babel/template": "7.0.0-beta.54",
-        "@babel/traverse": "7.0.0-beta.54",
-        "@babel/types": "7.0.0-beta.54"
+        "@babel/template": "7.0.0-rc.1",
+        "@babel/traverse": "7.0.0-rc.1",
+        "@babel/types": "7.0.0-rc.1"
       }
     },
     "@babel/highlight": {
-      "version": "7.0.0-beta.54",
-      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.0.0-beta.54.tgz",
-      "integrity": "sha1-FV1Qc1gym45waJcAF8P9dKmwhYQ=",
+      "version": "7.0.0-rc.1",
+      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.0.0-rc.1.tgz",
+      "integrity": "sha512-5PgPDV6F5s69XNznTcP0za3qH7qgBkr9DVQTXfZtpF+3iEyuIZB1Mjxu52F5CFxgzQUQJoBYHVxtH4Itdb5MgA==",
       "requires": {
         "chalk": "^2.0.0",
         "esutils": "^2.0.2",
@@ -300,45 +300,45 @@
       }
     },
     "@babel/parser": {
-      "version": "7.0.0-beta.54",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.0.0-beta.54.tgz",
-      "integrity": "sha1-wBqmO1fJyNzodEeWyB2d8SHyDbQ="
+      "version": "7.0.0-rc.1",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.0.0-rc.1.tgz",
+      "integrity": "sha512-rC+bIz2eZnJlacERmJO25UAbXVZttcSxh0Px0gRGinOTzug5tL7+L9urfIdSWlv1ZzP03+f2xkOFLOxZqSsVmQ=="
     },
     "@babel/plugin-proposal-async-generator-functions": {
-      "version": "7.0.0-beta.54",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-async-generator-functions/-/plugin-proposal-async-generator-functions-7.0.0-beta.54.tgz",
-      "integrity": "sha1-GYcb1lW110iwrj6ezr4ke+i3+Ds=",
+      "version": "7.0.0-rc.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-async-generator-functions/-/plugin-proposal-async-generator-functions-7.0.0-rc.1.tgz",
+      "integrity": "sha512-ewJnWv10AFUh+Yi6axMVQKW8L1pZCm86a44m2biYtXNSyt6FyWgdRloBbR7iCviPkeurfTCVdPS61G/t5cXVkQ==",
       "requires": {
-        "@babel/helper-plugin-utils": "7.0.0-beta.54",
-        "@babel/helper-remap-async-to-generator": "7.0.0-beta.54",
-        "@babel/plugin-syntax-async-generators": "7.0.0-beta.54"
+        "@babel/helper-plugin-utils": "7.0.0-rc.1",
+        "@babel/helper-remap-async-to-generator": "7.0.0-rc.1",
+        "@babel/plugin-syntax-async-generators": "7.0.0-rc.1"
       }
     },
     "@babel/plugin-proposal-object-rest-spread": {
-      "version": "7.0.0-beta.54",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-object-rest-spread/-/plugin-proposal-object-rest-spread-7.0.0-beta.54.tgz",
-      "integrity": "sha1-VIEmmgIN0NOHFagJT+0BXTDvTCo=",
+      "version": "7.0.0-rc.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-object-rest-spread/-/plugin-proposal-object-rest-spread-7.0.0-rc.1.tgz",
+      "integrity": "sha512-J9qLEkxuZrYh/mel9RA5wDrMGE7jQMOMa1XPZMysih4C0mveeQUExbAPyrVSrFQo5BXLcLIc6ccM24G9xPCCXA==",
       "requires": {
-        "@babel/helper-plugin-utils": "7.0.0-beta.54",
-        "@babel/plugin-syntax-object-rest-spread": "7.0.0-beta.54"
+        "@babel/helper-plugin-utils": "7.0.0-rc.1",
+        "@babel/plugin-syntax-object-rest-spread": "7.0.0-rc.1"
       }
     },
     "@babel/plugin-proposal-optional-catch-binding": {
-      "version": "7.0.0-beta.54",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-optional-catch-binding/-/plugin-proposal-optional-catch-binding-7.0.0-beta.54.tgz",
-      "integrity": "sha1-kx9pKY+gxBGyWWYWz1odgpJbh6k=",
+      "version": "7.0.0-rc.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-optional-catch-binding/-/plugin-proposal-optional-catch-binding-7.0.0-rc.1.tgz",
+      "integrity": "sha512-mNJULpCOErHPVvnqj2i464uVuWuTTrnJFoT8dYyODCSjHBypdVvEGZx4Rk67etdDMv+iytZTdKDHUXq5JtWCdg==",
       "requires": {
-        "@babel/helper-plugin-utils": "7.0.0-beta.54",
-        "@babel/plugin-syntax-optional-catch-binding": "7.0.0-beta.54"
+        "@babel/helper-plugin-utils": "7.0.0-rc.1",
+        "@babel/plugin-syntax-optional-catch-binding": "7.0.0-rc.1"
       }
     },
     "@babel/plugin-proposal-unicode-property-regex": {
-      "version": "7.0.0-beta.54",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-unicode-property-regex/-/plugin-proposal-unicode-property-regex-7.0.0-beta.54.tgz",
-      "integrity": "sha1-FiRjH69oi8veSRhxK9CvcYb30kU=",
+      "version": "7.0.0-rc.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-unicode-property-regex/-/plugin-proposal-unicode-property-regex-7.0.0-rc.1.tgz",
+      "integrity": "sha512-NrUBXqwxnvrhJDzeJ4yOiPDDpPbjVQsydRELHVqzjy+WAOh/cAT4JOmMrQegU/vOjj62LM8S1Kp8wHpDgskTLQ==",
       "requires": {
-        "@babel/helper-plugin-utils": "7.0.0-beta.54",
-        "@babel/helper-regex": "7.0.0-beta.54",
+        "@babel/helper-plugin-utils": "7.0.0-rc.1",
+        "@babel/helper-regex": "7.0.0-rc.1",
         "regexpu-core": "^4.2.0"
       },
       "dependencies": {
@@ -376,84 +376,84 @@
       }
     },
     "@babel/plugin-syntax-async-generators": {
-      "version": "7.0.0-beta.54",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-async-generators/-/plugin-syntax-async-generators-7.0.0-beta.54.tgz",
-      "integrity": "sha1-/6yPZJJ2FHYol8yWQ0lf04CX3UE=",
+      "version": "7.0.0-rc.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-async-generators/-/plugin-syntax-async-generators-7.0.0-rc.1.tgz",
+      "integrity": "sha512-2F5FYc89TCrqE/8+qFlr5jVMTHfkhEOg9JUx+GXI3inW2OfcY+J6bN8EDc8PLz84PHaR8W630YOuh2PveJu3WA==",
       "requires": {
-        "@babel/helper-plugin-utils": "7.0.0-beta.54"
+        "@babel/helper-plugin-utils": "7.0.0-rc.1"
       }
     },
     "@babel/plugin-syntax-jsx": {
-      "version": "7.0.0-beta.54",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-7.0.0-beta.54.tgz",
-      "integrity": "sha1-cRca7pArlMzy4iqBDRQmtRZbjYQ=",
+      "version": "7.0.0-rc.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-7.0.0-rc.1.tgz",
+      "integrity": "sha512-n0BcD2LmCrQkDKRhUd7lSiXiRpbo6Z7x77v3FSuevH5oWTFChjX34vHCCOszgVP37NLAxhuf4Jz0KwiPgXnexg==",
       "requires": {
-        "@babel/helper-plugin-utils": "7.0.0-beta.54"
+        "@babel/helper-plugin-utils": "7.0.0-rc.1"
       }
     },
     "@babel/plugin-syntax-object-rest-spread": {
-      "version": "7.0.0-beta.54",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-object-rest-spread/-/plugin-syntax-object-rest-spread-7.0.0-beta.54.tgz",
-      "integrity": "sha1-4PRFYSCBq1c+JTWturx7cQ0XlAw=",
+      "version": "7.0.0-rc.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-object-rest-spread/-/plugin-syntax-object-rest-spread-7.0.0-rc.1.tgz",
+      "integrity": "sha512-stOESgG+lc68DSFvXrqoH5dW91ZtedDoR40g9wJ1ruLahCdr9X5hVLv/ddf/g/1zzjevq59A1Q+xdUREhEnrvQ==",
       "requires": {
-        "@babel/helper-plugin-utils": "7.0.0-beta.54"
+        "@babel/helper-plugin-utils": "7.0.0-rc.1"
       }
     },
     "@babel/plugin-syntax-optional-catch-binding": {
-      "version": "7.0.0-beta.54",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-optional-catch-binding/-/plugin-syntax-optional-catch-binding-7.0.0-beta.54.tgz",
-      "integrity": "sha1-Lrjd3hnd9zo0PQh6CHFZ7UTlSAk=",
+      "version": "7.0.0-rc.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-optional-catch-binding/-/plugin-syntax-optional-catch-binding-7.0.0-rc.1.tgz",
+      "integrity": "sha512-e4dGUnZGhg1LWTvyQ6/m8nKZ9bUrtPwl9M487CEVhTA5lVUvYxASHBCEtkVWPwT16NzcWlFR/PghsHeLFGIw7A==",
       "requires": {
-        "@babel/helper-plugin-utils": "7.0.0-beta.54"
+        "@babel/helper-plugin-utils": "7.0.0-rc.1"
       }
     },
     "@babel/plugin-transform-arrow-functions": {
-      "version": "7.0.0-beta.54",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-arrow-functions/-/plugin-transform-arrow-functions-7.0.0-beta.54.tgz",
-      "integrity": "sha1-RKl3uOYeTvzHZYu74mDyBMobz3I=",
+      "version": "7.0.0-rc.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-arrow-functions/-/plugin-transform-arrow-functions-7.0.0-rc.1.tgz",
+      "integrity": "sha512-9JnWkl+iKmjNgMFrLjfGJQm3f66SJxwaYjdsm49Vpvo9x7ADHMGMZYa5Yto9WNQBlIdtf+fhypwBcz6IPxdyvg==",
       "requires": {
-        "@babel/helper-plugin-utils": "7.0.0-beta.54"
+        "@babel/helper-plugin-utils": "7.0.0-rc.1"
       }
     },
     "@babel/plugin-transform-async-to-generator": {
-      "version": "7.0.0-beta.54",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-async-to-generator/-/plugin-transform-async-to-generator-7.0.0-beta.54.tgz",
-      "integrity": "sha1-0DXmXFCISTfWTb5o0WSYwDL4u+w=",
+      "version": "7.0.0-rc.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-async-to-generator/-/plugin-transform-async-to-generator-7.0.0-rc.1.tgz",
+      "integrity": "sha512-8oE9Frx07ILINop9hOejXgcDVhmt4FuB3ZjXnIMcSMkAuiT3xLrxFMDo1Qo0kf5mty2jLlnOO6tbbH0kiIWxWA==",
       "requires": {
-        "@babel/helper-module-imports": "7.0.0-beta.54",
-        "@babel/helper-plugin-utils": "7.0.0-beta.54",
-        "@babel/helper-remap-async-to-generator": "7.0.0-beta.54"
+        "@babel/helper-module-imports": "7.0.0-rc.1",
+        "@babel/helper-plugin-utils": "7.0.0-rc.1",
+        "@babel/helper-remap-async-to-generator": "7.0.0-rc.1"
       }
     },
     "@babel/plugin-transform-block-scoped-functions": {
-      "version": "7.0.0-beta.54",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoped-functions/-/plugin-transform-block-scoped-functions-7.0.0-beta.54.tgz",
-      "integrity": "sha1-k4p3+xLw4RZhvfU4bkrspH8MBTs=",
+      "version": "7.0.0-rc.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoped-functions/-/plugin-transform-block-scoped-functions-7.0.0-rc.1.tgz",
+      "integrity": "sha512-dFEgZqmyWXaVYrFU11IgLX8M1+gK7GSU+CVRv42D7P1FFMNndg1u36jXIa7URExEuTeTUykLM/IWgk5pHWxo6A==",
       "requires": {
-        "@babel/helper-plugin-utils": "7.0.0-beta.54"
+        "@babel/helper-plugin-utils": "7.0.0-rc.1"
       }
     },
     "@babel/plugin-transform-block-scoping": {
-      "version": "7.0.0-beta.54",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoping/-/plugin-transform-block-scoping-7.0.0-beta.54.tgz",
-      "integrity": "sha1-vK4cL/rkzDt7PlRV8KmNrswJo8Y=",
+      "version": "7.0.0-rc.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoping/-/plugin-transform-block-scoping-7.0.0-rc.1.tgz",
+      "integrity": "sha512-9uGwvSqJcmcKPEkLHA7ffrG0lKXTXprupwGjEKDw27OoRWXHdWUmA4VwpuzMrUsYyV+q+P6mgj6TPzoGJA3fAw==",
       "requires": {
-        "@babel/helper-plugin-utils": "7.0.0-beta.54",
-        "lodash": "^4.17.5"
+        "@babel/helper-plugin-utils": "7.0.0-rc.1",
+        "lodash": "^4.17.10"
       }
     },
     "@babel/plugin-transform-classes": {
-      "version": "7.0.0-beta.54",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-classes/-/plugin-transform-classes-7.0.0-beta.54.tgz",
-      "integrity": "sha1-sVeB0uSZziVDjnP+ovpaCYWFaP8=",
+      "version": "7.0.0-rc.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-classes/-/plugin-transform-classes-7.0.0-rc.1.tgz",
+      "integrity": "sha512-mPXMbQR8zNHMXvaJ71wQ7iPcQLHPv12XjWwvYkDjtsEvknDQ2HWA+UYZGVpZ0bv3jLQIZuwc1kZ6f5vSsavvog==",
       "requires": {
-        "@babel/helper-annotate-as-pure": "7.0.0-beta.54",
-        "@babel/helper-define-map": "7.0.0-beta.54",
-        "@babel/helper-function-name": "7.0.0-beta.54",
-        "@babel/helper-optimise-call-expression": "7.0.0-beta.54",
-        "@babel/helper-plugin-utils": "7.0.0-beta.54",
-        "@babel/helper-replace-supers": "7.0.0-beta.54",
-        "@babel/helper-split-export-declaration": "7.0.0-beta.54",
+        "@babel/helper-annotate-as-pure": "7.0.0-rc.1",
+        "@babel/helper-define-map": "7.0.0-rc.1",
+        "@babel/helper-function-name": "7.0.0-rc.1",
+        "@babel/helper-optimise-call-expression": "7.0.0-rc.1",
+        "@babel/helper-plugin-utils": "7.0.0-rc.1",
+        "@babel/helper-replace-supers": "7.0.0-rc.1",
+        "@babel/helper-split-export-declaration": "7.0.0-rc.1",
         "globals": "^11.1.0"
       },
       "dependencies": {
@@ -465,28 +465,28 @@
       }
     },
     "@babel/plugin-transform-computed-properties": {
-      "version": "7.0.0-beta.54",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-computed-properties/-/plugin-transform-computed-properties-7.0.0-beta.54.tgz",
-      "integrity": "sha1-soSUlCuU+4bQGZR2PStcQ73Zhq8=",
+      "version": "7.0.0-rc.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-computed-properties/-/plugin-transform-computed-properties-7.0.0-rc.1.tgz",
+      "integrity": "sha512-dfJNqbyF6S8nvFzGc6NthqCqopn1PoY3q2E1KcgrFSgxwYAMOLuhu5eA5iFeXwggp6tIo6OVVXC55/Twsolmow==",
       "requires": {
-        "@babel/helper-plugin-utils": "7.0.0-beta.54"
+        "@babel/helper-plugin-utils": "7.0.0-rc.1"
       }
     },
     "@babel/plugin-transform-destructuring": {
-      "version": "7.0.0-beta.54",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-destructuring/-/plugin-transform-destructuring-7.0.0-beta.54.tgz",
-      "integrity": "sha1-gfZJo+T8tiwrKtSX94OoALmURy8=",
+      "version": "7.0.0-rc.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-destructuring/-/plugin-transform-destructuring-7.0.0-rc.1.tgz",
+      "integrity": "sha512-YpuGA3cj5+gRD053nWtogo+3wxc10mNAAyf5syXXCVS/cOWpRjc3qPidzHtPodz+v8TgAwwaXwIz/ghLOojRQw==",
       "requires": {
-        "@babel/helper-plugin-utils": "7.0.0-beta.54"
+        "@babel/helper-plugin-utils": "7.0.0-rc.1"
       }
     },
     "@babel/plugin-transform-dotall-regex": {
-      "version": "7.0.0-beta.54",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-dotall-regex/-/plugin-transform-dotall-regex-7.0.0-beta.54.tgz",
-      "integrity": "sha1-KDW39BQbGfoGSOuW/+PE/M0eyiA=",
+      "version": "7.0.0-rc.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-dotall-regex/-/plugin-transform-dotall-regex-7.0.0-rc.1.tgz",
+      "integrity": "sha512-6G62wnwVWCjhvmWmWatXHO4wfvWhUL1bJX0MABYIf1bpD5ROFly/HxgWkuMVcTSeIuLzsfsYKSF1CMUI0bykXw==",
       "requires": {
-        "@babel/helper-plugin-utils": "7.0.0-beta.54",
-        "@babel/helper-regex": "7.0.0-beta.54",
+        "@babel/helper-plugin-utils": "7.0.0-rc.1",
+        "@babel/helper-regex": "7.0.0-rc.1",
         "regexpu-core": "^4.1.3"
       },
       "dependencies": {
@@ -524,151 +524,151 @@
       }
     },
     "@babel/plugin-transform-duplicate-keys": {
-      "version": "7.0.0-beta.54",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-duplicate-keys/-/plugin-transform-duplicate-keys-7.0.0-beta.54.tgz",
-      "integrity": "sha1-S49Ps0mQKoAGeRkfWdD6U/yklAA=",
+      "version": "7.0.0-rc.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-duplicate-keys/-/plugin-transform-duplicate-keys-7.0.0-rc.1.tgz",
+      "integrity": "sha512-cWyoUi1izJk5JbWFG07GZrZyZgG+DW4axPKI0MA+lSAxjP8VZwFUhJyjT7R4bGN81KTVv1aprKclQnKxN2R0Lw==",
       "requires": {
-        "@babel/helper-plugin-utils": "7.0.0-beta.54"
+        "@babel/helper-plugin-utils": "7.0.0-rc.1"
       }
     },
     "@babel/plugin-transform-exponentiation-operator": {
-      "version": "7.0.0-beta.54",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-exponentiation-operator/-/plugin-transform-exponentiation-operator-7.0.0-beta.54.tgz",
-      "integrity": "sha1-EBcJY2b7Q+vKjtjY0M3R69ZP67I=",
+      "version": "7.0.0-rc.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-exponentiation-operator/-/plugin-transform-exponentiation-operator-7.0.0-rc.1.tgz",
+      "integrity": "sha512-5lc0nlX8TPdkHSIX3/3jMtqvvJfzcARcev4qqsaVkXWQ6XNrNnD8ExyTEVgoGhr5Ppz1wA0ymAK8W33uGeKSOg==",
       "requires": {
-        "@babel/helper-builder-binary-assignment-operator-visitor": "7.0.0-beta.54",
-        "@babel/helper-plugin-utils": "7.0.0-beta.54"
+        "@babel/helper-builder-binary-assignment-operator-visitor": "7.0.0-rc.1",
+        "@babel/helper-plugin-utils": "7.0.0-rc.1"
       }
     },
     "@babel/plugin-transform-for-of": {
-      "version": "7.0.0-beta.54",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-for-of/-/plugin-transform-for-of-7.0.0-beta.54.tgz",
-      "integrity": "sha1-Jh0pkgWKngkjS5/2eCAFT/xV95w=",
+      "version": "7.0.0-rc.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-for-of/-/plugin-transform-for-of-7.0.0-rc.1.tgz",
+      "integrity": "sha512-v09o2ywKHu+b/vkLknjKPV9QXCxuU2cVFxkWhBqcKwl3ERe3clhiab7a/8T9Sc332o4Im6n/LLugKMtpfxqRsQ==",
       "requires": {
-        "@babel/helper-plugin-utils": "7.0.0-beta.54"
+        "@babel/helper-plugin-utils": "7.0.0-rc.1"
       }
     },
     "@babel/plugin-transform-function-name": {
-      "version": "7.0.0-beta.54",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-function-name/-/plugin-transform-function-name-7.0.0-beta.54.tgz",
-      "integrity": "sha1-zHIvmXOTEzfe89HmxVE4WB7dNx4=",
+      "version": "7.0.0-rc.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-function-name/-/plugin-transform-function-name-7.0.0-rc.1.tgz",
+      "integrity": "sha512-MiUORPQo3kvSCYBn/T6kKIfdDKqFAnEsaiRnTz36Y6M/p6NX7br5MgqPumVNgDboYKQ9kzaFNM8YJvWLcjL6SQ==",
       "requires": {
-        "@babel/helper-function-name": "7.0.0-beta.54",
-        "@babel/helper-plugin-utils": "7.0.0-beta.54"
+        "@babel/helper-function-name": "7.0.0-rc.1",
+        "@babel/helper-plugin-utils": "7.0.0-rc.1"
       }
     },
     "@babel/plugin-transform-literals": {
-      "version": "7.0.0-beta.54",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-literals/-/plugin-transform-literals-7.0.0-beta.54.tgz",
-      "integrity": "sha1-cPB+zC87e8n1QqV46C7sGKVQQJg=",
+      "version": "7.0.0-rc.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-literals/-/plugin-transform-literals-7.0.0-rc.1.tgz",
+      "integrity": "sha512-iI468X7shsmB/oIPi8+UfMcOpcQPEsMAz5hDc0H8dKBGUWbPcAlyQpC8CaNDZ7y1/7lK65wtvXs5OGTQd3OsJg==",
       "requires": {
-        "@babel/helper-plugin-utils": "7.0.0-beta.54"
+        "@babel/helper-plugin-utils": "7.0.0-rc.1"
       }
     },
     "@babel/plugin-transform-modules-amd": {
-      "version": "7.0.0-beta.54",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-amd/-/plugin-transform-modules-amd-7.0.0-beta.54.tgz",
-      "integrity": "sha1-+1B0B0FCC7SF7hMV0uETPbTkM9I=",
+      "version": "7.0.0-rc.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-amd/-/plugin-transform-modules-amd-7.0.0-rc.1.tgz",
+      "integrity": "sha512-xKIF2ZAFOZRgIhEeW6zuyieyqfjft59NaHvb2C7+N9omdFDVkrx5ZeHVLb8y163a3mUb2MqJg1PLfZXdwvz1EA==",
       "requires": {
-        "@babel/helper-module-transforms": "7.0.0-beta.54",
-        "@babel/helper-plugin-utils": "7.0.0-beta.54"
+        "@babel/helper-module-transforms": "7.0.0-rc.1",
+        "@babel/helper-plugin-utils": "7.0.0-rc.1"
       }
     },
     "@babel/plugin-transform-modules-commonjs": {
-      "version": "7.0.0-beta.54",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-7.0.0-beta.54.tgz",
-      "integrity": "sha1-B9kSp6JNrS2b9dRM4yLdxFeo2zc=",
+      "version": "7.0.0-rc.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-7.0.0-rc.1.tgz",
+      "integrity": "sha512-G2Y2HwdUVSR+6V1g5q7D6hLm6HQ5f0HJ4TeYzPDIwKj3Ij3djyJ1lrFRtMRxanclcRy/N01sVe0z31m8Dslmzw==",
       "requires": {
-        "@babel/helper-module-transforms": "7.0.0-beta.54",
-        "@babel/helper-plugin-utils": "7.0.0-beta.54",
-        "@babel/helper-simple-access": "7.0.0-beta.54"
+        "@babel/helper-module-transforms": "7.0.0-rc.1",
+        "@babel/helper-plugin-utils": "7.0.0-rc.1",
+        "@babel/helper-simple-access": "7.0.0-rc.1"
       }
     },
     "@babel/plugin-transform-modules-systemjs": {
-      "version": "7.0.0-beta.54",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-systemjs/-/plugin-transform-modules-systemjs-7.0.0-beta.54.tgz",
-      "integrity": "sha1-CSPwEqwlLgN0ZyRf8n+JVPTOaAM=",
+      "version": "7.0.0-rc.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-systemjs/-/plugin-transform-modules-systemjs-7.0.0-rc.1.tgz",
+      "integrity": "sha512-denli1X4utH2boaedaCv3uDmrmBH0CMioIswTxViNY4M8nti3DV1m7wfKE4kDYq8UrIILLYwxxOsAvGxOS9/Ug==",
       "requires": {
-        "@babel/helper-hoist-variables": "7.0.0-beta.54",
-        "@babel/helper-plugin-utils": "7.0.0-beta.54"
+        "@babel/helper-hoist-variables": "7.0.0-rc.1",
+        "@babel/helper-plugin-utils": "7.0.0-rc.1"
       }
     },
     "@babel/plugin-transform-modules-umd": {
-      "version": "7.0.0-beta.54",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-umd/-/plugin-transform-modules-umd-7.0.0-beta.54.tgz",
-      "integrity": "sha1-OvDiz49TOymEqMptoxYkaFDDrto=",
+      "version": "7.0.0-rc.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-umd/-/plugin-transform-modules-umd-7.0.0-rc.1.tgz",
+      "integrity": "sha512-wvhxd77dRxyQGSEqfSRfe6dEBDy7Q13MaC1RKLX2H4+SQKZPvGuNr0BS0CEJ3Fm3uSEZ7potTBfRO4YNAygjXg==",
       "requires": {
-        "@babel/helper-module-transforms": "7.0.0-beta.54",
-        "@babel/helper-plugin-utils": "7.0.0-beta.54"
+        "@babel/helper-module-transforms": "7.0.0-rc.1",
+        "@babel/helper-plugin-utils": "7.0.0-rc.1"
       }
     },
     "@babel/plugin-transform-new-target": {
-      "version": "7.0.0-beta.54",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-new-target/-/plugin-transform-new-target-7.0.0-beta.54.tgz",
-      "integrity": "sha1-Y07lf6gFcgGVzTEIbJc/H8XJlJs=",
+      "version": "7.0.0-rc.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-new-target/-/plugin-transform-new-target-7.0.0-rc.1.tgz",
+      "integrity": "sha512-mI10u9cgVpTjJllgISn6SmM2H/3X1osvmgT/4sjQjYARGgEfG9khrxtI74IBRhRhtBF9VBgwhah6sYAym+aghw==",
       "requires": {
-        "@babel/helper-plugin-utils": "7.0.0-beta.54"
+        "@babel/helper-plugin-utils": "7.0.0-rc.1"
       }
     },
     "@babel/plugin-transform-object-super": {
-      "version": "7.0.0-beta.54",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-object-super/-/plugin-transform-object-super-7.0.0-beta.54.tgz",
-      "integrity": "sha1-0l+tZu/5DeA+5i+DhPCvV7zQZdk=",
+      "version": "7.0.0-rc.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-object-super/-/plugin-transform-object-super-7.0.0-rc.1.tgz",
+      "integrity": "sha512-mwoid0Rx+L55NupRE9xs1JAgFRz0JIYS/JR0aqBlLOQwBY1KrbrAtQfNwHQobwZrP9O24VBRfViMsiYLh/UV4A==",
       "requires": {
-        "@babel/helper-plugin-utils": "7.0.0-beta.54",
-        "@babel/helper-replace-supers": "7.0.0-beta.54"
+        "@babel/helper-plugin-utils": "7.0.0-rc.1",
+        "@babel/helper-replace-supers": "7.0.0-rc.1"
       }
     },
     "@babel/plugin-transform-parameters": {
-      "version": "7.0.0-beta.54",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-parameters/-/plugin-transform-parameters-7.0.0-beta.54.tgz",
-      "integrity": "sha1-djBvGbmsrGzxNyGvFey584KGT/c=",
+      "version": "7.0.0-rc.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-parameters/-/plugin-transform-parameters-7.0.0-rc.1.tgz",
+      "integrity": "sha512-PKjm+xf23XvdP0WRj/fIiP3xa5DYOg6qd0150Mpu4JvCIci6vrWvkc+kU9RtwkXLycWRfzdSnnyuSZABxPAP8A==",
       "requires": {
-        "@babel/helper-call-delegate": "7.0.0-beta.54",
-        "@babel/helper-get-function-arity": "7.0.0-beta.54",
-        "@babel/helper-plugin-utils": "7.0.0-beta.54"
+        "@babel/helper-call-delegate": "7.0.0-rc.1",
+        "@babel/helper-get-function-arity": "7.0.0-rc.1",
+        "@babel/helper-plugin-utils": "7.0.0-rc.1"
       }
     },
     "@babel/plugin-transform-react-display-name": {
-      "version": "7.0.0-beta.54",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-display-name/-/plugin-transform-react-display-name-7.0.0-beta.54.tgz",
-      "integrity": "sha1-h8tqK7wl2xb61/bshqEHh/SCEYw=",
+      "version": "7.0.0-rc.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-display-name/-/plugin-transform-react-display-name-7.0.0-rc.1.tgz",
+      "integrity": "sha512-XvrjX3XW4jScdL8h2gVpwYmuZlNUNja+DSkWeE8F1mcXS1nQ5Bf8GmxfGk2D7vmSrgxkDUusXZiHMFoIoNwQ/Q==",
       "requires": {
-        "@babel/helper-plugin-utils": "7.0.0-beta.54"
+        "@babel/helper-plugin-utils": "7.0.0-rc.1"
       }
     },
     "@babel/plugin-transform-react-jsx": {
-      "version": "7.0.0-beta.54",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx/-/plugin-transform-react-jsx-7.0.0-beta.54.tgz",
-      "integrity": "sha1-fptqYktkBtQ4tEqPrSPUN6dhO2Y=",
+      "version": "7.0.0-rc.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx/-/plugin-transform-react-jsx-7.0.0-rc.1.tgz",
+      "integrity": "sha512-lGSDCkRp8/2JMu0vBeayMLF2xLSiD1n9KZFH+zRSLtrvdNJFhifmzHJ9dYYBcDY7qDQayEpj/Ze9UpyxaU+oSA==",
       "requires": {
-        "@babel/helper-builder-react-jsx": "7.0.0-beta.54",
-        "@babel/helper-plugin-utils": "7.0.0-beta.54",
-        "@babel/plugin-syntax-jsx": "7.0.0-beta.54"
+        "@babel/helper-builder-react-jsx": "7.0.0-rc.1",
+        "@babel/helper-plugin-utils": "7.0.0-rc.1",
+        "@babel/plugin-syntax-jsx": "7.0.0-rc.1"
       }
     },
     "@babel/plugin-transform-react-jsx-self": {
-      "version": "7.0.0-beta.54",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-self/-/plugin-transform-react-jsx-self-7.0.0-beta.54.tgz",
-      "integrity": "sha1-AE5jWLzezQ+ekELLv4C26dgabnU=",
+      "version": "7.0.0-rc.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-self/-/plugin-transform-react-jsx-self-7.0.0-rc.1.tgz",
+      "integrity": "sha512-cItXIWcpge64i4FTowxuRdEBIqV0DReJNi3Iu8pEwNH4LLZbZ1OdYBZOL8nVLPP2vrfvsigt1qFJfYsbkPxcbw==",
       "requires": {
-        "@babel/helper-plugin-utils": "7.0.0-beta.54",
-        "@babel/plugin-syntax-jsx": "7.0.0-beta.54"
+        "@babel/helper-plugin-utils": "7.0.0-rc.1",
+        "@babel/plugin-syntax-jsx": "7.0.0-rc.1"
       }
     },
     "@babel/plugin-transform-react-jsx-source": {
-      "version": "7.0.0-beta.54",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-source/-/plugin-transform-react-jsx-source-7.0.0-beta.54.tgz",
-      "integrity": "sha1-HW7uZf93L7ACuZXlOMDJYV7Wo/c=",
+      "version": "7.0.0-rc.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-source/-/plugin-transform-react-jsx-source-7.0.0-rc.1.tgz",
+      "integrity": "sha512-M6cdiYTNWzqlmaa4YYpHTAp2N6tnROMCkvdy2eD9STHA9LpRz26fRQtbEc/kYL3MXroK2DEZpb8Zva6kczgbNg==",
       "requires": {
-        "@babel/helper-plugin-utils": "7.0.0-beta.54",
-        "@babel/plugin-syntax-jsx": "7.0.0-beta.54"
+        "@babel/helper-plugin-utils": "7.0.0-rc.1",
+        "@babel/plugin-syntax-jsx": "7.0.0-rc.1"
       }
     },
     "@babel/plugin-transform-regenerator": {
-      "version": "7.0.0-beta.54",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-regenerator/-/plugin-transform-regenerator-7.0.0-beta.54.tgz",
-      "integrity": "sha1-i0bhkvO/4Ja7v4bid2TnZi5fmg8=",
+      "version": "7.0.0-rc.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-regenerator/-/plugin-transform-regenerator-7.0.0-rc.1.tgz",
+      "integrity": "sha512-a73XZOJGt0Ft8/YbRAUl0Vs1GuPpjB6QVQNYPxWUNXblSiywhkkZxLssHZnao2xTD26kLRfMoXfOtj9FMz5fcw==",
       "requires": {
         "regenerator-transform": "^0.13.3"
       },
@@ -684,63 +684,63 @@
       }
     },
     "@babel/plugin-transform-runtime": {
-      "version": "7.0.0-beta.54",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-runtime/-/plugin-transform-runtime-7.0.0-beta.54.tgz",
-      "integrity": "sha1-rUXR6EqdDPxI3xSN2mCf8JwSH9I=",
+      "version": "7.0.0-rc.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-runtime/-/plugin-transform-runtime-7.0.0-rc.1.tgz",
+      "integrity": "sha512-Tmg0jYdu/Bn0r8iQpQXNmybenq65ci8z/ReMO+IR5CBtnhEYBYtIPxZgvmwZFbggLm1MJ/oRdDRmRl4a/G8QEw==",
       "requires": {
-        "@babel/helper-module-imports": "7.0.0-beta.54",
-        "@babel/helper-plugin-utils": "7.0.0-beta.54"
+        "@babel/helper-module-imports": "7.0.0-rc.1",
+        "@babel/helper-plugin-utils": "7.0.0-rc.1"
       }
     },
     "@babel/plugin-transform-shorthand-properties": {
-      "version": "7.0.0-beta.54",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-shorthand-properties/-/plugin-transform-shorthand-properties-7.0.0-beta.54.tgz",
-      "integrity": "sha1-UOc8KvxYmLEFVRDd9g7hOmMBUX8=",
+      "version": "7.0.0-rc.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-shorthand-properties/-/plugin-transform-shorthand-properties-7.0.0-rc.1.tgz",
+      "integrity": "sha512-NkUsTSKL8txvPt9vtdkcbJEyiUtcSOAr6ZnAE+Vg4mB0hYI0sWEJCAzl26KDDFgdVSKJSAaenjX5UR3BAF3KaA==",
       "requires": {
-        "@babel/helper-plugin-utils": "7.0.0-beta.54"
+        "@babel/helper-plugin-utils": "7.0.0-rc.1"
       }
     },
     "@babel/plugin-transform-spread": {
-      "version": "7.0.0-beta.54",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-spread/-/plugin-transform-spread-7.0.0-beta.54.tgz",
-      "integrity": "sha1-TwhS3w9LHbJCbED6zY/l8Cij28k=",
+      "version": "7.0.0-rc.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-spread/-/plugin-transform-spread-7.0.0-rc.1.tgz",
+      "integrity": "sha512-/3EkUVVi55i/JCbL2CxXTaoCXCopj3qQMTZ0lvgtpepx1yAMpoHYFBNWLIuQmjG7JhDauOwEdBg8TRsneYRmmw==",
       "requires": {
-        "@babel/helper-plugin-utils": "7.0.0-beta.54"
+        "@babel/helper-plugin-utils": "7.0.0-rc.1"
       }
     },
     "@babel/plugin-transform-sticky-regex": {
-      "version": "7.0.0-beta.54",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-sticky-regex/-/plugin-transform-sticky-regex-7.0.0-beta.54.tgz",
-      "integrity": "sha1-Vo8161EYrpb62C6sNjdNeSO0eIM=",
+      "version": "7.0.0-rc.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-sticky-regex/-/plugin-transform-sticky-regex-7.0.0-rc.1.tgz",
+      "integrity": "sha512-sXPFGI3GTtSMxVTDwrRmgwmUcq+l0ovzUZFfAd4YK1zJQ7YQCaCjcmLskuiGM20SoteYserDADg0SrLw+8B8hA==",
       "requires": {
-        "@babel/helper-plugin-utils": "7.0.0-beta.54",
-        "@babel/helper-regex": "7.0.0-beta.54"
+        "@babel/helper-plugin-utils": "7.0.0-rc.1",
+        "@babel/helper-regex": "7.0.0-rc.1"
       }
     },
     "@babel/plugin-transform-template-literals": {
-      "version": "7.0.0-beta.54",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-template-literals/-/plugin-transform-template-literals-7.0.0-beta.54.tgz",
-      "integrity": "sha1-yx9jA8r7hEKmxsaaDfu2BpnzJ7w=",
+      "version": "7.0.0-rc.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-template-literals/-/plugin-transform-template-literals-7.0.0-rc.1.tgz",
+      "integrity": "sha512-xq9eSNA65VXbMmVEjKUXB0czP8y/CRs88S8HcwZbJ7XGo4FARUJV3aGQfIPvGUmbkQegsxZx5rlTPlw3NPl+Aw==",
       "requires": {
-        "@babel/helper-annotate-as-pure": "7.0.0-beta.54",
-        "@babel/helper-plugin-utils": "7.0.0-beta.54"
+        "@babel/helper-annotate-as-pure": "7.0.0-rc.1",
+        "@babel/helper-plugin-utils": "7.0.0-rc.1"
       }
     },
     "@babel/plugin-transform-typeof-symbol": {
-      "version": "7.0.0-beta.54",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-typeof-symbol/-/plugin-transform-typeof-symbol-7.0.0-beta.54.tgz",
-      "integrity": "sha1-bQaGhiOcnrr1NNHA2AMpU/e1Ibw=",
+      "version": "7.0.0-rc.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-typeof-symbol/-/plugin-transform-typeof-symbol-7.0.0-rc.1.tgz",
+      "integrity": "sha512-wUKNscuv3WOOFy3tGOBeayeOLyZjixjOSvb0QNXrCDRuENhfPaFQjZt/T0UDAZN0mXvAQ7Ksx2pOtXBsyIBxUA==",
       "requires": {
-        "@babel/helper-plugin-utils": "7.0.0-beta.54"
+        "@babel/helper-plugin-utils": "7.0.0-rc.1"
       }
     },
     "@babel/plugin-transform-unicode-regex": {
-      "version": "7.0.0-beta.54",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-regex/-/plugin-transform-unicode-regex-7.0.0-beta.54.tgz",
-      "integrity": "sha1-HcfpFQs5qusZ/KHIY+CC9glq/GA=",
+      "version": "7.0.0-rc.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-regex/-/plugin-transform-unicode-regex-7.0.0-rc.1.tgz",
+      "integrity": "sha512-3yz7ehk0VFLqoKVV1GbTdH2sfMtYznhllkBDtnybveM6MeFA5WYCf6iWf+I/vF/8QIMDd1b4359GGWKCI+KuIQ==",
       "requires": {
-        "@babel/helper-plugin-utils": "7.0.0-beta.54",
-        "@babel/helper-regex": "7.0.0-beta.54",
+        "@babel/helper-plugin-utils": "7.0.0-rc.1",
+        "@babel/helper-regex": "7.0.0-rc.1",
         "regexpu-core": "^4.1.3"
       },
       "dependencies": {
@@ -778,46 +778,46 @@
       }
     },
     "@babel/preset-env": {
-      "version": "7.0.0-beta.54",
-      "resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.0.0-beta.54.tgz",
-      "integrity": "sha1-SwXE46rtZKUJCY5OhU38DgLt8FM=",
+      "version": "7.0.0-rc.1",
+      "resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.0.0-rc.1.tgz",
+      "integrity": "sha512-c1mn7dKMBnkcS9Se9cuB5K2PAN48I0/mFXIA/ARyu7dHnLxiteSL0wyQukVp4NenKqFlAtPFx5ZtgWEMjaYmbg==",
       "requires": {
-        "@babel/helper-module-imports": "7.0.0-beta.54",
-        "@babel/helper-plugin-utils": "7.0.0-beta.54",
-        "@babel/plugin-proposal-async-generator-functions": "7.0.0-beta.54",
-        "@babel/plugin-proposal-object-rest-spread": "7.0.0-beta.54",
-        "@babel/plugin-proposal-optional-catch-binding": "7.0.0-beta.54",
-        "@babel/plugin-proposal-unicode-property-regex": "7.0.0-beta.54",
-        "@babel/plugin-syntax-async-generators": "7.0.0-beta.54",
-        "@babel/plugin-syntax-object-rest-spread": "7.0.0-beta.54",
-        "@babel/plugin-syntax-optional-catch-binding": "7.0.0-beta.54",
-        "@babel/plugin-transform-arrow-functions": "7.0.0-beta.54",
-        "@babel/plugin-transform-async-to-generator": "7.0.0-beta.54",
-        "@babel/plugin-transform-block-scoped-functions": "7.0.0-beta.54",
-        "@babel/plugin-transform-block-scoping": "7.0.0-beta.54",
-        "@babel/plugin-transform-classes": "7.0.0-beta.54",
-        "@babel/plugin-transform-computed-properties": "7.0.0-beta.54",
-        "@babel/plugin-transform-destructuring": "7.0.0-beta.54",
-        "@babel/plugin-transform-dotall-regex": "7.0.0-beta.54",
-        "@babel/plugin-transform-duplicate-keys": "7.0.0-beta.54",
-        "@babel/plugin-transform-exponentiation-operator": "7.0.0-beta.54",
-        "@babel/plugin-transform-for-of": "7.0.0-beta.54",
-        "@babel/plugin-transform-function-name": "7.0.0-beta.54",
-        "@babel/plugin-transform-literals": "7.0.0-beta.54",
-        "@babel/plugin-transform-modules-amd": "7.0.0-beta.54",
-        "@babel/plugin-transform-modules-commonjs": "7.0.0-beta.54",
-        "@babel/plugin-transform-modules-systemjs": "7.0.0-beta.54",
-        "@babel/plugin-transform-modules-umd": "7.0.0-beta.54",
-        "@babel/plugin-transform-new-target": "7.0.0-beta.54",
-        "@babel/plugin-transform-object-super": "7.0.0-beta.54",
-        "@babel/plugin-transform-parameters": "7.0.0-beta.54",
-        "@babel/plugin-transform-regenerator": "7.0.0-beta.54",
-        "@babel/plugin-transform-shorthand-properties": "7.0.0-beta.54",
-        "@babel/plugin-transform-spread": "7.0.0-beta.54",
-        "@babel/plugin-transform-sticky-regex": "7.0.0-beta.54",
-        "@babel/plugin-transform-template-literals": "7.0.0-beta.54",
-        "@babel/plugin-transform-typeof-symbol": "7.0.0-beta.54",
-        "@babel/plugin-transform-unicode-regex": "7.0.0-beta.54",
+        "@babel/helper-module-imports": "7.0.0-rc.1",
+        "@babel/helper-plugin-utils": "7.0.0-rc.1",
+        "@babel/plugin-proposal-async-generator-functions": "7.0.0-rc.1",
+        "@babel/plugin-proposal-object-rest-spread": "7.0.0-rc.1",
+        "@babel/plugin-proposal-optional-catch-binding": "7.0.0-rc.1",
+        "@babel/plugin-proposal-unicode-property-regex": "7.0.0-rc.1",
+        "@babel/plugin-syntax-async-generators": "7.0.0-rc.1",
+        "@babel/plugin-syntax-object-rest-spread": "7.0.0-rc.1",
+        "@babel/plugin-syntax-optional-catch-binding": "7.0.0-rc.1",
+        "@babel/plugin-transform-arrow-functions": "7.0.0-rc.1",
+        "@babel/plugin-transform-async-to-generator": "7.0.0-rc.1",
+        "@babel/plugin-transform-block-scoped-functions": "7.0.0-rc.1",
+        "@babel/plugin-transform-block-scoping": "7.0.0-rc.1",
+        "@babel/plugin-transform-classes": "7.0.0-rc.1",
+        "@babel/plugin-transform-computed-properties": "7.0.0-rc.1",
+        "@babel/plugin-transform-destructuring": "7.0.0-rc.1",
+        "@babel/plugin-transform-dotall-regex": "7.0.0-rc.1",
+        "@babel/plugin-transform-duplicate-keys": "7.0.0-rc.1",
+        "@babel/plugin-transform-exponentiation-operator": "7.0.0-rc.1",
+        "@babel/plugin-transform-for-of": "7.0.0-rc.1",
+        "@babel/plugin-transform-function-name": "7.0.0-rc.1",
+        "@babel/plugin-transform-literals": "7.0.0-rc.1",
+        "@babel/plugin-transform-modules-amd": "7.0.0-rc.1",
+        "@babel/plugin-transform-modules-commonjs": "7.0.0-rc.1",
+        "@babel/plugin-transform-modules-systemjs": "7.0.0-rc.1",
+        "@babel/plugin-transform-modules-umd": "7.0.0-rc.1",
+        "@babel/plugin-transform-new-target": "7.0.0-rc.1",
+        "@babel/plugin-transform-object-super": "7.0.0-rc.1",
+        "@babel/plugin-transform-parameters": "7.0.0-rc.1",
+        "@babel/plugin-transform-regenerator": "7.0.0-rc.1",
+        "@babel/plugin-transform-shorthand-properties": "7.0.0-rc.1",
+        "@babel/plugin-transform-spread": "7.0.0-rc.1",
+        "@babel/plugin-transform-sticky-regex": "7.0.0-rc.1",
+        "@babel/plugin-transform-template-literals": "7.0.0-rc.1",
+        "@babel/plugin-transform-typeof-symbol": "7.0.0-rc.1",
+        "@babel/plugin-transform-unicode-regex": "7.0.0-rc.1",
         "browserslist": "^3.0.0",
         "invariant": "^2.2.2",
         "js-levenshtein": "^1.1.3",
@@ -836,58 +836,58 @@
       }
     },
     "@babel/preset-react": {
-      "version": "7.0.0-beta.54",
-      "resolved": "https://registry.npmjs.org/@babel/preset-react/-/preset-react-7.0.0-beta.54.tgz",
-      "integrity": "sha1-mAIQN6dLJ7RqRtOyjoSh8vQG2ts=",
+      "version": "7.0.0-rc.1",
+      "resolved": "https://registry.npmjs.org/@babel/preset-react/-/preset-react-7.0.0-rc.1.tgz",
+      "integrity": "sha512-EeXOUywwFJyEWWO5DV5vh3DNTlMR1uDzQ5gWvQ8pt5eAQxaoGLkdoxWkE8CJDiCS6PGMcIWVw8vm6mInmSV+Yg==",
       "requires": {
-        "@babel/helper-plugin-utils": "7.0.0-beta.54",
-        "@babel/plugin-transform-react-display-name": "7.0.0-beta.54",
-        "@babel/plugin-transform-react-jsx": "7.0.0-beta.54",
-        "@babel/plugin-transform-react-jsx-self": "7.0.0-beta.54",
-        "@babel/plugin-transform-react-jsx-source": "7.0.0-beta.54"
+        "@babel/helper-plugin-utils": "7.0.0-rc.1",
+        "@babel/plugin-transform-react-display-name": "7.0.0-rc.1",
+        "@babel/plugin-transform-react-jsx": "7.0.0-rc.1",
+        "@babel/plugin-transform-react-jsx-self": "7.0.0-rc.1",
+        "@babel/plugin-transform-react-jsx-source": "7.0.0-rc.1"
       }
     },
-    "@babel/runtime": {
-      "version": "7.0.0-beta.55",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.0.0-beta.55.tgz",
-      "integrity": "sha1-C8M6paasCwEvN+JbnmqqLkiakWs=",
+    "@babel/runtime-corejs2": {
+      "version": "7.0.0-rc.1",
+      "resolved": "https://registry.npmjs.org/@babel/runtime-corejs2/-/runtime-corejs2-7.0.0-rc.1.tgz",
+      "integrity": "sha512-2QWAvXXu7r0zmgrXExWXnXh7vuarvjgsDB9qL4hN925dSRrrFZWXjiIQ+LB14753shjZkZ+4xLEJrO9hBKGwRA==",
       "requires": {
         "core-js": "^2.5.7",
         "regenerator-runtime": "^0.12.0"
       },
       "dependencies": {
         "regenerator-runtime": {
-          "version": "0.12.0",
-          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.12.0.tgz",
-          "integrity": "sha512-SpV2LhF5Dm9UYMEprB3WwsBnWwqTrmjrm2UZb42cl2G02WVGgx7Mg8aa9pdLEKp6hZ+/abcMc2NxKA8f02EG2w=="
+          "version": "0.12.1",
+          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.12.1.tgz",
+          "integrity": "sha512-odxIc1/vDlo4iZcfXqRYFj0vpXFNoGdKMAUieAlFYO6m/nl5e9KR/beGf41z4a1FI+aQgtjhuaSlDxQ0hmkrHg=="
         }
       }
     },
     "@babel/template": {
-      "version": "7.0.0-beta.54",
-      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.0.0-beta.54.tgz",
-      "integrity": "sha1-1bDS0tVcDniwSMYaBY82z9fZGvM=",
+      "version": "7.0.0-rc.1",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.0.0-rc.1.tgz",
+      "integrity": "sha512-gPLng2iedNlkaGD0UdwaUByQXK8k4bnaoq2RH5JgR2mqHvh2RyjkDdaMbZFlSss1Iu8+PrXwbIRworTl8iRqbA==",
       "requires": {
-        "@babel/code-frame": "7.0.0-beta.54",
-        "@babel/parser": "7.0.0-beta.54",
-        "@babel/types": "7.0.0-beta.54",
-        "lodash": "^4.17.5"
+        "@babel/code-frame": "7.0.0-rc.1",
+        "@babel/parser": "7.0.0-rc.1",
+        "@babel/types": "7.0.0-rc.1",
+        "lodash": "^4.17.10"
       }
     },
     "@babel/traverse": {
-      "version": "7.0.0-beta.54",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.0.0-beta.54.tgz",
-      "integrity": "sha1-LBf5jc2/GaqRj94Sjw4aC8CJ4Fo=",
+      "version": "7.0.0-rc.1",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.0.0-rc.1.tgz",
+      "integrity": "sha512-lNOpJ5xzakg+fCobQQHdeDRYeN54b+bAZpeTYMeeYPAvN+hTldg9/FSNKYEMRs5EWoQ0Yt74gwq98InSORdSDQ==",
       "requires": {
-        "@babel/code-frame": "7.0.0-beta.54",
-        "@babel/generator": "7.0.0-beta.54",
-        "@babel/helper-function-name": "7.0.0-beta.54",
-        "@babel/helper-split-export-declaration": "7.0.0-beta.54",
-        "@babel/parser": "7.0.0-beta.54",
-        "@babel/types": "7.0.0-beta.54",
+        "@babel/code-frame": "7.0.0-rc.1",
+        "@babel/generator": "7.0.0-rc.1",
+        "@babel/helper-function-name": "7.0.0-rc.1",
+        "@babel/helper-split-export-declaration": "7.0.0-rc.1",
+        "@babel/parser": "7.0.0-rc.1",
+        "@babel/types": "7.0.0-rc.1",
         "debug": "^3.1.0",
         "globals": "^11.1.0",
-        "lodash": "^4.17.5"
+        "lodash": "^4.17.10"
       },
       "dependencies": {
         "debug": {
@@ -906,12 +906,12 @@
       }
     },
     "@babel/types": {
-      "version": "7.0.0-beta.54",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.0.0-beta.54.tgz",
-      "integrity": "sha1-AlrWhJL+1ULBPxTFeaRMhI5TEGM=",
+      "version": "7.0.0-rc.1",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.0.0-rc.1.tgz",
+      "integrity": "sha512-MBwO1JQKin9BwKTGydrYe4VDJbStCUy35IhJzeZt3FByOdx/q3CYaqMRrH70qVD2RA7+Xk8e3RN0mzKZkYBYuQ==",
       "requires": {
         "esutils": "^2.0.2",
-        "lodash": "^4.17.5",
+        "lodash": "^4.17.10",
         "to-fast-properties": "^2.0.0"
       },
       "dependencies": {
@@ -2851,9 +2851,9 @@
       "integrity": "sha1-MpAafWuTqH1Z8Iqu5H6o/27JD98="
     },
     "caniuse-lite": {
-      "version": "1.0.30000865",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000865.tgz",
-      "integrity": "sha512-vs79o1mOSKRGv/1pSkp4EXgl4ZviWeYReXw60XfacPU64uQWZwJT6vZNmxRF9O+6zu71sJwMxLK5JXxbzuVrLw=="
+      "version": "1.0.30000876",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000876.tgz",
+      "integrity": "sha512-v+Q2afhJJ1oydQnEB4iHhxDz5x9lWPbRnQBQlM3FgtZxqLO8KDSdu4txUrFwC1Ws9I2kQi/QImkvj17NbVpNAg=="
     },
     "chai": {
       "version": "4.1.2",

--- a/package.json
+++ b/package.json
@@ -21,11 +21,11 @@
     "url": "https://github.com/embark-framework/embark.git"
   },
   "dependencies": {
-    "@babel/core": "^7.0.0-beta.54",
-    "@babel/plugin-transform-runtime": "^7.0.0-beta.54",
-    "@babel/preset-env": "^7.0.0-beta.54",
-    "@babel/preset-react": "^7.0.0-beta.54",
-    "@babel/runtime": "^7.0.0-beta.54",
+    "@babel/core": "7.0.0-rc.1",
+    "@babel/plugin-transform-runtime": "7.0.0-rc.1",
+    "@babel/preset-env": "7.0.0-rc.1",
+    "@babel/preset-react": "7.0.0-rc.1",
+    "@babel/runtime-corejs2": "7.0.0-rc.1",
     "ascii-table": "0.0.9",
     "async": "^2.0.1",
     "babel-loader": "^8.0.0-beta.4",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "@babel/runtime-corejs2": "7.0.0-rc.1",
     "ascii-table": "0.0.9",
     "async": "^2.0.1",
-    "babel-loader": "^8.0.0-beta.4",
+    "babel-loader": "8.0.0-beta.4",
     "babel-plugin-webpack-aliases": "^1.1.3",
     "bip39": "^2.5.0",
     "chokidar": "^2.0.3",

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "decompress": "^4.2.0",
     "deep-equal": "^1.0.1",
     "ejs": "^2.5.8",
-    "embarkjs": "^0.3.1",
+    "embarkjs": "^0.3.2",
     "eth-ens-namehash": "^2.0.8",
     "eth-lib": "^0.2.8",
     "ethereumjs-wallet": "0.6.0",


### PR DESCRIPTION
## Overview

Applies changes complementary to those of https://github.com/embark-framework/EmbarkJS/pull/10 and bumps `embarkjs` to (just released) `0.3.2`.