### PR TITLE
Fix embark test using node option

### DIFF
--- a/test_apps/test_app/test/simple_storage_deploy_spec.js
+++ b/test_apps/test_app/test/simple_storage_deploy_spec.js
@@ -1,22 +1,34 @@
-/*global contract, it, embark, assert, before*/
+/*global contract, it, embark, assert, before, web3*/
 const SimpleStorage = embark.require('Embark/contracts/SimpleStorage');
+const Utils = require('embarkjs').Utils;
 
 contract("SimpleStorage Deploy", function () {
-  let SimpleStorageInstance;
-
-  before(async function() {
-    SimpleStorageInstance = await SimpleStorage.deploy({arguments: [150]}).send();
+  let simpleStorageInstance;
+  before(function(done) {
+    Utils.secureSend(web3, SimpleStorage.deploy({arguments: [150]}), {}, true, function(err, receipt) {
+      if(err) {
+        return done(err);
+      }
+      simpleStorageInstance = SimpleStorage;
+      simpleStorageInstance.options.address = receipt.contractAddress;
+      done();
+    });
   });
 
   it("should set constructor value", async function () {
-    let result = await SimpleStorageInstance.methods.storedData().call();
+    let result = await simpleStorageInstance.methods.storedData().call();
     assert.strictEqual(parseInt(result, 10), 150);
   });
 
-  it("set storage value", async function () {
-    await SimpleStorageInstance.methods.set(150).send();
-    let result = await SimpleStorageInstance.methods.get().call();
-    assert.strictEqual(parseInt(result, 10), 150);
+  it("set storage value", function (done) {
+    Utils.secureSend(web3, simpleStorageInstance.methods.set(200), {}, false, async function(err) {
+      if (err) {
+        return done(err);
+      }
+      let result = await simpleStorageInstance.methods.get().call();
+      assert.strictEqual(parseInt(result, 10), 200);
+      done();
+    });
   });
 
 });


### PR DESCRIPTION
## Overview
**TL;DR**
For Simple Storage:
The issues is the problem with ws, if I switch the contract deployment to http, it works fine.
For ENS:
once again the problem is ws, the promise is never resolve so the code runner wait for it indefinitely
At the same time I feel that the ens test is useless because it actually test that on deploy is working
and I don't think it is the intent

Maybe what we should do is: display a warning when deploying contract with ws and change our test to use http.