### PR TITLE
Do not start webserver if set to false in embark.json

### DIFF
--- a/lib/core/config.js
+++ b/lib/core/config.js
@@ -322,6 +322,10 @@ Config.prototype.loadWebServerConfigFile = function() {
 
   let webServerConfig = this._mergeConfig(configFilePath, configObject, false);
 
+  if (configFilePath === false) {
+    this.webServerConfig = {enabled: false};
+    return;
+  }
   if (this.webServerConfig) {
     // cli falgs to `embark run` should override configFile and defaults (configObject)
     this.webServerConfig = utils.recursiveMerge(webServerConfig, this.webServerConfig);


### PR DESCRIPTION
We added webserver options to the cmd at some point. It added a manual `webserverConfig` to the configs, that overrided the `false` put in embark.json