### PR TITLE
eject-webpack cmd should report error and exit if run outside DApp

### DIFF
--- a/cmd/cmd.js
+++ b/cmd/cmd.js
@@ -316,6 +316,10 @@ class Cmd {
       .command('eject-webpack')
       .description(__('copy the default webpack config into your dapp for customization'))
       .action(function() {
+        embark.initConfig('development', {
+          embarkConfig: 'embark.json',
+          interceptLogs: false
+        });
         embark.ejectWebpack();
       });
   }


### PR DESCRIPTION
## Overview

If `embark eject-webpack` is run outside of a DApp, it should print an error and exit.