### PR TITLE
pipeline option/default for upload command

### DIFF
--- a/cmd/cmd.js
+++ b/cmd/cmd.js
@@ -260,6 +260,7 @@ class Cmd {
       .option('--loglevel [loglevel]', __('level of logging to display') + ' ["error", "warn", "info", "debug", "trace"]', /^(error|warn|info|debug|trace)$/i, 'debug')
       .option('--locale [locale]', __('language to use (default: en)'))
       .option('-c, --client [client]', __('Use a specific ethereum client or simulator (supported: %s)', 'geth, testrpc'))
+      .option('--pipeline [pipeline]', __('webpack config to use (default: production)'))
       .description(__('Upload your dapp to a decentralized storage') + '.')
       .action(function (env, _options) {
         i18n.setOrDetectLocale(_options.locale);
@@ -272,6 +273,7 @@ class Cmd {
         _options.logFile = _options.logfile; // fix casing
         _options.logLevel = _options.loglevel; // fix casing
         _options.client = _options.client || 'geth';
+        _options.webpackConfigName = _options.pipeline || 'production';
         embark.upload(_options);
       });
   }

--- a/cmd/cmd_controller.js
+++ b/cmd/cmd_controller.js
@@ -446,7 +446,8 @@ class EmbarkController {
       logger: options.logger,
       config: options.config,
       plugins: options.plugins,
-      context: this.context
+      context: this.context,
+      webpackConfigName: options.webpackConfigName
     });
     engine.init();
 

--- a/lib/modules/ipfs/upload.js
+++ b/lib/modules/ipfs/upload.js
@@ -43,7 +43,7 @@ class IPFS {
       },
       function printUrls(dir_hash, callback) {
         console.log(("=== " + __("DApp available at") + " http://localhost:8080/ipfs/" + dir_hash + "/").green);
-        console.log(("=== " + __("DApp available at") + " http://ipfs.infura.io/ipfs/" + dir_hash + "/").green);
+        console.log(("=== " + __("DApp available at") + " https://ipfs.infura.io/ipfs/" + dir_hash + "/").green);
 
         callback(null, dir_hash);
       }

--- a/lib/modules/swarm/upload.js
+++ b/lib/modules/swarm/upload.js
@@ -31,7 +31,7 @@ class Swarm {
           return callback('No directory hash was returned');
         }
         console.log(("=== " + __("DApp available at") + ` ${self.getUrl}${dir_hash}/`).green);
-        console.log(("=== " + __("DApp available at") + ` http://swarm-gateways.net/bzz:/${dir_hash}`).green);
+        console.log(("=== " + __("DApp available at") + ` https://swarm-gateways.net/bzz:/${dir_hash}`).green);
 
         callback(null, dir_hash);
       }

--- a/lib/pipeline/webpack.config.js
+++ b/lib/pipeline/webpack.config.js
@@ -165,7 +165,8 @@ devBabelLoader.options.compact = false;
 const production = cloneDeep(base);
 production.mode = 'production';
 production.name = 'production';
-production.plugins.push(new CompressionPlugin());
+// compression of webpack's JS output not enabled by default
+// production.plugins.push(new CompressionPlugin());
 
 // export a list of named configs
 // -----------------------------------------------------------------------------

--- a/lib/pipeline/webpack.config.js
+++ b/lib/pipeline/webpack.config.js
@@ -10,7 +10,7 @@
 // is in embark's node_modules vs. the dapp's node_modules
 
 const cloneDeep = require('lodash.clonedeep');
-const CompressionPlugin = require('compression-webpack-plugin');
+// const CompressionPlugin = require('compression-webpack-plugin');
 const glob = require('glob');
 const HardSourceWebpackPlugin = require('hard-source-webpack-plugin');
 const path = require('path');


### PR DESCRIPTION
## Overview

`embark upload` needs to support a `--pipeline` option, with default value of `production`.

URLs reported after upload for the ipfs and swarm gateways should be `https`.

Webpack shouldn't produce `.gz` files in `buildDir` by default, since that doesn't provide any benefit at present — they're just extra things that get uploaded.