### PR TITLE
`embark test —node` help, plus fix for vm option

### DIFF
--- a/cmd/cmd.js
+++ b/cmd/cmd.js
@@ -262,23 +262,19 @@ class Cmd {
   }
 
   test() {
+    const urlRegexExp = /^(vm|embark|((ws|https?):\/\/([a-zA-Z0-9_.-]*):?([0-9]*)?))$/i;
     program
       .command('test [file]')
       .option('-n , --node <node>', __('Node to connect to. Valid values are ["vm", "embark", "<custom node endpoint>"]: \n') + 
               '                       vm - ' + __('Starts an Ethereum simulator (ganache) and runs the tests using the simulator') + '\n' +
               '                       embark - ' + __('Uses the node associated with an already running embark process') + '\n' + 
               '                       ' + __('<custom node endpoint> - Connects to a running node available at the end point and uses it to run the tests'), 
-              /^(vm|embark|((ws|https?):\/\/([a-zA-Z0-9_.-]*):?([0-9]*)?))$/i, null)
+              urlRegexExp, 'vm')
       .option('-d , --gasDetails', __('When set, will print the gas cost for each contract deploy'))
       .option('--locale [locale]', __('language to use (default: en)'))
       .option('--loglevel [loglevel]', __('level of logging to display') + ' ["error", "warn", "info", "debug", "trace"]', /^(error|warn|info|debug|trace)$/i, 'warn')
       .description(__('run tests'))
       .action(function(file, options) {
-        if(options.node === null){
-          console.log(__('Invalid value for option --node. Valid values are ["vm", "embark", "<custom node endpoint>"]".').red);
-          console.log(options.optionHelp());
-          process.exit(1);
-        }
         checkDeps();
         i18n.setOrDetectLocale(options.locale);
         embark.runTests({file, loglevel: options.loglevel, gasDetails: options.gasDetails, node: options.node});

--- a/cmd/cmd.js
+++ b/cmd/cmd.js
@@ -264,12 +264,21 @@ class Cmd {
   test() {
     program
       .command('test [file]')
-      .option('-n , --node [node]', __('Node to connect to (default: vm)'))
+      .option('-n , --node <node>', __('Node to connect to. Valid values are ["vm", "embark", "<custom node endpoint>"]: \n') + 
+              '                       vm - ' + __('Starts an Ethereum simulator (ganache) and runs the tests using the simulator') + '\n' +
+              '                       embark - ' + __('Uses the node associated with an already running embark process') + '\n' + 
+              '                       ' + __('<custom node endpoint> - Connects to a running node available at the end point and uses it to run the tests'), 
+              /^(vm|embark|((ws|https?):\/\/([a-zA-Z0-9_.-]*):?([0-9]*)?))$/i, null)
       .option('-d , --gasDetails', __('When set, will print the gas cost for each contract deploy'))
       .option('--locale [locale]', __('language to use (default: en)'))
       .option('--loglevel [loglevel]', __('level of logging to display') + ' ["error", "warn", "info", "debug", "trace"]', /^(error|warn|info|debug|trace)$/i, 'warn')
       .description(__('run tests'))
       .action(function(file, options) {
+        if(options.node === null){
+          console.log(__('Invalid value for option --node. Valid values are ["vm", "embark", "<custom node endpoint>"]".').red);
+          console.log(options.optionHelp());
+          process.exit(1);
+        }
         checkDeps();
         i18n.setOrDetectLocale(options.locale);
         embark.runTests({file, loglevel: options.loglevel, gasDetails: options.gasDetails, node: options.node});

--- a/lib/tests/test.js
+++ b/lib/tests/test.js
@@ -58,7 +58,7 @@ class Test {
       });
     }
 
-    if (this.simOptions.host || this.options.node) {
+    if (this.simOptions.host || (this.options.node && this.options.node !== 'vm')) {
       let options = this.simOptions;
       if (this.options.node) {
         options = utils.deconstructUrl(this.options.node);


### PR DESCRIPTION
## Overview
**TL;DR**
Add better help info for `embark test —node`.

Fixed issue with `embark test —node vm` where the `vm` was attempted to be parsed as a URL instead of running the simulator.

### Cool Spaceship Picture
![Cool Spaceship Picture](https://img00.deviantart.net/6a33/i/2010/301/a/5/spaceship___pheasant_peacock_by_b_freak_xd-d31nw0r.jpg)


