### PR TITLE
Avoid Solc to die because of compilation

### DIFF
--- a/lib/core/processes/processWrapper.js
+++ b/lib/core/processes/processWrapper.js
@@ -12,13 +12,14 @@ class ProcessWrapper {
    * Manages the log interception so that all console.* get sent back to the parent process
    * Also creates an Events instance. To use it, just do `this.events.[on|request]`
    *
-   * @param {Options}     _options    Nothing for now
+   * @param {Options}     options    pingParent: true by default
    */
-  constructor(_options) {
+  constructor(options = {pingParent: true}) {
     this.interceptLogs();
     this.events = new Events();
-
-    this.pingParent();
+    if(options.pingParent) {
+      this.pingParent();
+    }
   }
 
   // Ping parent to see if it is still alive. Otherwise, let's die

--- a/lib/modules/solidity/solcP.js
+++ b/lib/modules/solidity/solcP.js
@@ -10,7 +10,7 @@ const NpmTimer = require('../library_manager/npmTimer');
 class SolcProcess extends ProcessWrapper {
 
   constructor(options){
-    super();
+    super({pingParent: false});
     this._logger = options.logger;
     this._showSpinner = options.showSpinner === true;
   }


### PR DESCRIPTION
## Overview
**TL;DR**
Do not let solc process die because the process is compiling.

Debug:
```
!!!!!!!!!!!!!!!! Compiling
############################################
Checking Parent /home/anthony/code/embark-framework/embark/lib/modules/ipfs/process.js
ping /home/anthony/code/embark-framework/embark/lib/modules/ipfs/process.js
/home/anthony/code/embark-framework/embark/lib/modules/ipfs/process.js pong trueconnected: true
End Checking Parent /home/anthony/code/embark-framework/embark/lib/modules/ipfs/process.js
############################################
############################################
Checking Parent /home/anthony/code/embark-framework/embark/lib/modules/blockchain_process/blockchainProcess.js
ping /home/anthony/code/embark-framework/embark/lib/modules/blockchain_process/blockchainProcess.js
/home/anthony/code/embark-framework/embark/lib/modules/blockchain_process/blockchainProcess.js pong trueconnected: true
End Checking Parent /home/anthony/code/embark-framework/embark/lib/modules/blockchain_process/blockchainProcess.js
############################################
############################################
Checking Parent /home/anthony/code/embark-framework/embark/lib/modules/ipfs/process.js
ping /home/anthony/code/embark-framework/embark/lib/modules/ipfs/process.js
/home/anthony/code/embark-framework/embark/lib/modules/ipfs/process.js pong trueconnected: true
End Checking Parent /home/anthony/code/embark-framework/embark/lib/modules/ipfs/process.js
############################################
############################################
Checking Parent /home/anthony/code/embark-framework/embark/lib/modules/blockchain_process/blockchainProcess.js
ping /home/anthony/code/embark-framework/embark/lib/modules/blockchain_process/blockchainProcess.js
/home/anthony/code/embark-framework/embark/lib/modules/blockchain_process/blockchainProcess.js pong trueconnected: true
End Checking Parent /home/anthony/code/embark-framework/embark/lib/modules/blockchain_process/blockchainProcess.js
############################################
!!!!!!!!!!!!!!!! End Compiling
############################################
Checking Parent /home/anthony/code/embark-framework/embark/lib/modules/solidity/solcP.js
ping /home/anthony/code/embark-framework/embark/lib/modules/solidity/solcP.js
error
true // connected
false // result
/home/anthony/code/embark-framework/embark/lib/modules/solidity/solcP.js
2
############################################
```
Observation: 
- blockchain and ipfs process are checked twice while solp process isn't check while compiling.
- Event if the process is connected the `send` return false, I assume because solcp process is too busy compiling.

Fix:
The solcp process doesn't start any external process like ipfs and geth. so as soon as the main process die, he will die immediately too. (there is no kill override in solcp)
Is it correct to assume that the solcp process doesn't need to play Ping-Pong with the parent?
@iurimatias @jrainville 

If that is not possible, I could also increase the number of retrie/the interval but if there is a lot to compile, this error will come back.
