### PR TITLE
Reload config when a file is added/removed

### DIFF
--- a/lib/core/engine.js
+++ b/lib/core/engine.js
@@ -179,6 +179,7 @@ class Engine {
       self.fileTimeout = setTimeout(() => {
         // TODO: still need to redeploy contracts because the original contracts
         // config is being corrupted
+        self.config.reloadConfig();
         if (fileType === 'asset') {
           // Throttle file changes so we re-write only once for all files
           self.events.emit('asset-changed', self.contractsManager);
@@ -186,8 +187,6 @@ class Engine {
         // TODO: for now need to deploy on asset changes as well
         // because the contractsManager config is corrupted after a deploy
         if (fileType === 'contract' || fileType === 'config') {
-          self.config.reloadConfig();
-
           self.events.request('deploy:contracts', () => {});
         }
       }, 50);


### PR DESCRIPTION
## Overview
**TL;DR**

When a file is removed, the config needs to be reloaded, otherwise the pipeline try to compile a file that doesn't exist and crash