### PR TITLE
Fix contracts with http import inceptions

### DIFF
--- a/lib/core/file.js
+++ b/lib/core/file.js
@@ -12,6 +12,7 @@ class File {
     this.path = options.path;
     this.basedir = options.basedir;
     this.resolver = options.resolver;
+    this.downloadedImports = false;
   }
 
   parseFileForImport(content, isHttpContract, callback) {
@@ -52,12 +53,12 @@ class File {
       // We already parsed this file
       return callback(null, newContent);
     }
-    self.downloadedImports = true;
     async.each(filesToDownload, ((fileObj, eachCb) => {
       self.downloadFile(fileObj.fileRelativePath, fileObj.url, (_content) => {
         eachCb();
       });
     }), (err) => {
+      self.downloadedImports = true;
       callback(err, newContent);
     });
   }
@@ -98,7 +99,7 @@ class File {
         fs.readFile(filename, next);
       },
       function parseForImports(content, next) {
-        self.parseFileForImport(content, true, (err) => {
+        self.parseFileForImport(content.toString(), true, (err) => {
           next(err, content);
         });
       }

--- a/test/config.js
+++ b/test/config.js
@@ -78,14 +78,16 @@ describe('embark.Config', function () {
           "type": "http",
           "path": "https://raw.githubusercontent.com/embark-framework/embark/master/test_app/app/contracts/simple_storage.sol",
           "basedir": "",
-          "resolver": undefined
+          "resolver": undefined,
+          "downloadedImports": false
         },
         {
           "filename": ".embark/contracts/status-im/contracts/master/contracts/identity/ERC725.sol",
           "type": "http",
           "path": "https://raw.githubusercontent.com/status-im/contracts/master/contracts/identity/ERC725.sol",
           "basedir": "",
-          "resolver": undefined
+          "resolver": undefined,
+          "downloadedImports": false
         }
       ];
       config.loadExternalContractsFiles();


### PR DESCRIPTION
The flag to say that the file had downloaded it's dependencies was set too soon, because we recursively check all dependencies and if a dep has an http import, we didn't download it.

Also, weird `toString` was needed, but only when a contract import another http contract.

### Cool Spaceship Picture
![front-cover](https://user-images.githubusercontent.com/11926403/45561143-05724900-b815-11e8-8cc0-cd6e4f6def45.png)
