### PR TITLE
Avoid multiple connect to IPC

### DIFF
--- a/lib/tests/test.js
+++ b/lib/tests/test.js
@@ -144,24 +144,25 @@ class Test {
         self.engine.startService("codeCoverage");
 
         if (self.options.node === 'embark') {
-          return self.engine.ipc.connect((err) => {
-            if (err) {
-              this.engine.logger.error(err.message || err);
-              this.engine.logger.error("Could not connect to Embark's IPC. Is embark running?");
-              process.exit(1);
-            }
-            self.engine.ipc.request('blockchain:node', {}, (err, node) => {
-              if (err) {
-                return self.engine.logger.error(err.message || err);
-              }
-              self.options.node = node;
-              cb();
-            });
-          });
+          if (!self.engine.ipc.connected) {
+            self.engine.logger.error("Could not connect to Embark's IPC. Is embark running?");
+            process.exit(1);
+          }
+          return self.connectToIpcNode(cb);
         }
         cb();
       }
     ], callback);
+  }
+
+  connectToIpcNode(cb) {
+    this.engine.ipc.request('blockchain:node', {}, (err, node) => {
+      if (err) {
+        return this.engine.logger.error(err.message || err);
+      }
+      this.options.node = node;
+      cb();
+    });
   }
 
   onReady(callback) {

--- a/lib/tests/test.js
+++ b/lib/tests/test.js
@@ -158,7 +158,8 @@ class Test {
   connectToIpcNode(cb) {
     this.engine.ipc.request('blockchain:node', {}, (err, node) => {
       if (err) {
-        return this.engine.logger.error(err.message || err);
+        this.engine.logger.error(err.message || err);
+        return cb();
       }
       this.options.node = node;
       cb();


### PR DESCRIPTION
## Overview
**TL;DR**

Since the connection is made when possible in `engine.init()` which is called before. There is no need to call connect again.
Also calling connect again makes the process totally stop waiting for something.