### PR TITLE
Prepend "embark-" to plugin names and little fixes

### DIFF
--- a/cmd/dashboard/monitor.js
+++ b/cmd/dashboard/monitor.js
@@ -369,7 +369,9 @@ class Monitor {
     this.logText.log('console> '.bold.green + cmd);
     this.events.request('console:executeCmd', cmd, (err, result) => {
       let message = err || result;
-      this.logText.log(message);
+      if (message) {
+        this.logText.log(message);
+      }
       if (cb) {
         cb(message);
       }

--- a/cmd/dashboard/repl.js
+++ b/cmd/dashboard/repl.js
@@ -1,21 +1,23 @@
 const repl = require("repl");
 const util = require("util");
+
 class REPL {
   constructor(options) {
     this.events = options.events;
-    this.env = options.env
+    this.env = options.env;
   }
 
   enhancedEval(cmd, context, filename, callback) {
-    this.events.request('console:executeCmd', cmd.trim(), callback);
+    this.events.request('console:executeCmd', cmd.trim(), function (err, message) {
+      callback(err, message || ''); // This way, we don't print undefined
+    });
   }
 
   enhancedWriter(output) {
     if ((typeof output) === "string") {
       return output;
-    } else {
-      return util.inspect(output, {colors: true});
     }
+    return util.inspect(output, {colors: true});
   }
 
   start(done) {
@@ -36,7 +38,6 @@ class REPL {
 
     done();
   }
-
 }
 
 module.exports = REPL;

--- a/lib/modules/plugin_cmd/index.js
+++ b/lib/modules/plugin_cmd/index.js
@@ -1,6 +1,7 @@
-let fs = require('./../../core/fs.js');
-let utils = require('./../../utils/utils.js');
-let async = require('async');
+const fs = require('./../../core/fs.js');
+const utils = require('./../../utils/utils.js');
+const async = require('async');
+
 class PluginCommand {
   constructor(embark) {
     this.embark = embark;
@@ -8,49 +9,53 @@ class PluginCommand {
     this.embarkConfig = this.config.embarkConfig;
     this.registerCommand();
   }
+
   registerCommand() {
-    const self = this;
-    self.embark.registerConsoleCommand((cmd, _options) => {
+    this.embark.registerConsoleCommand((cmd, _options) => {
       let cmdArray = cmd.split(' ');
       cmdArray = cmdArray.filter(cmd => cmd.trim().length > 0);
       let cmdName = cmdArray[0];
       return {
-        match: () =>  cmdName === 'plugin',
-        process: (callback) => {
-          if(cmdArray.length < 3 || cmdArray[1] !== 'install' || typeof cmdArray[2] === 'undefined') {
-            return callback('invalid use of plugin command. Please use plugin install <package>');
-          }
-          let npmInstall = ['npm', 'install', '--save'];
-          npmInstall = npmInstall.concat(cmdArray.slice(2));
-          let npmPackage = npmInstall[3];
-          self.embark.logger.info(`Installing npm package ${npmPackage} ...`);
-          async.waterfall([
-            function npmInstallAsync(cb) {
-              utils.runCmd(npmInstall.join(' '), {silent: false, exitOnError: false}, (err) => {
-                if(err) {
-                  return cb(err);
-                }
-                cb();
-              });
-            },
-            function addToEmbarkConfig(cb) {
-              // get the installed package from package.json
-              let packageFile = fs.readJSONSync(self.config.packageFile);
-              let dependencies = Object.keys(packageFile.dependencies);
-              let installedPackage = dependencies.filter((dep) => npmPackage.indexOf(dep) >=0);
-              self.embarkConfig.plugins[installedPackage[0]] = {};
-              fs.writeFile(self.config.embarkConfigFile, JSON.stringify(self.embarkConfig, null, 2), cb);
-            }
-          ], (err) => {
-            if(err) {
-              let errorMessage = `Error installing npm package ${npmPackage}. Please visit https://embark.status.im/plugins/ for all supported plugins`;
-              self.embark.logger.error(errorMessage);
-              return callback('Error occurred');
-            }
-            callback(null, `npm package ${npmPackage} successfully installed as a plugin`);
-          });
-        }
+        match: () => cmdName === 'plugin',
+        process: this.installPlugin.bind(this, cmdArray)
       };
+    });
+  }
+
+  installPlugin(cmdArray, callback) {
+    const self = this;
+
+    if (cmdArray.length < 3 || cmdArray[1] !== 'install' || typeof cmdArray[2] === 'undefined') {
+      return callback(__('Invalid use of plugin command. Please use `plugin install <package>`'));
+    }
+    let npmInstall = ['npm', 'install', '--save'];
+    npmInstall = npmInstall.concat(cmdArray.slice(2));
+    let npmPackage = npmInstall[3];
+    self.embark.logger.info(__('Installing npm package %s...', npmPackage));
+    async.waterfall([
+      function npmInstallAsync(cb) {
+        utils.runCmd(npmInstall.join(' '), {silent: false, exitOnError: false}, (err) => {
+          if (err) {
+            return cb(err);
+          }
+          cb();
+        });
+      },
+      function addToEmbarkConfig(cb) {
+        // get the installed package from package.json
+        let packageFile = fs.readJSONSync(self.config.packageFile);
+        let dependencies = Object.keys(packageFile.dependencies);
+        let installedPackage = dependencies.filter((dep) => npmPackage.indexOf(dep) >= 0);
+        self.embarkConfig.plugins[installedPackage[0]] = {};
+        fs.writeFile(self.config.embarkConfigFile, JSON.stringify(self.embarkConfig, null, 2), cb);
+      }
+    ], (err) => {
+      if (err) {
+        self.embark.logger.error(__('Error installing npm package %s. Please visit ' +
+          'https://embark.status.im/plugins/ for all supported plugins', npmPackage));
+        return callback(__('Error occurred'));
+      }
+      callback(null, __('NPM package %s successfully installed as a plugin', npmPackage));
     });
   }
 }

--- a/lib/modules/plugin_cmd/index.js
+++ b/lib/modules/plugin_cmd/index.js
@@ -31,6 +31,9 @@ class PluginCommand {
     let npmInstall = ['npm', 'install', '--save'];
     npmInstall = npmInstall.concat(cmdArray.slice(2));
     let npmPackage = npmInstall[3];
+    if (!npmPackage.startsWith('embark')) {
+      npmPackage = 'embark-' + npmPackage;
+    }
     self.embark.logger.info(__('Installing npm package %s...', npmPackage));
     async.waterfall([
       function npmInstallAsync(cb) {


### PR DESCRIPTION
Now possible to do `plugin install fortune` and `plugin install embark-fortune`
I also restructured and linted a bit
Finally, fixed a simili-bug where the console would print `undefined` if the command had no result. Now, it print an empty sting.