### PR TITLE
web3@1.0.0-beta.35

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,8 @@ node_js:
 addons:
     code_climate:
         repo_token: 7454b1a666015e244c384d19f48c34e35d1ae58c3aa428ec542f10bbcb848358
+before_install:
+    - npm i -g npm@latest
 script:
     - npm run lint
     - npm run test

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -7,7 +7,7 @@ install:
   # Get the latest stable version of Node.js or io.js
   - ps: Install-Product node $env:nodejs_version
   # install modules
-  - npm install -g npm@5.7
+  - npm install -g npm@latest
   - npm install
 
 # Post-install test scripts.

--- a/package-lock.json
+++ b/package-lock.json
@@ -2183,6 +2183,11 @@
       "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
       "integrity": "sha1-4wOogrNCzD7oylE6eZmXNNqzriw="
     },
+    "cookiejar": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/cookiejar/-/cookiejar-2.1.2.tgz",
+      "integrity": "sha512-Mw+adcfzPxcPeI+0WlvRrr/3lGVO0bD75SxX6811cxSh1Wbxx7xZBGK1eVtDf6si8rg2lhnUjsVLMFMfbRIuwA=="
+    },
     "copy-concurrently": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/copy-concurrently/-/copy-concurrently-1.0.5.tgz",
@@ -5485,8 +5490,7 @@
         "pem-jwk": "^1.5.1",
         "protons": "^1.0.1",
         "rsa-pem-to-jwk": "^1.1.3",
-        "tweetnacl": "^1.0.0",
-        "webcrypto-shim": "github:dignifiedquire/webcrypto-shim#190bc9ec341375df6025b17ae12ddb2428ea49c8"
+        "tweetnacl": "^1.0.0"
       },
       "dependencies": {
         "base-x": {
@@ -5504,6 +5508,10 @@
           "requires": {
             "base-x": "^3.0.2"
           }
+        },
+        "webcrypto-shim": {
+          "version": "github:dignifiedquire/webcrypto-shim#190bc9ec341375df6025b17ae12ddb2428ea49c8",
+          "from": "github:dignifiedquire/webcrypto-shim#190bc9ec341375df6025b17ae12ddb2428ea49c8"
         }
       }
     },
