### PR TITLE
remove line causing crash

### DIFF
--- a/lib/modules/blockchain_process/index.js
+++ b/lib/modules/blockchain_process/index.js
@@ -74,7 +74,6 @@ class BlockchainModule {
       callback();
     });
     self.events.once(constants.blockchain.blockchainExit, () => {
-      self.provider.stop();
       callback();
     });
   }


### PR DESCRIPTION
this line was causing embark to crash if the blockchain process died. the variable doesn't exist and is probably a byproduct of a merge conflict.