### PR TITLE
Mainnet is livenet

### DIFF
--- a/lib/constants.json
+++ b/lib/constants.json
@@ -36,7 +36,7 @@
     "initiated": "initiated",
     "servicePortOnProxy": 10,
     "networkIds": {
-      "mainnet": 1,
+      "livenet": 1,
       "testnet": 3,
       "ropsten": 3,
       "rinkeby": 4


### PR DESCRIPTION
## Overview
**TL;DR**
`embark run/console livenet` was failing with:
```
TypeError: Cannot read property 'toString' of undefined
    at web3.eth.net.getId.then.id (/home/anthony/code/embark-framework/embark/lib/modules/blockchain_connector/index.js:85:45)
    at <anonymous>
    at process._tickCallback (internal/process/next_tick.js:118:7)
```

this is:
```
if (!networkId && constants.blockchain.networkIds[self.blockchainConfig.networkType]) {
  networkId = constants.blockchain.networkIds[self.blockchainConfig.networkType];
}
```

The networkType is `livenet`, not `mainnet`