### PR TITLE
Add call coverage to pure functions

### DIFF
--- a/lib/modules/blockchain_connector/provider.js
+++ b/lib/modules/blockchain_connector/provider.js
@@ -28,6 +28,7 @@ class Provider {
 
     self.web3.setProvider(self.provider);
 
+    console.dir("hello world")
     self.accounts = AccountParser.parseAccountsConfig(self.accountsConfig, self.web3, self.logger);
     self.addresses = [];
 
@@ -49,6 +50,10 @@ class Provider {
           result.result = result.result.concat(self.addresses);
           cb(null, result);
         });
+      }
+      if (payload.method === 'eth_call') {
+        console.dir("payload: ")
+        console.dir(payload)
       }
       realSend(payload, cb);
     };

--- a/lib/modules/blockchain_connector/provider.js
+++ b/lib/modules/blockchain_connector/provider.js
@@ -28,7 +28,6 @@ class Provider {
 
     self.web3.setProvider(self.provider);
 
-    console.dir("hello world")
     self.accounts = AccountParser.parseAccountsConfig(self.accountsConfig, self.web3, self.logger);
     self.addresses = [];
 
@@ -50,10 +49,6 @@ class Provider {
           result.result = result.result.concat(self.addresses);
           cb(null, result);
         });
-      }
-      if (payload.method === 'eth_call') {
-        console.dir("payload: ")
-        console.dir(payload)
       }
       realSend(payload, cb);
     };

