### PR TITLE
profile always return

### DIFF
--- a/lib/modules/profiler/gasEstimator.js
+++ b/lib/modules/profiler/gasEstimator.js
@@ -45,9 +45,7 @@ class GasEstimator {
                   getVarianceCb(err, gasAmount);
                 });
               }, (err, variance) => {
-                if (err) {
-                  return gasCb(err, name, abiMethod.type);
-                } else if (variance.every(v => v === variance[0])) {
+                if (variance.every(v => v === variance[0])) {
                   gasMap[name] = variance[0];
                 } else {
                   // get average


### PR DESCRIPTION
## Overview
**TL;DR**

profile never crash, even when gasEstimate is not successfull due to specific address required.
(adding estimate gas in the ui will allow us to estimage those function)

![screenshot from 2018-08-31 13-39-59](https://user-images.githubusercontent.com/491074/44912985-c7106080-ad23-11e8-9e01-e38c0f7c4cc8.png)

@emizzle 
