### PR TITLE
Add `dev_funds` doco to templates

### DIFF
--- a/templates/boilerplate/config/blockchain.js
+++ b/templates/boilerplate/config/blockchain.js
@@ -26,7 +26,12 @@ module.exports = {
     proxy: true, // Proxy is used to present meaningful information about transactions
     targetGasLimit: 8000000, // Target gas limit sets the artificial target gas floor for the blocks to mine
     simulatorMnemonic: "example exile argue silk regular smile grass bomb merge arm assist farm", // Mnemonic  used by the simulator to generate a wallet
-    simulatorBlocktime: 0 // Specify blockTime in seconds for automatic mining. Default is 0 and no auto-mining.
+    simulatorBlocktime: 0, // Specify blockTime in seconds for automatic mining. Default is 0 and no auto-mining.
+    account: {
+      // numAccounts: 3, // When specified, creates accounts for use in the dapp. This option only works in the development environment, and can be used as a quick start option that bypasses the need for MetaMask in development. These accounts are unlocked and funded with the below settings.
+      // password: "config/development/password", // Password for the created accounts (as specified in the `numAccounts` setting)
+      // balance: "5 ether" // Balance to be given to the created accounts (as specified in the `numAccounts` setting)
+    }
   },
 
   // merges with the settings in default

--- a/templates/demo/config/blockchain.js
+++ b/templates/demo/config/blockchain.js
@@ -26,7 +26,12 @@ module.exports = {
     proxy: true, // Proxy is used to present meaningful information about transactions
     targetGasLimit: 8000000, // Target gas limit sets the artificial target gas floor for the blocks to mine
     simulatorMnemonic: "example exile argue silk regular smile grass bomb merge arm assist farm", // Mnemonic  used by the simulator to generate a wallet
-    simulatorBlocktime: 0 // Specify blockTime in seconds for automatic mining. Default is 0 and no auto-mining.
+    simulatorBlocktime: 0, // Specify blockTime in seconds for automatic mining. Default is 0 and no auto-mining.
+    account: {
+      // numAccounts: 3, // When specified, creates accounts for use in the dapp. This option only works in the development environment, and can be used as a quick start option that bypasses the need for MetaMask in development. These accounts are unlocked and funded with the below settings.
+      // password: "config/development/password", // Password for the created accounts (as specified in the `numAccounts` setting)
+      // balance: "5 ether" // Balance to be given to the created accounts (as specified in the `numAccounts` setting)
+    }
   },
 
   // merges with the settings in default


### PR DESCRIPTION
## Overview
**TL;DR**
Added documentation for the dev_funds work that made it's way in to 3.1.x and now 3.2 in to the config files generated for the demo and the simple apps.