--- a/lib/tests/test.js
+++ b/lib/tests/test.js
@@ -112,28 +112,26 @@ class Test {
     // 3) Once we get the receipt back, we dispatch the real call and pass the original callback;
     //
     // This will still allow tests to get the return value from the call and run contracts unmodified.
-    simProvider.realSendAsync = simProvider.sendAsync;
+    simProvider.realSendAsync = simProvider.sendAsync.bind(simProvider);
     simProvider.sendAsync = function(payload, cb) {
       if(payload.method !== 'eth_call') {
-        return simProvider.realSendAsync.apply(simProvider.realSendAsync, [payload, cb]);
+        return simProvider.realSendAsync(payload, cb);
       }
 
       let newParams = Object.assign({}, payload.params[0], {gasPrice: '0x77359400'});
       let newPayload = {
-          id: parseInt(Math.random(1000000) * 1000000, 10),
+          id: payload.id + 1,
           method: 'eth_sendTransaction',
           params: [newParams],
           jsonrpc: payload.jsonrpc
       };
 
-      let txCallback = (_err, response) => {
+      simProvider.realSendAsync(newPayload, (_err, response) => {
         let txHash = response.result;
         self.web3.eth.getTransactionReceipt(txHash, (_err, _res) => {
-          simProvider.realSendAsync.apply(simProvider.realSendAsync, [payload, cb]);
+          simProvider.realSendAsync(payload, cb);
         });
-      };
-
-      simProvider.realSendAsync.apply(simProvider.realSendAsync, [newPayload, txCallback]);
+      });
     };
 
     this.web3.setProvider(simProvider);

--- a/lib/tests/test.js
+++ b/lib/tests/test.js
@@ -10,38 +10,6 @@ const utils = require('../utils/utils');
 
 const EmbarkJS = require('embarkjs');
 
-class ProxyProvider extends Web3.providers.WebsocketProvider {
-
-  constructor(realProvider) {
-    super(realProvider)
-    this.realProvider = realProvider
-  }
-
-  sendAsync(payload, callback) {
-    console.log('payload method is ', payload.method)
-
-    // if (payload.method === 'eth_call') {
-    //   this.realProvider.sendAsync({id: 123456, method: 'eth_sendTransaction', params: payload.params, jsonrpc: payload.jsonrpc}, () => {
-    //     console.log("===== eth_call duplicated as a tx")
-    //     console.dir(arguments)
-    //   })
-    // }
-
-    return this.realProvider.sendAsync(payload, callback)
-    // let method = this.methods[payload.method]
-    // if (method) {
-    //   return method.call(method, payload, (err, result) => {
-    //     if (err) {
-    //       return callback(err)
-    //     }
-    //     let response = {'id': payload.id, 'jsonrpc': '2.0', 'result': result}
-    //     callback(null, response)
-    //   })
-    // }
-    // callback(new Error('unknown method ' + payload.method))
-  }
-}
-
 function getSimulator() {
   try {
     return require('ganache-cli');
@@ -132,40 +100,40 @@ class Test {
       this.sim = getSimulator();
     }
 
-    console.dir("-----> tests")
+    let simProvider = this.sim.provider(this.simOptions);
 
-    //let proxyProvider = new ProxyProvider(this.sim.provider(this.simOptions))
-    //this.web3.setProvider(proxyProvider);
-
-    let simProvider = this.sim.provider(this.simOptions)
-
-    simProvider.real_sendAsync = simProvider.sendAsync
-    simProvider.sendAsync = function(payload, callback) {
-
-      if (payload.method === 'eth_call') {
-        let newParams = Object.assign({}, payload.params[0], {gasPrice: '0x77359400'})
-        console.dir(newParams)
-        return simProvider.real_sendAsync.apply(simProvider.real_sendAsync, [{id: 123456 + parseInt(Math.random(100000)*100000), method: 'eth_sendTransaction', params: [newParams], jsonrpc: payload.jsonrpc}, (error, response) => {
-          console.log("===== eth_call duplicated as a tx")
-          console.dir(error)
-          console.dir(response)
-
-          let txHash = response.result;
-
-          self.web3.eth.getTransactionReceipt(txHash, (_err, res) => {
-            console.dir('------------')
-            console.dir(_err)
-            console.dir(res)
-            console.dir('------------')
-            simProvider.real_sendAsync.apply(simProvider.real_sendAsync, [payload, callback])
-          })
-
-        }])
-      } else if (payload.method === 'eth_sendTransaction') {
-        console.log("=== eth_sendTransaction");
-        console.dir(payload);
+    // Here we patch the sendAsync method on the provider. The goal behind this is to force pure/constant/view calls to become
+    // transactions, so that we can pull in execution traces and account for those executions in code coverage.
+    //
+    // Instead of a simple call, here's what happens:
+    //
+    // 1) A transaction is sent with the same payload, and a pre-defined gas price;
+    // 2) We wait for the transaction to be mined by asking for the receipt;
+    // 3) Once we get the receipt back, we dispatch the real call and pass the original callback;
+    //
+    // This will still allow tests to get the return value from the call and run contracts unmodified.
+    simProvider.realSendAsync = simProvider.sendAsync;
+    simProvider.sendAsync = function(payload, cb) {
+      if(payload.method !== 'eth_call') {
+        return simProvider.realSendAsync.apply(simProvider.realSendAsync, [payload, cb]);
       }
-      simProvider.real_sendAsync.apply(simProvider.real_sendAsync, [payload, callback])
+
+      let newParams = Object.assign({}, payload.params[0], {gasPrice: '0x77359400'});
+      let newPayload = {
+          id: parseInt(Math.random(1000000) * 1000000, 10),
+          method: 'eth_sendTransaction',
+          params: [newParams],
+          jsonrpc: payload.jsonrpc
+      };
+
+      let txCallback = (_err, response) => {
+        let txHash = response.result;
+        self.web3.eth.getTransactionReceipt(txHash, (_err, _res) => {
+          simProvider.realSendAsync.apply(simProvider.realSendAsync, [payload, cb]);
+        });
+      };
+
+      simProvider.realSendAsync.apply(simProvider.realSendAsync, [newPayload, txCallback]);
     };
 
     this.web3.setProvider(simProvider);

--- a/lib/tests/test.js
+++ b/lib/tests/test.js
@@ -10,6 +10,38 @@ const utils = require('../utils/utils');
 
 const EmbarkJS = require('embarkjs');
 
+class ProxyProvider extends Web3.providers.WebsocketProvider {
+
+  constructor(realProvider) {
+    super(realProvider)
+    this.realProvider = realProvider
+  }
+
+  sendAsync(payload, callback) {
+    console.log('payload method is ', payload.method)
+
+    // if (payload.method === 'eth_call') {
+    //   this.realProvider.sendAsync({id: 123456, method: 'eth_sendTransaction', params: payload.params, jsonrpc: payload.jsonrpc}, () => {
+    //     console.log("===== eth_call duplicated as a tx")
+    //     console.dir(arguments)
+    //   })
+    // }
+
+    return this.realProvider.sendAsync(payload, callback)
+    // let method = this.methods[payload.method]
+    // if (method) {
+    //   return method.call(method, payload, (err, result) => {
+    //     if (err) {
+    //       return callback(err)
+    //     }
+    //     let response = {'id': payload.id, 'jsonrpc': '2.0', 'result': result}
+    //     callback(null, response)
+    //   })
+    // }
+    // callback(new Error('unknown method ' + payload.method))
+  }
+}
+
 function getSimulator() {
   try {
     return require('ganache-cli');
@@ -99,7 +131,44 @@ class Test {
     if (!this.sim) {
       this.sim = getSimulator();
     }
-    this.web3.setProvider(this.sim.provider(this.simOptions));
+
+    console.dir("-----> tests")
+
+    //let proxyProvider = new ProxyProvider(this.sim.provider(this.simOptions))
+    //this.web3.setProvider(proxyProvider);
+
+    let simProvider = this.sim.provider(this.simOptions)
+
+    simProvider.real_sendAsync = simProvider.sendAsync
+    simProvider.sendAsync = function(payload, callback) {
+
+      if (payload.method === 'eth_call') {
+        let newParams = Object.assign({}, payload.params[0], {gasPrice: '0x77359400'})
+        console.dir(newParams)
+        return simProvider.real_sendAsync.apply(simProvider.real_sendAsync, [{id: 123456 + parseInt(Math.random(100000)*100000), method: 'eth_sendTransaction', params: [newParams], jsonrpc: payload.jsonrpc}, (error, response) => {
+          console.log("===== eth_call duplicated as a tx")
+          console.dir(error)
+          console.dir(response)
+
+          let txHash = response.result;
+
+          self.web3.eth.getTransactionReceipt(txHash, (_err, res) => {
+            console.dir('------------')
+            console.dir(_err)
+            console.dir(res)
+            console.dir('------------')
+            simProvider.real_sendAsync.apply(simProvider.real_sendAsync, [payload, callback])
+          })
+
+        }])
+      } else if (payload.method === 'eth_sendTransaction') {
+        console.log("=== eth_sendTransaction");
+        console.dir(payload);
+      }
+      simProvider.real_sendAsync.apply(simProvider.real_sendAsync, [payload, callback])
+    };
+
+    this.web3.setProvider(simProvider);
     callback();
   }
 


### PR DESCRIPTION
This PR adds code coverage to pure functions.

It does this by patching the simulator provider and, when getting a pure call, forcing a transaction through first, waiting for it to be mined, and only then will it send the call.

Because pure calls should be idempotent, no side effects are expected.

Co-Authored with @iurimatias and @jrainville 