### PR TITLE
Fix hang by not intercepting web3 transactions

### DIFF
--- a/lib/core/modules/coderunner/codeRunner.js
+++ b/lib/core/modules/coderunner/codeRunner.js
@@ -80,8 +80,8 @@ class CodeRunner {
       this.ipc.broadcast("runcode:newCommand", {code});
     }
 
-    if (result instanceof Promise) {
-      return result.then((value) => cb(null, value)).catch(cb);
+    if (result instanceof Promise && !result.on) {
+      return result.then((value) => { cb(null, value); }).catch(cb);
     }
 
     cb(null, result);

--- a/test_apps/test_app/test/simple_storage_spec.js
+++ b/test_apps/test_app/test/simple_storage_spec.js
@@ -23,7 +23,6 @@ contract("SimpleStorage", function () {
   });
 
   it("set storage value", function (done) {
-    // await SimpleStorage.methods.set(150).send();
     Utils.secureSend(web3, SimpleStorage.methods.set(150), {}, false, async function(err) {
       if (err) {
         return done(err);


### PR DESCRIPTION
Bug was caused because transactions sometime hang on websocket connections and with the `await in console` task, we added a condition, if the code eval returns a Promise, wait for it to resolve before call backing. 
However, this was intended to be used with the console, not the onDeploys and other transactions.
So for those, we let the normal behavior happen. But for function calls like `await web3.eth.getAccounts()`, we intercept and display a nice result.
You can still use `await` to do `await SimpleStorage.methods.set(200).send()` in the console