### PR TITLE
Show an error message on account parameters

### DIFF
--- a/lib/modules/deployment/contract_deployer.js
+++ b/lib/modules/deployment/contract_deployer.js
@@ -38,7 +38,7 @@ class ContractDeployer {
       const match = arg.match(/\$accounts\[([0-9]+)]/);
       if (match) {
         if (!accounts[match[1]]) {
-          return cb(__('No corresponding account at index $d', match[1]));
+          return cb(__('No corresponding account at index %d', match[1]));
         }
         return cb(null, accounts[match[1]]);
       }

--- a/lib/modules/deployment/index.js
+++ b/lib/modules/deployment/index.js
@@ -75,8 +75,12 @@ class DeployManager {
         async.auto(contractDeploys, function(err, _results) {
           if (err) {
             self.logger.error(__("error deploying contracts"));
-            self.logger.error(err.message);
-            self.logger.debug(err.stack);
+            if(err.message !== undefined) {
+              self.logger.error(err.message);
+              self.logger.debug(err.stack);
+            } else {
+              self.logger.error(err);
+            }
           }
           if (contracts.length === 0) {
             self.logger.info(__("no contracts found"));


### PR DESCRIPTION
## Overview
**TL;DR**
When specifying `$accounts[x]` where `x` is a non-existent index, the error shown was unclear. Now it shows the error that occurred.

### Cool Spaceship Picture
![FWC Ship](https://vignette.wikia.nocookie.net/destinypedia/images/8/8c/%22The_Road_Unraveled%22.png/revision/latest?cb=20180320200942)