### PR TITLE
getWeb3Location should use require.resolve()

### DIFF
--- a/lib/modules/blockchain_process/simulator.js
+++ b/lib/modules/blockchain_process/simulator.js
@@ -5,6 +5,7 @@ let proxy = require('./proxy');
 const Ipc = require('../../core/ipc');
 const constants = require('../../constants.json');
 const {defaultHost, dockerHostSwap} = require('../../utils/host');
+const fs = require('../../core/fs.js');
 
 class Simulator {
   constructor(options) {
@@ -15,7 +16,7 @@ class Simulator {
   run(options) {
     let cmds = [];
 
-    const ganache_main = require.resolve('ganache-cli');
+    const ganache_main = require.resolve('ganache-cli', {paths: fs.embarkPath('node_modules')});
     const ganache_json = pkgUp.sync(path.dirname(ganache_main));
     const ganache_root = path.dirname(ganache_json);
     const ganache_bin = require(ganache_json).bin;

--- a/lib/modules/code_generator/index.js
+++ b/lib/modules/code_generator/index.js
@@ -289,7 +289,7 @@ class CodeGenerator {
       function getWeb3Location(next) {
         self.events.request("version:get:web3", function(web3Version) {
           if (web3Version === "1.0.0-beta") {
-            return next(null, fs.embarkPath("node_modules/web3"));
+            return next(null, require.resolve("web3"));
           }
           self.events.request("version:getPackageLocation", "web3", web3Version, function(err, location) {
             return next(null, fs.dappPath(location));
@@ -350,7 +350,7 @@ class CodeGenerator {
       function getWeb3Location(next) {
         self.events.request("version:get:web3", function(web3Version) {
           if (web3Version === "1.0.0-beta") {
-            return next(null, utils.joinPath(fs.embarkPath("node_modules/web3")));
+            return next(null, require.resolve("web3"));
           }
           self.events.request("version:getPackageLocation", "web3", web3Version, function(err, location) {
             return next(null, fs.dappPath(location));

--- a/lib/modules/code_generator/index.js
+++ b/lib/modules/code_generator/index.js
@@ -289,7 +289,7 @@ class CodeGenerator {
       function getWeb3Location(next) {
         self.events.request("version:get:web3", function(web3Version) {
           if (web3Version === "1.0.0-beta") {
-            return next(null, require.resolve("web3"));
+            return next(null, require.resolve("web3", {paths: fs.embarkPath("node_modules")}));
           }
           self.events.request("version:getPackageLocation", "web3", web3Version, function(err, location) {
             return next(null, fs.dappPath(location));
@@ -350,7 +350,7 @@ class CodeGenerator {
       function getWeb3Location(next) {
         self.events.request("version:get:web3", function(web3Version) {
           if (web3Version === "1.0.0-beta") {
-            return next(null, require.resolve("web3"));
+            return next(null, require.resolve("web3", {paths: fs.embarkPath("node_modules")}));
           }
           self.events.request("version:getPackageLocation", "web3", web3Version, function(err, location) {
             return next(null, fs.dappPath(location));


### PR DESCRIPTION
## Overview

`getWeb3Location` was hard-wiring the web3 location to always be in `node_modules` within `fs.embarkPath()`. But if embark is installed locally, e.g. in dapp-bin, web3 may be a sibling dependency of embark, owing to how npm lifts non-conflicting transitive dependencies to the top-level `node_modules`. For example, in dapp-bin the web3 pkg is found in `dapp-bin/node_modules/web3` after running `npm install`.

This PR changes the lookup to use `require.resolve()`.

~~An important thing to consider is that with this change, if a dapp has installed web3 as a dev/dep, that web3 will always be resolved instead of embark's own web3.~~