### PR TITLE
template download error

### DIFF
--- a/lib/utils/template_generator.js
+++ b/lib/utils/template_generator.js
@@ -22,7 +22,11 @@ class TemplateGenerator {
     console.log(__('Installing Template from ' + uri + '....').green);
 
     fs.mkdirpSync(utils.dirname(tmpFilePath));
-    utils.downloadFile(url, tmpFilePath, () => {
+    utils.downloadFile(url, tmpFilePath, (err) => {
+      if (err) {
+        console.error(err.red);
+        process.exit(1);
+      }
       utils.extractZip(tmpFilePath, fspath, {
         map: file => {
           let fixed_path = file.path.split('/');

--- a/lib/utils/template_generator.js
+++ b/lib/utils/template_generator.js
@@ -25,6 +25,8 @@ class TemplateGenerator {
     utils.downloadFile(url, tmpFilePath, (err) => {
       if (err) {
         console.error(err.red);
+        console.error('Does the template really exist?'.red);
+        console.error(`Embark's supported templates: https://embark.status.im/templates/`.green);
         process.exit(1);
       }
       utils.extractZip(tmpFilePath, fspath, {

--- a/lib/utils/utils.js
+++ b/lib/utils/utils.js
@@ -161,7 +161,7 @@ function downloadFile(url, dest, cb) {
   var file = o_fs.createWriteStream(dest);
   (url.substring(0, 5) === 'https' ? https : http).get(url, function (response) {
     if (response.statusCode !== 200) {
-      if (cb) cb(`Download failed, response code ${response.statusCode}`);
+      cb(`Download failed, response code ${response.statusCode}`);
       return;
     }
     response.pipe(file);
@@ -170,7 +170,7 @@ function downloadFile(url, dest, cb) {
     });
   }).on('error', function (err) {
     o_fs.unlink(dest);
-    if (cb) cb(err.message);
+    cb(err.message);
   });
 }
 

--- a/lib/utils/utils.js
+++ b/lib/utils/utils.js
@@ -162,6 +162,7 @@ function downloadFile(url, dest, cb) {
   (url.substring(0, 5) === 'https' ? https : http).get(url, function (response) {
     if (response.statusCode !== 200) {
       if (cb) cb(`Download failed, response code ${response.statusCode}`);
+      return;
     }
     response.pipe(file);
     file.on('finish', function () {

--- a/lib/utils/utils.js
+++ b/lib/utils/utils.js
@@ -160,6 +160,9 @@ function downloadFile(url, dest, cb) {
   const o_fs = require('fs-extra');
   var file = o_fs.createWriteStream(dest);
   (url.substring(0, 5) === 'https' ? https : http).get(url, function (response) {
+    if (response.statusCode !== 200) {
+      if (cb) cb(`Download failed, response code ${response.statusCode}`);
+    }
     response.pipe(file);
     file.on('finish', function () {
       file.close(cb);


### PR DESCRIPTION
## Overview

If download fails for a template specified with `embark new --template [url]`, an error should be reported and the process should exit.