### PR TITLE
set async limit funding

### DIFF
--- a/lib/contracts/provider.js
+++ b/lib/contracts/provider.js
@@ -78,7 +78,7 @@ class Provider {
     if (!self.isDev) {
       return callback();
     }
-    async.each(self.accounts, (account, eachCb) => {
+    async.eachLimit(self.accounts, 1, (account, eachCb) => {
       fundAccount(self.web3, account.address, account.hexBalance, eachCb);
     }, callback);
   }


### PR DESCRIPTION
Caused all the fundings to have the same nonce. With the limit, only funds one account at a time.