### PR TITLE
Extend template_generator to support git urls and branches

### DIFF
--- a/lib/utils/template_generator.js
+++ b/lib/utils/template_generator.js
@@ -75,25 +75,66 @@ class TemplateGenerator {
     console.log('\n' + __('App ready at ').green + templatePath);
   }
 
-  getExternalProject(uri) {
-    let match = uri.match(
-      /\.[a-z]+\/([-a-zA-Z0-9@:%_+.~#?&\/=]+)/
-    );
+  extractGithubUrlAndFolder(uri){
+
+    /*  first matching group is the url, second the repoPart and third the branch with a hash in the beginning (if existing)
+        e.g. (["git@github.com/status-im/dappcon-workshop-dapp#master", "status-im/dappcon-workshop-dapp", "#master" ])
+        should work with all formats of the following:
+        * git@github.com/status-im/dappcon-workshop-dapp#start-here
+        * git@github.com/status-im/dappcon-workshop-dapp
+        * http://www.github.com/status-im/dappcon-workshop-dapp
+        * https://www.github.com/status-im/dappcon-workshop-dapp
+        * github.com/status-im/dappcon-workshop-dapp#start-here
+
+        sadly it doesn't extract from http(s)://github.com/status-im/dappcon-workshop-dapp/tree/start-here
+        thats why we have a special case later
+    */
+    const match = uri.match(/github\.com+\/(.+?)(#.*)?$/);
+    const githubPart = "https://github.com/";
+    let repoPart = match !== null? match[1] : null;
+    let branchName = match !== null? match[2] : null;
+
+    if (branchName && branchName !== '#'){
+      branchName = branchName.substring(1);
+    } else {
+      branchName = "master";
+    }
 
     let url, folder;
+    if (uri.includes("/tree")){
+    //e.g http(s)://github.com/status-im/dappcon-workshop-dapp/tree/start-here
+      let repoPartAndBranch = repoPart.split("/tree/");
+      repoPart = repoPartAndBranch[0];
+      branchName = repoPartAndBranch[1];
+      url = "https://github.com/" + repoPart + "/archive/"+ branchName +".zip";
+      folder = repoPart + "/" + branchName;
+    } else if (repoPart !== undefined) {
+      url = githubPart + repoPart + "/archive/" + branchName + ".zip";
+      folder = repoPart + "/" + branchName;
+   }
 
-    if (uri.startsWith('http')) {
-      url = uri + "/archive/master.zip";
-      folder = match[1];
-    } else if (uri.startsWith('github')) {
-      url = "https://" + uri + "/archive/master.zip";
-      folder = match[1];
-    } else if (uri.split('/').length === 2) {
-      url = "https://github.com/" + uri + "/archive/master.zip";
-      folder = uri;
+    return {
+      'url': url,
+      'folder': folder
+    };
+  }
+
+  getExternalProject(uri) {
+    let url, folder;
+    if (uri.split('/').length === 2) {
+      //e.g embark-framework/embark
+      let repoPartAndBranch = uri.split('#');
+      let repoPart = repoPartAndBranch[0];
+      let branchName = (repoPartAndBranch.length === 2)? repoPartAndBranch[1] : "master";
+      url = "https://github.com/" + repoPart + "/archive/"+ branchName + ".zip";
+      folder = repoPart + "/" + branchName;
     } else if (uri.indexOf('/') === -1) {
       url = "https://github.com/embark-framework/embark-" + uri + "-template/archive/master.zip";
       folder = "embark-framework/embark-" + uri + "-template";
+    } else {
+      let urlAndFolder = this.extractGithubUrlAndFolder(uri);
+      url = urlAndFolder.url;
+      folder = urlAndFolder.folder;
     }
 
     return {
@@ -101,7 +142,5 @@ class TemplateGenerator {
       filePath: utils.joinPath(".embark/templates/", folder, "archive.zip")
     };
   }
-
 }
-
 module.exports = TemplateGenerator;

--- a/test/template.js
+++ b/test/template.js
@@ -15,31 +15,49 @@ describe('TemplateGenerator', function () {
       it('return correct zip filename for https link', function () {
         let result = templateGenerator.getExternalProject("https://github.com/embark-framework/embark");
         assert.strictEqual(result.url, "https://github.com/embark-framework/embark/archive/master.zip");
-        assert.strictEqual(result.filePath.replace(/\\/g,'/'), ".embark/templates/embark-framework/embark/archive.zip");
+        assert.strictEqual(result.filePath.replace(/\\/g,'/'), ".embark/templates/embark-framework/embark/master/archive.zip");
+      });
+
+      it('return correct zip filename for https link with branch specified', function () {
+        let result = templateGenerator.getExternalProject("https://github.com/embark-framework/embark/tree/develop");
+        assert.strictEqual(result.url, "https://github.com/embark-framework/embark/archive/develop.zip");
+        assert.strictEqual(result.filePath.replace(/\\/g,'/'), ".embark/templates/embark-framework/embark/develop/archive.zip");
       });
 
       it('return correct zip filename for http link', function () {
         let result = templateGenerator.getExternalProject("http://github.com/embark-framework/embark");
-        assert.strictEqual(result.url, "http://github.com/embark-framework/embark/archive/master.zip");
-        assert.strictEqual(result.filePath.replace(/\\/g,'/'), ".embark/templates/embark-framework/embark/archive.zip");
+        assert.strictEqual(result.url, "https://github.com/embark-framework/embark/archive/master.zip");
+        assert.strictEqual(result.filePath.replace(/\\/g,'/'), ".embark/templates/embark-framework/embark/master/archive.zip");
+      });
+
+      it('return correct zip filename for http link with branch specified', function () {
+        let result = templateGenerator.getExternalProject("http://github.com/embark-framework/embark/tree/develop");
+        assert.strictEqual(result.url, "https://github.com/embark-framework/embark/archive/develop.zip");
+        assert.strictEqual(result.filePath.replace(/\\/g,'/'), ".embark/templates/embark-framework/embark/develop/archive.zip");
       });
 
       it('return correct zip filename without protocol specified ', function () {
         let result = templateGenerator.getExternalProject("github.com/embark-framework/embark");
         assert.strictEqual(result.url, "https://github.com/embark-framework/embark/archive/master.zip");
-        assert.strictEqual(result.filePath.replace(/\\/g,'/'), ".embark/templates/embark-framework/embark/archive.zip");
+        assert.strictEqual(result.filePath.replace(/\\/g,'/'), ".embark/templates/embark-framework/embark/master/archive.zip");
       });
 
-      it('return correct zip filename without protocol specified ', function () {
-        let result = templateGenerator.getExternalProject("github.com/embark-framework/embark");
-        assert.strictEqual(result.url, "https://github.com/embark-framework/embark/archive/master.zip");
-        assert.strictEqual(result.filePath.replace(/\\/g,'/'), ".embark/templates/embark-framework/embark/archive.zip");
+      it('return correct zip filename without protocol with branch specified', function () {
+        let result = templateGenerator.getExternalProject("github.com/embark-framework/embark#develop");
+        assert.strictEqual(result.url, "https://github.com/embark-framework/embark/archive/develop.zip");
+        assert.strictEqual(result.filePath.replace(/\\/g,'/'), ".embark/templates/embark-framework/embark/develop/archive.zip");
       });
 
       it('return correct zip filename with just username/repo specified', function () {
         let result = templateGenerator.getExternalProject("embark-framework/embark");
         assert.strictEqual(result.url, "https://github.com/embark-framework/embark/archive/master.zip");
-        assert.strictEqual(result.filePath.replace(/\\/g,'/'), ".embark/templates/embark-framework/embark/archive.zip");
+        assert.strictEqual(result.filePath.replace(/\\/g,'/'), ".embark/templates/embark-framework/embark/master/archive.zip");
+      });
+
+      it('return correct zip filename with just username/repo and branch specified', function () {
+        let result = templateGenerator.getExternalProject("embark-framework/embark#develop");
+        assert.strictEqual(result.url, "https://github.com/embark-framework/embark/archive/develop.zip");
+        assert.strictEqual(result.filePath.replace(/\\/g,'/'), ".embark/templates/embark-framework/embark/develop/archive.zip");
       });
 
       it('return correct zip filename with just embark template specified', function () {
@@ -47,7 +65,6 @@ describe('TemplateGenerator', function () {
         assert.strictEqual(result.url, "https://github.com/embark-framework/embark-react-template/archive/master.zip");
         assert.strictEqual(result.filePath.replace(/\\/g,'/'), ".embark/templates/embark-framework/embark-react-template/archive.zip");
       });
-
     });
 
   });


### PR DESCRIPTION
This change will also:
* upgrade calls from HTTP to HTTPS
* update / add some tests
See: #765

## Overview
With these changes I wanted to make the following referenecs work for generating a project from a template:
* git@github.com/status-im/dappcon-workshop-dapp#start-here
* git@github.com/status-im/dappcon-workshop-dapp
* http://www.github.com/status-im/dappcon-workshop-dapp
* https://www.github.com/status-im/dappcon-workshop-dapp
* github.com/status-im/dappcon-workshop-dapp#start-here
* http(s)://github.com/status-im/dappcon-workshop-dapp/tree/start-here
* embark-framework/embark

The relevant changes are inside template_generator.js, sadly I couldn't re-use the branch detection of the contract download since it seems that this here would need some special expections from the rule.
### Questions
Since I am not that familiar with the codebase have please a very DETAILED look at the tests I modified. After merging this PR the generator will always use HTTPS (even if specifying HTTP) for downloading templates. Also the path being returned will reflect the branch from which it was created.
The point with the folder representing the branch is something where I couldn't really see whether this would cause any issue.


### Review
Looking forward to all your replies / feedback.
