### PR TITLE
Better manage default options

### DIFF
--- a/lib/core/processes/processWrapper.js
+++ b/lib/core/processes/processWrapper.js
@@ -14,12 +14,11 @@ class ProcessWrapper {
    *
    * @param {Options}     options    pingParent: true by default
    */
-  constructor(argOptions = {}) {
-    const defaultOptions = {pingParent: true}
-    const options = {...defaultOptions, ...argOptions};
+  constructor(options = {}) {
+    this.options = Object.assign({pingParent: true}, options);
     this.interceptLogs();
     this.events = new Events();
-    if(options.pingParent) {
+    if(this.options.pingParent) {
       this.pingParent();
     }
   }

--- a/lib/core/processes/processWrapper.js
+++ b/lib/core/processes/processWrapper.js
@@ -14,7 +14,9 @@ class ProcessWrapper {
    *
    * @param {Options}     options    pingParent: true by default
    */
-  constructor(options = {pingParent: true}) {
+  constructor(argOptions = {}) {
+    const defaultOptions = {pingParent: true}
+    const options = {...defaultOptions, ...argOptions};
     this.interceptLogs();
     this.events = new Events();
     if(options.pingParent) {


### PR DESCRIPTION
## Overview
**TL;DR**

Make sure webpackProcess.js die when parent process die by playing ping pong

Fix the merge of default options with options pass in parameters:
![screenshot at sep 14 10-18-13](https://user-images.githubusercontent.com/491074/45541638-8c202980-b807-11e8-85b9-d48d10b1fd93.png)
