### PR TITLE
Add --node option for tests

### DIFF
--- a/cmd/cmd.js
+++ b/cmd/cmd.js
@@ -207,13 +207,14 @@ class Cmd {
   test() {
     program
       .command('test [file]')
+      .option('-n , --node [node]', __('Node to connect to (default: vm)'))
       .option('-d , --gasDetails', __('When set, will print the gas cost for each contract deploy'))
       .option('--locale [locale]', __('language to use (default: en)'))
       .option('--loglevel [loglevel]', __('level of logging to display') + ' ["error", "warn", "info", "debug", "trace"]', /^(error|warn|info|debug|trace)$/i, 'warn')
       .description(__('run tests'))
       .action(function (file, options) {
         i18n.setOrDetectLocale(options.locale);
-        embark.runTests({file, loglevel: options.loglevel, gasDetails: options.gasDetails});
+        embark.runTests({file, loglevel: options.loglevel, gasDetails: options.gasDetails, node: options.node});
       });
   }
 

--- a/lib/core/engine.js
+++ b/lib/core/engine.js
@@ -213,7 +213,8 @@ class Engine {
   web3Service(options) {
     this.registerModule('blockchain_process', {
       locale: this.locale,
-      isDev: this.isDev
+      isDev: this.isDev,
+      ipc: this.ipc
     });
 
     this.registerModule('blockchain_connector', {

--- a/lib/modules/blockchain_process/index.js
+++ b/lib/modules/blockchain_process/index.js
@@ -13,6 +13,7 @@ class BlockchainModule {
     this.embark = embark;
     this.locale = options.locale;
     this.isDev = options.isDev;
+    this.ipc = options.ipc;
 
     this.registerBlockchainProcess();
   }
@@ -24,6 +25,11 @@ class BlockchainModule {
         if (connected) return cb();
         self.startBlockchainNode(cb);
       });
+    });
+
+    if (!this.ipc.isServer()) return;
+    self.ipc.on('blockchain:node', (_message, cb) => {
+      cb(null, utils.buildUrlFromConfig(self.contractsConfig.deployment));
     });
   }
 
@@ -47,7 +53,7 @@ class BlockchainModule {
         if (!self.contractsConfig || !self.contractsConfig.deployment || !self.contractsConfig.deployment.host) {
           return next();
         }
-        const {host, port, type, protocol}  = self.contractsConfig.deployment;
+        const {host, port, type, protocol} = self.contractsConfig.deployment;
         utils.pingEndpoint(host, port, type, protocol, self.blockchainConfig.wsOrigins.split(',')[0], next);
       }
     ], function (err) {

--- a/lib/modules/solidity/solcW.js
+++ b/lib/modules/solidity/solcW.js
@@ -21,6 +21,10 @@ class SolcW {
       return self.load_compiler_internally(done);
     }
 
+    if (self.ipc.connected) {
+      self.compilerLoaded = true;
+      return done();
+    }
     self.ipc.connect((err) => {
       if (err) {
         return self.load_compiler_internally(done);

--- a/lib/pipeline/pipeline.js
+++ b/lib/pipeline/pipeline.js
@@ -136,7 +136,7 @@ class Pipeline {
 
                 ], function (err, contentFile) {
                   if (err) {
-                    self.logger.error(err);
+                    self.logger.error(err.message || err);
                     return fileCb(err);
                   }
 

--- a/lib/tests/run_tests.js
+++ b/lib/tests/run_tests.js
@@ -61,7 +61,7 @@ module.exports = {
       },
       function setupGlobalNamespace(files, next) {
         // TODO put default config
-        const test = new Test({loglevel});
+        const test = new Test({loglevel, node: options.node});
         global.embark = test;
         global.assert = assert;
         global.config = test.config.bind(test);

--- a/lib/tests/test.js
+++ b/lib/tests/test.js
@@ -139,6 +139,20 @@ class Test {
     this.initDeployServices();
     this.engine.startService("codeGenerator");
 
+    if (this.options.node === 'embark') {
+      return this.engine.ipc.connect((err) => {
+        if (err) {
+          return this.engine.logger.error(err.message || err);
+        }
+        this.engine.ipc.request('blockchain:node', {}, (err, node) => {
+          if (err) {
+            return this.engine.logger.error(err.message || err);
+          }
+          this.options.node = node;
+          callback();
+        });
+      });
+    }
     callback();
   }
 

--- a/lib/tests/test.js
+++ b/lib/tests/test.js
@@ -58,10 +58,15 @@ class Test {
       });
     }
 
-    if (this.simOptions.host) {
-      let {host, port, type, protocol, accounts} = this.simOptions;
+    if (this.simOptions.host || this.options.node) {
+      let options = this.simOptions;
+      if (this.options.node) {
+        options = utils.deconstructUrl(this.options.node);
+      }
+
+      let {host, port, type, protocol, accounts} = options;
       if (!protocol) {
-        protocol = (this.simOptions.type === "rpc") ? 'http' : 'ws';
+        protocol = (options.type === "rpc") ? 'http' : 'ws';
       }
       const endpoint = `${protocol}://${host}:${port}`;
       const providerOptions = {

--- a/lib/tests/test.js
+++ b/lib/tests/test.js
@@ -142,7 +142,9 @@ class Test {
     if (this.options.node === 'embark') {
       return this.engine.ipc.connect((err) => {
         if (err) {
-          return this.engine.logger.error(err.message || err);
+          this.engine.logger.error(err.message || err);
+          this.engine.logger.error("Could not connect to Embark's IPC. Is embark running?");
+          process.exit(1);
         }
         this.engine.ipc.request('blockchain:node', {}, (err, node) => {
           if (err) {

--- a/lib/tests/test_logger.js
+++ b/lib/tests/test_logger.js
@@ -16,7 +16,6 @@ class TestLogger {
     if (!(this.shouldLog('error'))) {
       return;
     }
-    console.error(txt);
     this.logFunction(txt.red);
   }
 

--- a/lib/utils/utils.js
+++ b/lib/utils/utils.js
@@ -340,13 +340,18 @@ function normalizeInput(input) {
  *  The URL host, required.
  * @param {string} port
  *  The URL port, default to empty string.
+ * @param {string} [type]
+ *  Type of connection
  * @returns {string} the constructued URL, with defaults
  */
-function buildUrl(protocol, host, port) {
+function buildUrl(protocol, host, port, type) {
   if (!host) throw new Error('utils.buildUrl: parameter \'host\' is required');
   if (port) port = ':' + port;
   else port = '';
-  return `${protocol || 'http'}://${host}${port}`;
+  if (!protocol) {
+    protocol = type === 'ws' ? 'ws' : 'http';
+  }
+  return `${protocol}://${host}${port}`;
 }
 
 /**
@@ -361,7 +366,7 @@ function buildUrl(protocol, host, port) {
 function buildUrlFromConfig(configObj) {
   if (!configObj) throw new Error('[utils.buildUrlFromConfig]: config object must cannot be null');
   if (!configObj.host) throw new Error('[utils.buildUrlFromConfig]: object must contain a \'host\' property');
-  return this.buildUrl(configObj.protocol, canonicalHost(configObj.host), configObj.port);
+  return this.buildUrl(configObj.protocol, canonicalHost(configObj.host), configObj.port, configObj.type);
 }
 
 function deconstructUrl(endpoint) {

--- a/lib/utils/utils.js
+++ b/lib/utils/utils.js
@@ -364,6 +364,16 @@ function buildUrlFromConfig(configObj) {
   return this.buildUrl(configObj.protocol, canonicalHost(configObj.host), configObj.port);
 }
 
+function deconstructUrl(endpoint) {
+  const matches = endpoint.match(/(ws|https?):\/\/([a-zA-Z0-9_.-]*):?([0-9]*)?/);
+  return {
+    protocol: matches[1],
+    host: matches[2],
+    port: matches[3],
+    type: matches[1] === 'ws' ? 'ws' : 'rpc'
+  };
+}
+
 function getWeiBalanceFromString(balanceString, web3){
   if(!web3){
     throw new Error(__('[utils.getWeiBalanceFromString]: Missing parameter \'web3\''));
@@ -482,6 +492,7 @@ module.exports = {
   normalizeInput,
   buildUrl,
   buildUrlFromConfig,
+  deconstructUrl,
   getWeiBalanceFromString,
   getHexBalanceFromString,
   compact,


### PR DESCRIPTION
## Overview
**TL;DR**
Enables `embark test --node <node>`
Where node can be a url (eg: ws://localhost:8546) or "embark". If "embark", use IPC to check the node at which Embark is connected

### Known issues
Connecting  to a WS node creates some problem, because some of our tests just don't work well on WS for some reason. This is not related to this PR. The problem is present on develop too. I created an issue in Pivotal to track it.