### PR TITLE
Isolate the code runner

### DIFF
--- a/cmd/dashboard/repl.js
+++ b/cmd/dashboard/repl.js
@@ -44,6 +44,10 @@ class REPL {
       writer: this.enhancedWriter.bind(this)
     });
 
+    this.events.request("runcode:getContext", (context) => {
+      this.replServer.context = context;
+    });
+
     this.replServer.on("exit", () => {
       process.exit();
     });

--- a/lib/core/modules/coderunner/codeRunner.js
+++ b/lib/core/modules/coderunner/codeRunner.js
@@ -8,13 +8,12 @@ class CodeRunner {
     this.events = options.events;
     this.ipc = options.ipc;
     this.commands = [];
+    this.runCode = new RunCode();
     let self = this;
-    // necessary to init the context
-    RunCode.initContext();
 
     if (this.ipc.isServer()) {
       this.ipc.on('runcode:getCommands', (_err, callback) => {
-        let result = {web3Config: RunCode.getWeb3Config(), commands: self.commands};
+        let result = {web3Config: self.runCode.getWeb3Config(), commands: self.commands};
         callback(null, result);
       });
     }
@@ -34,7 +33,11 @@ class CodeRunner {
         self.commands.push({varName, code});
         self.ipc.broadcast("runcode:newCommand", {varName, code});
       }
-      RunCode.registerVar(varName, code);
+      self.runCode.registerVar(varName, code);
+    });
+
+    this.events.setCommandHandler('runcode:getContext', (cb) => {
+      cb(self.runCode.context);
     });
 
     this.events.setCommandHandler('runcode:eval', (code, cb, forConsoleOnly = false) => {
@@ -53,14 +56,17 @@ class CodeRunner {
           code = `(async function() {${code}})();`;
         }
       }
-      let result = RunCode.doEval(code);
-      if (result instanceof Promise) {
-        return result.then((value) => cb(null, value)).catch(cb);
-      }
+      let result = self.runCode.doEval(code);
+
       if (forConsoleOnly && self.ipc.isServer()) {
         self.commands.push({code});
         self.ipc.broadcast("runcode:newCommand", {code});
       }
+
+      if (result instanceof Promise) {
+        return result.then((value) => cb(null, value)).catch(cb);
+      }
+
       cb(null, result);
     });
   }

--- a/lib/core/modules/coderunner/runCode.js
+++ b/lib/core/modules/coderunner/runCode.js
@@ -1,31 +1,27 @@
-/*eslint no-unused-vars: off*/
-let __mainContext = this;
+const vm = require('vm');
 
-function initContext() {
-  doEval("__mainContext = this");
+class RunCode {
+  constructor() {
+    this.context = Object.assign({}, global.this);
+  }
+
+  doEval(code) {
+    return vm.runInNewContext(code, this.context);
+  }
+
+  registerVar(varName, code) {
+    // TODO: Update all the code being dependent of web3
+    // To identify, look at the top of the file for something like:
+    // /*global web3*/
+    if (varName === 'web3') {
+      global.web3 = code;
+    }
+    this.context[varName] = code;
+  }
+
+  getWeb3Config() {
+    return {defaultAccount: this.context.web3.eth.defaultAccount, provider: this.context.web3.currentProvider};
+  }
 }
 
-// ======================
-// the eval is used for evaluating some of the contact calls for different purposes
-// this should be at least moved to a different process and scope
-// for now it is defined here
-// ======================
-function doEval(code) {
-  // TODO: add trace log here
-  return eval(code);
-}
-
-function registerVar(varName, code) {
-  __mainContext[varName] = code;
-}
-
-function getWeb3Config() {
-  return {defaultAccount:__mainContext.web3.eth.defaultAccount, provider: __mainContext.web3.currentProvider};
-}
-
-module.exports = {
-  doEval,
-  registerVar,
-  initContext,
-  getWeb3Config
-};
+module.exports = RunCode;

--- a/test_apps/test_app/test/ens_spec.js
+++ b/test_apps/test_app/test/ens_spec.js
@@ -18,9 +18,7 @@ config({
       "onDeploy": [
         `ENSRegistry.methods.setOwner('${rootNode}', web3.eth.defaultAccount).send().then(() => {
           ENSRegistry.methods.setResolver('${rootNode}', "$Resolver").send();
-          Resolver.methods.setAddr('${rootNode}', '${address}').send().then(() => {
-            global.ensTestReady = true;
-          });
+          Resolver.methods.setAddr('${rootNode}', '${address}').send();
         });`
       ]
     }
@@ -28,21 +26,18 @@ config({
 });
 
 contract("ENS", function () {
-  this.timeout(1000);
+  it("should have registered embark.eth", function () {
+    let maxRetry = 20;
+    let domainAddress;
 
-  before(function (done) {
-  //   Wait for onDeploy to finish
-    const wait = setInterval(() => {
-      if (!global.ensTestReady) {
+    const wait = setInterval(async () => {
+      domainAddress = await Resolver.methods.addr(rootNode).call();
+      if (domainAddress || maxRetry === 0) {
+        clearInterval(wait);
+        assert.strictEqual(domainAddress, address);
         return;
       }
-      clearInterval(wait);
-      done();
+      maxRetry--;
     }, 50);
-  });
-
-  it("should have registered embark.eth", async function () {
-    const domainAddress = await Resolver.methods.addr(rootNode).call();
-    assert.strictEqual(domainAddress, address);
   });
 });


### PR DESCRIPTION
## Overview
**TL;DR**
Name a contract Buffer cause a failure.

The error is cause because by default Buffer is part of the global namespace. By doing a contract Buffer the default one is overridden.
Some of the library have usage of the Buffer.

To avoid any conflict, the code runner do not touch the global namespace, it uses a vm
(https://nodejs.org/api/vm.html)

The context is also set on the repl such that auto completion still works.