@@ -8924,9 +8932,9 @@
           "integrity": "sha512-ccav/yGvoa80BQDljCxsmmQ3Xvx60/UpBIij5QN21W3wBi/hhIC9OoO+KLpu9IJTS9j4DRVJ3aDDF9cMSoa2lw=="
         },
         "buffer": {
-          "version": "5.2.0",
-          "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.2.0.tgz",
-          "integrity": "sha512-nUJyfChH7PMJy75eRDCCKtszSEFokUNXC1hNVSe+o+VdcgvDPLs20k3v8UXI8ruRYAJiYtyRea8mYyqPxoHWDw==",
+          "version": "5.2.1",
+          "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.2.1.tgz",
+          "integrity": "sha512-c+Ko0loDaFfuPWiL02ls9Xd3GO3cPVmUobQ6t3rXNUk304u6hGq+8N/kFi+QEIKhzK3uwolVhLzszmfLmMLnqg==",
           "requires": {
             "base64-js": "^1.0.2",
             "ieee754": "^1.1.4"
@@ -9700,23 +9708,23 @@
       }
     },
     "web3": {
-      "version": "1.0.0-beta.34",
-      "resolved": "https://registry.npmjs.org/web3/-/web3-1.0.0-beta.34.tgz",
-      "integrity": "sha1-NH5WG3hAmMtVYzFfSQR5odkfKrE=",
+      "version": "1.0.0-beta.35",
+      "resolved": "https://registry.npmjs.org/web3/-/web3-1.0.0-beta.35.tgz",
+      "integrity": "sha512-xwDmUhvTcHQvvNnOPcPZZgCxKUsI2e+GbHy7JkTK3/Rmnutazy8x7fsAXT9myw7V1qpi3GgLoZ3fkglSUbg1Mg==",
       "requires": {
-        "web3-bzz": "1.0.0-beta.34",
-        "web3-core": "1.0.0-beta.34",
-        "web3-eth": "1.0.0-beta.34",
-        "web3-eth-personal": "1.0.0-beta.34",
-        "web3-net": "1.0.0-beta.34",
-        "web3-shh": "1.0.0-beta.34",
-        "web3-utils": "1.0.0-beta.34"
+        "web3-bzz": "1.0.0-beta.35",
+        "web3-core": "1.0.0-beta.35",
+        "web3-eth": "1.0.0-beta.35",
+        "web3-eth-personal": "1.0.0-beta.35",
+        "web3-net": "1.0.0-beta.35",
+        "web3-shh": "1.0.0-beta.35",
+        "web3-utils": "1.0.0-beta.35"
       }
     },
     "web3-bzz": {
-      "version": "1.0.0-beta.34",
-      "resolved": "https://registry.npmjs.org/web3-bzz/-/web3-bzz-1.0.0-beta.34.tgz",
-      "integrity": "sha1-Bo03d3q2Xlxg+OyLmlDP5FJ3kpw=",
+      "version": "1.0.0-beta.35",
+      "resolved": "https://registry.npmjs.org/web3-bzz/-/web3-bzz-1.0.0-beta.35.tgz",
+      "integrity": "sha512-BhAU0qhlr8zltm4gs/+P1gki2VkxHJaM2Rrh4DGesDW0lzwufRoNvWFlwx1bKHoFPWNbSmm9PRkHOYOINL/Tgw==",
       "requires": {
         "got": "7.1.0",
         "swarm-js": "0.1.37",
@@ -9731,24 +9739,24 @@
       }
     },
     "web3-core": {
-      "version": "1.0.0-beta.34",
-      "resolved": "https://registry.npmjs.org/web3-core/-/web3-core-1.0.0-beta.34.tgz",
-      "integrity": "sha1-EhvoVV6fsA0sXQXd0zgdDJ5GmH4=",
+      "version": "1.0.0-beta.35",
+      "resolved": "https://registry.npmjs.org/web3-core/-/web3-core-1.0.0-beta.35.tgz",
+      "integrity": "sha512-ayGavbgVk4KL9Y88Uv411fBJ0SVgVfKhKEBweKYzmP0zOqneMzWt6YsyD1n6kRvjAbqA0AfUPEOKyMNjcx2tjw==",
       "requires": {
-        "web3-core-helpers": "1.0.0-beta.34",
-        "web3-core-method": "1.0.0-beta.34",
-        "web3-core-requestmanager": "1.0.0-beta.34",
-        "web3-utils": "1.0.0-beta.34"
+        "web3-core-helpers": "1.0.0-beta.35",
+        "web3-core-method": "1.0.0-beta.35",
+        "web3-core-requestmanager": "1.0.0-beta.35",
+        "web3-utils": "1.0.0-beta.35"
       }
     },
     "web3-core-helpers": {
-      "version": "1.0.0-beta.34",
-      "resolved": "https://registry.npmjs.org/web3-core-helpers/-/web3-core-helpers-1.0.0-beta.34.tgz",
-      "integrity": "sha1-sWjaANPhnhVrwVriAyA91N/uLQM=",
+      "version": "1.0.0-beta.35",
+      "resolved": "https://registry.npmjs.org/web3-core-helpers/-/web3-core-helpers-1.0.0-beta.35.tgz",
+      "integrity": "sha512-APOu3sEsamyqWt//8o4yq9KF25/uqGm+pQShson/sC4gKzmfJB07fLo2ond0X30E8fIqAPeVCotPXQxGciGUmA==",
       "requires": {
         "underscore": "1.8.3",
-        "web3-eth-iban": "1.0.0-beta.34",
-        "web3-utils": "1.0.0-beta.34"
+        "web3-eth-iban": "1.0.0-beta.35",
+        "web3-utils": "1.0.0-beta.35"
       },
       "dependencies": {
         "underscore": {
@@ -9759,15 +9767,15 @@
       }
     },
     "web3-core-method": {
-      "version": "1.0.0-beta.34",
-      "resolved": "https://registry.npmjs.org/web3-core-method/-/web3-core-method-1.0.0-beta.34.tgz",
-      "integrity": "sha1-7BY8iixJD6AqfsFVWfpzB/x8xt0=",
+      "version": "1.0.0-beta.35",
+      "resolved": "https://registry.npmjs.org/web3-core-method/-/web3-core-method-1.0.0-beta.35.tgz",
+      "integrity": "sha512-jidImCide8q0GpfsO4L73qoHrbkeWgwU3uOH5DKtJtv0ccmG086knNMRgryb/o9ZgetDWLmDEsJnHjBSoIwcbA==",
       "requires": {
         "underscore": "1.8.3",
-        "web3-core-helpers": "1.0.0-beta.34",
-        "web3-core-promievent": "1.0.0-beta.34",
-        "web3-core-subscriptions": "1.0.0-beta.34",
-        "web3-utils": "1.0.0-beta.34"
+        "web3-core-helpers": "1.0.0-beta.35",
+        "web3-core-promievent": "1.0.0-beta.35",
+        "web3-core-subscriptions": "1.0.0-beta.35",
+        "web3-utils": "1.0.0-beta.35"
       },
       "dependencies": {
         "underscore": {
@@ -9778,9 +9786,9 @@
       }
     },
     "web3-core-promievent": {
-      "version": "1.0.0-beta.34",
-      "resolved": "https://registry.npmjs.org/web3-core-promievent/-/web3-core-promievent-1.0.0-beta.34.tgz",
-      "integrity": "sha1-pPT6Z4S7KT6CxglgrltWqUzQPtw=",
+      "version": "1.0.0-beta.35",
+      "resolved": "https://registry.npmjs.org/web3-core-promievent/-/web3-core-promievent-1.0.0-beta.35.tgz",
+      "integrity": "sha512-GvqXqKq07OmHuVi5uNRg6k79a1/CI0ViCC+EtNv4CORHtDRmYEt5Bvdv6z6FJEiaaQkD0lKbFwNhLxutx7HItw==",
       "requires": {
         "any-promise": "1.3.0",
         "eventemitter3": "1.1.1"
@@ -9794,15 +9802,15 @@
       }
     },
     "web3-core-requestmanager": {
-      "version": "1.0.0-beta.34",
-      "resolved": "https://registry.npmjs.org/web3-core-requestmanager/-/web3-core-requestmanager-1.0.0-beta.34.tgz",
-      "integrity": "sha1-Afj2zyrmtvC3DDi64e90G1urIVw=",
+      "version": "1.0.0-beta.35",
+      "resolved": "https://registry.npmjs.org/web3-core-requestmanager/-/web3-core-requestmanager-1.0.0-beta.35.tgz",
+      "integrity": "sha512-S+zW2h17ZZQU9oe3yaCJE0E7aJS4C3Kf4kGPDv+nXjW0gKhQQhgVhw1Doq/aYQGqNSWJp7f1VHkz5gQWwg6RRg==",
       "requires": {
         "underscore": "1.8.3",
-        "web3-core-helpers": "1.0.0-beta.34",
-        "web3-providers-http": "1.0.0-beta.34",
-        "web3-providers-ipc": "1.0.0-beta.34",
-        "web3-providers-ws": "1.0.0-beta.34"
+        "web3-core-helpers": "1.0.0-beta.35",
+        "web3-providers-http": "1.0.0-beta.35",
+        "web3-providers-ipc": "1.0.0-beta.35",
+        "web3-providers-ws": "1.0.0-beta.35"
       },
       "dependencies": {
         "underscore": {
@@ -9813,13 +9821,13 @@
       }
     },
     "web3-core-subscriptions": {
-      "version": "1.0.0-beta.34",
-      "resolved": "https://registry.npmjs.org/web3-core-subscriptions/-/web3-core-subscriptions-1.0.0-beta.34.tgz",
-      "integrity": "sha1-n+0UQDPyIcPPIQYDAv/a9e8t4t4=",
+      "version": "1.0.0-beta.35",
+      "resolved": "https://registry.npmjs.org/web3-core-subscriptions/-/web3-core-subscriptions-1.0.0-beta.35.tgz",
+      "integrity": "sha512-gXzLrWvcGkGiWq1y33Z4Y80XI8XMrwowiQJkrPSjQ81K5PBKquOGwcMffLaKcwdmEy/NpsOXDeFo3eLE1Ghvvw==",
       "requires": {
         "eventemitter3": "1.1.1",
         "underscore": "1.8.3",
-        "web3-core-helpers": "1.0.0-beta.34"
+        "web3-core-helpers": "1.0.0-beta.35"
       },
       "dependencies": {
         "eventemitter3": {
@@ -9835,22 +9843,22 @@
       }
     },
     "web3-eth": {
-      "version": "1.0.0-beta.34",
-      "resolved": "https://registry.npmjs.org/web3-eth/-/web3-eth-1.0.0-beta.34.tgz",
-      "integrity": "sha1-dAhgAIUMb+b1Ne9Jg31tS7YRMmg=",
+      "version": "1.0.0-beta.35",
+      "resolved": "https://registry.npmjs.org/web3-eth/-/web3-eth-1.0.0-beta.35.tgz",
+      "integrity": "sha512-04mcb2nGPXThawuuYICPOxv0xOHofvQKsjZeIq+89nyOC8DQMGTAErDkGyMHQYtjpth5XDhic0wuEsA80AmFZA==",
       "requires": {
         "underscore": "1.8.3",
-        "web3-core": "1.0.0-beta.34",
-        "web3-core-helpers": "1.0.0-beta.34",
-        "web3-core-method": "1.0.0-beta.34",
-        "web3-core-subscriptions": "1.0.0-beta.34",
-        "web3-eth-abi": "1.0.0-beta.34",
-        "web3-eth-accounts": "1.0.0-beta.34",
-        "web3-eth-contract": "1.0.0-beta.34",
-        "web3-eth-iban": "1.0.0-beta.34",
-        "web3-eth-personal": "1.0.0-beta.34",
-        "web3-net": "1.0.0-beta.34",
-        "web3-utils": "1.0.0-beta.34"
+        "web3-core": "1.0.0-beta.35",
+        "web3-core-helpers": "1.0.0-beta.35",
+        "web3-core-method": "1.0.0-beta.35",
+        "web3-core-subscriptions": "1.0.0-beta.35",
+        "web3-eth-abi": "1.0.0-beta.35",
+        "web3-eth-accounts": "1.0.0-beta.35",
+        "web3-eth-contract": "1.0.0-beta.35",
+        "web3-eth-iban": "1.0.0-beta.35",
+        "web3-eth-personal": "1.0.0-beta.35",
+        "web3-net": "1.0.0-beta.35",
+        "web3-utils": "1.0.0-beta.35"
       },
       "dependencies": {
         "underscore": {
@@ -9861,14 +9869,14 @@
       }
     },
     "web3-eth-abi": {
-      "version": "1.0.0-beta.34",
-      "resolved": "https://registry.npmjs.org/web3-eth-abi/-/web3-eth-abi-1.0.0-beta.34.tgz",
-      "integrity": "sha1-A0Uz46ovfln/MXk+rqaFwO1a9no=",
+      "version": "1.0.0-beta.35",
+      "resolved": "https://registry.npmjs.org/web3-eth-abi/-/web3-eth-abi-1.0.0-beta.35.tgz",
+      "integrity": "sha512-KUDC+EtFFYG8z01ZleKrASdjj327/rtWHzEt6RWsEj7bBa0bGp9nEh+nqdZx/Sdgz1O8tnfFzJlrRcXpfr1vGg==",
       "requires": {
         "bn.js": "4.11.6",
         "underscore": "1.8.3",
-        "web3-core-helpers": "1.0.0-beta.34",
-        "web3-utils": "1.0.0-beta.34"
+        "web3-core-helpers": "1.0.0-beta.35",
+        "web3-utils": "1.0.0-beta.35"
       },
       "dependencies": {
         "bn.js": {
@@ -9884,9 +9892,9 @@
       }
     },
     "web3-eth-accounts": {
-      "version": "1.0.0-beta.34",
-      "resolved": "https://registry.npmjs.org/web3-eth-accounts/-/web3-eth-accounts-1.0.0-beta.34.tgz",
-      "integrity": "sha1-4JFC7uzHl6w0WbdemyOUbTaV8zM=",
+      "version": "1.0.0-beta.35",
+      "resolved": "https://registry.npmjs.org/web3-eth-accounts/-/web3-eth-accounts-1.0.0-beta.35.tgz",
+      "integrity": "sha512-duIgRsfht/0kAW/eQ0X9lKtVIykbETrnM2H7EnvplCzPHtQLodpib4o9JXfh9n6ZDgdDC7cuJoiVB9QJg089ew==",
       "requires": {
         "any-promise": "1.3.0",
         "crypto-browserify": "3.12.0",
@@ -9894,10 +9902,10 @@
         "scrypt.js": "0.2.0",
         "underscore": "1.8.3",
         "uuid": "2.0.1",
-        "web3-core": "1.0.0-beta.34",
-        "web3-core-helpers": "1.0.0-beta.34",
-        "web3-core-method": "1.0.0-beta.34",
-        "web3-utils": "1.0.0-beta.34"
+        "web3-core": "1.0.0-beta.35",
+        "web3-core-helpers": "1.0.0-beta.35",
+        "web3-core-method": "1.0.0-beta.35",
+        "web3-utils": "1.0.0-beta.35"
       },
       "dependencies": {
         "eth-lib": {
@@ -9923,18 +9931,18 @@
       }
     },
     "web3-eth-contract": {
-      "version": "1.0.0-beta.34",
-      "resolved": "https://registry.npmjs.org/web3-eth-contract/-/web3-eth-contract-1.0.0-beta.34.tgz",
-      "integrity": "sha1-nbs4+udkOoCEJ6IBgEcOx0FckeY=",
+      "version": "1.0.0-beta.35",
+      "resolved": "https://registry.npmjs.org/web3-eth-contract/-/web3-eth-contract-1.0.0-beta.35.tgz",
+      "integrity": "sha512-foPohOg5O1UCGKGZOIs+kQK5IZdV2QQ7pAWwNxH8WHplUA+fre1MurXNpoxknUmH6mYplFhXjqgYq2MsrBpHrA==",
       "requires": {
         "underscore": "1.8.3",
-        "web3-core": "1.0.0-beta.34",
-        "web3-core-helpers": "1.0.0-beta.34",
-        "web3-core-method": "1.0.0-beta.34",
-        "web3-core-promievent": "1.0.0-beta.34",
-        "web3-core-subscriptions": "1.0.0-beta.34",
-        "web3-eth-abi": "1.0.0-beta.34",
-        "web3-utils": "1.0.0-beta.34"
+        "web3-core": "1.0.0-beta.35",
+        "web3-core-helpers": "1.0.0-beta.35",
+        "web3-core-method": "1.0.0-beta.35",
+        "web3-core-promievent": "1.0.0-beta.35",
+        "web3-core-subscriptions": "1.0.0-beta.35",
+        "web3-eth-abi": "1.0.0-beta.35",
+        "web3-utils": "1.0.0-beta.35"
       },
       "dependencies": {
         "underscore": {
@@ -9945,12 +9953,12 @@
       }
     },
     "web3-eth-iban": {
-      "version": "1.0.0-beta.34",
-      "resolved": "https://registry.npmjs.org/web3-eth-iban/-/web3-eth-iban-1.0.0-beta.34.tgz",
-      "integrity": "sha1-mvRYYFhnzPdOqXmq8yazi6alugw=",
+      "version": "1.0.0-beta.35",
+      "resolved": "https://registry.npmjs.org/web3-eth-iban/-/web3-eth-iban-1.0.0-beta.35.tgz",
+      "integrity": "sha512-H5wkcNcAIc+h/WoDIKv7ZYmrM2Xqu3O7jBQl1IWo73EDVQji+AoB2i3J8tuwI1yZRInRwrfpI3Zuwuf54hXHmQ==",
       "requires": {
         "bn.js": "4.11.6",
-        "web3-utils": "1.0.0-beta.34"
+        "web3-utils": "1.0.0-beta.35"
       },
       "dependencies": {
         "bn.js": {
@@ -9961,44 +9969,44 @@
       }
     },
     "web3-eth-personal": {
-      "version": "1.0.0-beta.34",
-      "resolved": "https://registry.npmjs.org/web3-eth-personal/-/web3-eth-personal-1.0.0-beta.34.tgz",
-      "integrity": "sha1-mvuhZzQuveVCC81YlcP2w0OI8gU=",
+      "version": "1.0.0-beta.35",
+      "resolved": "https://registry.npmjs.org/web3-eth-personal/-/web3-eth-personal-1.0.0-beta.35.tgz",
+      "integrity": "sha512-AcM9nnlxu7ZRRxPvkrFB9eLxMM4A2cPfj2aCg21Wb2EpMnhR+b/O1cT33k7ApRowoMpM+T9M8vx2oPNwXfaCOQ==",
       "requires": {
-        "web3-core": "1.0.0-beta.34",
-        "web3-core-helpers": "1.0.0-beta.34",
-        "web3-core-method": "1.0.0-beta.34",
-        "web3-net": "1.0.0-beta.34",
-        "web3-utils": "1.0.0-beta.34"
+        "web3-core": "1.0.0-beta.35",
+        "web3-core-helpers": "1.0.0-beta.35",
+        "web3-core-method": "1.0.0-beta.35",
+        "web3-net": "1.0.0-beta.35",
+        "web3-utils": "1.0.0-beta.35"
       }
     },
     "web3-net": {
-      "version": "1.0.0-beta.34",
-      "resolved": "https://registry.npmjs.org/web3-net/-/web3-net-1.0.0-beta.34.tgz",
-      "integrity": "sha1-QnzqL0MYgUScjjjVIykPFz+f9j0=",
+      "version": "1.0.0-beta.35",
+      "resolved": "https://registry.npmjs.org/web3-net/-/web3-net-1.0.0-beta.35.tgz",
+      "integrity": "sha512-bbwaQ/KohGjIJ6HAKbZ6KrklCAaG6/B7hIbAbVLSFLxF+Yz9lmAgQYaDInpidpC/NLb3WOmcbRF+P77J4qMVIA==",
       "requires": {
-        "web3-core": "1.0.0-beta.34",
-        "web3-core-method": "1.0.0-beta.34",
-        "web3-utils": "1.0.0-beta.34"
+        "web3-core": "1.0.0-beta.35",
+        "web3-core-method": "1.0.0-beta.35",
+        "web3-utils": "1.0.0-beta.35"
       }
     },
     "web3-providers-http": {
-      "version": "1.0.0-beta.34",
-      "resolved": "https://registry.npmjs.org/web3-providers-http/-/web3-providers-http-1.0.0-beta.34.tgz",
-      "integrity": "sha1-5WG1K7tDdmKCAH1AKFv+NVDCfno=",
+      "version": "1.0.0-beta.35",
+      "resolved": "https://registry.npmjs.org/web3-providers-http/-/web3-providers-http-1.0.0-beta.35.tgz",
+      "integrity": "sha512-DcIMFq52Fb08UpWyZ3ZlES6NsNqJnco4hBS/Ej6eOcASfuUayPI+GLkYVZsnF3cBYqlH+DOKuArcKSuIxK7jIA==",
       "requires": {
-        "web3-core-helpers": "1.0.0-beta.34",
-        "xhr2": "0.1.4"
+        "web3-core-helpers": "1.0.0-beta.35",
+        "xhr2-cookies": "1.1.0"
       }
     },
     "web3-providers-ipc": {
-      "version": "1.0.0-beta.34",
-      "resolved": "https://registry.npmjs.org/web3-providers-ipc/-/web3-providers-ipc-1.0.0-beta.34.tgz",
-      "integrity": "sha1-obd/GjBtc2SanAOQUuQMtxMo0Ao=",
+      "version": "1.0.0-beta.35",
+      "resolved": "https://registry.npmjs.org/web3-providers-ipc/-/web3-providers-ipc-1.0.0-beta.35.tgz",
+      "integrity": "sha512-iB0FG0HcpUnayfa8pn4guqEQ4Y1nrroi/jffdtQgFkrNt0sD3fMSwwC0AbmECqj3tDLl0e1slBR0RENll+ZF0g==",
       "requires": {
         "oboe": "2.1.3",
         "underscore": "1.8.3",
-        "web3-core-helpers": "1.0.0-beta.34"
+        "web3-core-helpers": "1.0.0-beta.35"
       },
       "dependencies": {
         "underscore": {
@@ -10009,12 +10017,12 @@
       }
     },
     "web3-providers-ws": {
-      "version": "1.0.0-beta.34",
-      "resolved": "https://registry.npmjs.org/web3-providers-ws/-/web3-providers-ws-1.0.0-beta.34.tgz",
-      "integrity": "sha1-fecPG4Py3jZHZ3IVa+z+9uNRbrM=",
+      "version": "1.0.0-beta.35",
+      "resolved": "https://registry.npmjs.org/web3-providers-ws/-/web3-providers-ws-1.0.0-beta.35.tgz",
+      "integrity": "sha512-Cx64NgDStynKaUGDIIOfaCd0fZusL8h5avKTkdTjUu2aHhFJhZoVBGVLhoDtUaqZGWIZGcBJOoVf2JkGUOjDRQ==",
       "requires": {
         "underscore": "1.8.3",
-        "web3-core-helpers": "1.0.0-beta.34",
+        "web3-core-helpers": "1.0.0-beta.35",
         "websocket": "git://github.com/frozeman/WebSocket-Node.git#6c72925e3f8aaaea8dc8450f97627e85263999f2"
       },
       "dependencies": {
@@ -10026,20 +10034,20 @@
       }
     },
     "web3-shh": {
-      "version": "1.0.0-beta.34",
-      "resolved": "https://registry.npmjs.org/web3-shh/-/web3-shh-1.0.0-beta.34.tgz",
-      "integrity": "sha1-l1Bh1x6uxCzO5Xb3vY9w8DhEr+A=",
+      "version": "1.0.0-beta.35",
+      "resolved": "https://registry.npmjs.org/web3-shh/-/web3-shh-1.0.0-beta.35.tgz",
+      "integrity": "sha512-8qSonk/x0xabERS9Sr6AIADN/Ty+5KwARkkGIfSYHKqFpdMDz+76F7cUCxtoCZoS8K04xgZlDKYe0TJXLYA0Fw==",
       "requires": {
-        "web3-core": "1.0.0-beta.34",
-        "web3-core-method": "1.0.0-beta.34",
-        "web3-core-subscriptions": "1.0.0-beta.34",
-        "web3-net": "1.0.0-beta.34"
+        "web3-core": "1.0.0-beta.35",
+        "web3-core-method": "1.0.0-beta.35",
+        "web3-core-subscriptions": "1.0.0-beta.35",
+        "web3-net": "1.0.0-beta.35"
       }
     },
     "web3-utils": {
-      "version": "1.0.0-beta.34",
-      "resolved": "https://registry.npmjs.org/web3-utils/-/web3-utils-1.0.0-beta.34.tgz",
-      "integrity": "sha1-lBH8OarvOcpOBhafdiKX2f8CCXA=",
+      "version": "1.0.0-beta.35",
+      "resolved": "https://registry.npmjs.org/web3-utils/-/web3-utils-1.0.0-beta.35.tgz",
+      "integrity": "sha512-Dq6f0SOKj3BDFRgOPnE6ALbzBDCKVIW8mKWVf7tGVhTDHf+wQaWwQSC3aArFSqdExB75BPBPyDpuMTNszhljpA==",
       "requires": {
         "bn.js": "4.11.6",
         "eth-lib": "0.1.27",
@@ -10080,10 +10088,6 @@
           "integrity": "sha1-LgHbAvfY0JRPdxBPFgnrDDBM92g="
         }
       }
-    },
-    "webcrypto-shim": {
-      "version": "github:dignifiedquire/webcrypto-shim#190bc9ec341375df6025b17ae12ddb2428ea49c8",
-      "from": "github:dignifiedquire/webcrypto-shim#master"
     },
     "webpack": {
       "version": "4.17.1",
@@ -10340,10 +10344,13 @@
         "xhr-request": "^1.0.1"
       }
     },
-    "xhr2": {
-      "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/xhr2/-/xhr2-0.1.4.tgz",
-      "integrity": "sha1-f4dliEdxbbUCYyOBL4GMras4el8="
+    "xhr2-cookies": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/xhr2-cookies/-/xhr2-cookies-1.1.0.tgz",
+      "integrity": "sha1-fXdEnQmZGX8VXLc7I99yUF7YnUg=",
+      "requires": {
+        "cookiejar": "^2.1.1"
+      }
     },
     "xregexp": {
       "version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -85,7 +85,7 @@
     "url-loader": "^0.6.2",
     "uuid": "^3.2.1",
     "viz.js": "^1.8.1",
-    "web3": "1.0.0-beta.34",
+    "web3": "1.0.0-beta.35",
     "webpack": "^4.16.1",
     "window-size": "^1.1.0"
   },


### PR DESCRIPTION
## Overview

When doing a clean install on develop this afternoon (`rm -rf node_modules && npm i .`), I found that changes were introduced to `package-lock.json`. I've created a [gist from the diff](https://gist.github.com/michaelsbradleyjr/8afdf78e537e03e4ed6bab31b53e6be0).

When running `npm ls --depth=0` there are dependencies reported missing:

```
npm ERR! invalid: webcrypto-shim@0.1.1 /Users/michael/temp/nozzle/embark/node_modules/libp2p-crypto/node_modules/webcrypto-shim
npm ERR! invalid: websocket@1.0.26 /Users/michael/temp/nozzle/embark/node_modules/web3-providers-ws/node_modules/websocket
npm ERR! missing: typedarray-to-buffer@^3.1.2, required by websocket@1.0.26
npm ERR! missing: yaeti@^0.0.6, required by websocket@1.0.26
npm ERR! extraneous: debug@2.6.9 /Users/michael/temp/nozzle/embark/node_modules/web3-providers-ws/node_modules/debug
```

When attempting to run `npm run fulltest`, there is a failure owing to the missing deps.

Bumping web3 to `1.0.0-beta.35` seems to fix the problem; afterward, one dependency is still reported as invalid, but that's associated with the `ipfs-api` package, not web3, and doesn't seem to prevent the tests from passing nor `embark_demo` from functioning as expected (but see https://github.com/embark-framework/EmbarkJS/pull/18).