### PR TITLE
No accounts warning in development

### DIFF
--- a/lib/core/config.js
+++ b/lib/core/config.js
@@ -183,7 +183,7 @@ Config.prototype.loadBlockchainConfigFile = function() {
   if (!configFilePath) {
     this.blockchainConfig.default = true;
   }
-  if(!this.blockchainConfig.account && !this.blockchainConfig.isDev) {
+  if(!this.blockchainConfig.account && !this.blockchainConfig.isDev && this.env !== 'development') {
     this.logger.warn(
       __('Account settings are needed for this chain.' +
          ' Please put a valid address and possibly a password in your blockchain config or use a dev chain.')


### PR DESCRIPTION
Caused the `--simple` app to always get the "Please specify accounts config", because it doesn't have a blockchain config, so it uses the defaults, which doesn't use `isDev`.