### PR TITLE
Use trace logger for code runner error

### DIFF
--- a/lib/core/modules/coderunner/codeRunner.js
+++ b/lib/core/modules/coderunner/codeRunner.js
@@ -8,7 +8,7 @@ class CodeRunner {
     this.events = options.events;
     this.ipc = options.ipc;
     this.commands = [];
-    this.runCode = new RunCode();
+    this.runCode = new RunCode({logger: this.logger});
     this.registerIpcEvents();
     this.IpcClientListen();
     this.registerEvents();

--- a/lib/core/modules/coderunner/runCode.js
+++ b/lib/core/modules/coderunner/runCode.js
@@ -1,7 +1,8 @@
 const vm = require('vm');
 
 class RunCode {
-  constructor() {
+  constructor({logger}) {
+    this.logger = logger;
     this.context = Object.assign({}, {global, console, exports, require, module, __filename, __dirname});
   }
 
@@ -9,7 +10,7 @@ class RunCode {
     try {
       return vm.runInNewContext(code, this.context);
     } catch(e) {
-      console.error(e.message);
+      this.logger.trace(e.message);
     }
   }
 


### PR DESCRIPTION
## Overview

Instead of using console.error when an error is happening, use the logger with a trace level