### PR TITLE
Don't stop everything on contract deploy fail

### DIFF
--- a/lib/modules/deployment/index.js
+++ b/lib/modules/deployment/index.js
@@ -62,6 +62,7 @@ class DeployManager {
             self.events.request('deploy:contract', contract, (err) => {
               if (err) {
                 contract.error = err.message || err;
+                self.logger.error(err.message || err);
                 errors.push(err);
               }
               callback();
@@ -80,10 +81,9 @@ class DeployManager {
         try {
           async.auto(contractDeploys, function(_err, _results) {
             if (errors.length) {
-              self.logger.error(__("error deploying contracts"));
-              errors.forEach(error => {
-                self.logger.error(error.message || error);
-              });
+              _err = __("Error deploying contracts. Please fix errors to continue.");
+              self.logger.error(_err);
+              return done(_err);
             }
             if (contracts.length === 0) {
               self.logger.info(__("no contracts found"));

--- a/lib/modules/deployment/index.js
+++ b/lib/modules/deployment/index.js
@@ -52,6 +52,7 @@ class DeployManager {
         self.events.emit("deploy:beforeAll");
 
         const contractDeploys = {};
+        const errors = [];
         contracts.forEach(contract => {
           function deploy(result, callback) {
             if (typeof result === 'function') {
@@ -59,7 +60,11 @@ class DeployManager {
             }
             contract._gasLimit = self.gasLimit;
             self.events.request('deploy:contract', contract, (err) => {
-              callback(err);
+              if (err) {
+                contract.error = err.message || err;
+                errors.push(err);
+              }
+              callback();
             });
           }
 
@@ -72,23 +77,25 @@ class DeployManager {
           contractDeploys[className].push(deploy);
         });
 
-        async.auto(contractDeploys, function(err, _results) {
-          if (err) {
-            self.logger.error(__("error deploying contracts"));
-            if(err.message !== undefined) {
-              self.logger.error(err.message);
-              self.logger.debug(err.stack);
-            } else {
-              self.logger.error(err);
+        try {
+          async.auto(contractDeploys, function(_err, _results) {
+            if (errors.length) {
+              self.logger.error(__("error deploying contracts"));
+              errors.forEach(error => {
+                self.logger.error(error.message || error);
+              });
             }
-          }
-          if (contracts.length === 0) {
-            self.logger.info(__("no contracts found"));
-            return done();
-          }
-          self.logger.info(__("finished deploying contracts"));
-          done(err);
-        });
+            if (contracts.length === 0) {
+              self.logger.info(__("no contracts found"));
+              return done();
+            }
+            self.logger.info(__("finished deploying contracts"));
+            done(err);
+          });
+        } catch (e) {
+          self.logger.error(e.message || e);
+          done(__('Error deploying'));
+        }
       });
     });
   }


### PR DESCRIPTION
Originally meant to fix: "if there is an error deploying contracts, status stays pending"

But ended up changing the behavior a bit. Before, as soon as one contract deploy failed, it would stop everything. That's why they stayed "pending". 

Now, every contract deploy will have its chance, but it will still stop before the pipeline if there is an error.