### PR TITLE
report error and exit if --node option value is not valid

### DIFF
--- a/cmd/cmd.js
+++ b/cmd/cmd.js
@@ -274,12 +274,13 @@ class Cmd {
       .option('--loglevel [loglevel]', __('level of logging to display') + ' ["error", "warn", "info", "debug", "trace"]', /^(error|warn|info|debug|trace)$/i, 'warn')
       .description(__('run tests'))
       .action(function(file, options) {
-        const node = options.node;
+        const node = options.node || 'vm';
         const urlRegexExp = /^(vm|embark|((ws|https?):\/\/([a-zA-Z0-9_.-]*):?([0-9]*)?))$/i;
         if (node && !(node === 'embark' || node === 'vm' || node.match(urlRegexExp))) {
           console.error(`invalid --node option: must be 'vm', 'embark' or a valid URL`.red);
           process.exit(1);
         }
+        options.node = node;
         checkDeps();
         i18n.setOrDetectLocale(options.locale);
         embark.runTests({file, loglevel: options.loglevel, gasDetails: options.gasDetails,

--- a/cmd/cmd.js
+++ b/cmd/cmd.js
@@ -277,7 +277,7 @@ class Cmd {
         const node = options.node || 'vm';
         const urlRegexExp = /^(vm|embark|((ws|https?):\/\/([a-zA-Z0-9_.-]*):?([0-9]*)?))$/i;
         if (!urlRegexExp.test(node)) {
-          console.error(`invalid --node option: must be 'vm', 'embark' or a valid URL`.red);
+          console.error(`invalid --node option: must be 'vm', 'embark' or a valid URL\n`.red);
           options.outputHelp();
           process.exit(1);
         }

--- a/cmd/cmd.js
+++ b/cmd/cmd.js
@@ -262,20 +262,24 @@ class Cmd {
   }
 
   test() {
-    const urlRegexExp = /^(vm|embark|((ws|https?):\/\/([a-zA-Z0-9_.-]*):?([0-9]*)?))$/i;
     program
       .command('test [file]')
-      .option('-n , --node <node>', __('Node to connect to. Valid values are ["vm", "embark", "<custom node endpoint>"]: \n') + 
+      .option('-n , --node <node>', __('Node to connect to. Valid values are ["vm", "embark", "<custom node endpoint>"]: \n') +
               '                       vm - ' + __('Starts an Ethereum simulator (ganache) and runs the tests using the simulator') + '\n' +
-              '                       embark - ' + __('Uses the node associated with an already running embark process') + '\n' + 
-              '                       ' + __('<custom node endpoint> - Connects to a running node available at the end point and uses it to run the tests'), 
-              urlRegexExp, 'vm')
+              '                       embark - ' + __('Uses the node associated with an already running embark process') + '\n' +
+              '                       ' + __('<custom node endpoint> - Connects to a running node available at the end point and uses it to run the tests'))
       .option('-d , --gasDetails', __('When set, will print the gas cost for each contract deploy'))
       .option('-c , --coverage', __('When set, will generate the coverage after the tests'))
       .option('--locale [locale]', __('language to use (default: en)'))
       .option('--loglevel [loglevel]', __('level of logging to display') + ' ["error", "warn", "info", "debug", "trace"]', /^(error|warn|info|debug|trace)$/i, 'warn')
       .description(__('run tests'))
       .action(function(file, options) {
+        const node = options.node;
+        const urlRegexExp = /^(vm|embark|((ws|https?):\/\/([a-zA-Z0-9_.-]*):?([0-9]*)?))$/i;
+        if (node && !(node === 'embark' || node === 'vm' || node.match(urlRegexExp))) {
+          console.error(`invalid --node option: must be 'vm', 'embark' or a valid URL`.red);
+          process.exit(1);
+        }
         checkDeps();
         i18n.setOrDetectLocale(options.locale);
         embark.runTests({file, loglevel: options.loglevel, gasDetails: options.gasDetails,

--- a/cmd/cmd.js
+++ b/cmd/cmd.js
@@ -276,7 +276,7 @@ class Cmd {
       .action(function(file, options) {
         const node = options.node || 'vm';
         const urlRegexExp = /^(vm|embark|((ws|https?):\/\/([a-zA-Z0-9_.-]*):?([0-9]*)?))$/i;
-        if (!(node === 'embark' || node === 'vm' || node.match(urlRegexExp))) {
+        if (!urlRegexExp.test(node)) {
           console.error(`invalid --node option: must be 'vm', 'embark' or a valid URL`.red);
           options.outputHelp();
           process.exit(1);

--- a/cmd/cmd.js
+++ b/cmd/cmd.js
@@ -276,7 +276,7 @@ class Cmd {
       .action(function(file, options) {
         const node = options.node || 'vm';
         const urlRegexExp = /^(vm|embark|((ws|https?):\/\/([a-zA-Z0-9_.-]*):?([0-9]*)?))$/i;
-        if (node && !(node === 'embark' || node === 'vm' || node.match(urlRegexExp))) {
+        if (!(node === 'embark' || node === 'vm' || node.match(urlRegexExp))) {
           console.error(`invalid --node option: must be 'vm', 'embark' or a valid URL`.red);
           process.exit(1);
         }

--- a/cmd/cmd.js
+++ b/cmd/cmd.js
@@ -278,6 +278,7 @@ class Cmd {
         const urlRegexExp = /^(vm|embark|((ws|https?):\/\/([a-zA-Z0-9_.-]*):?([0-9]*)?))$/i;
         if (!(node === 'embark' || node === 'vm' || node.match(urlRegexExp))) {
           console.error(`invalid --node option: must be 'vm', 'embark' or a valid URL`.red);
+          options.outputHelp();
           process.exit(1);
         }
         options.node = node;


### PR DESCRIPTION
## Overview

Previously, if the option value for `embark test --node [value]` was not valid, it would be silently replaced with `'vm'` and the command would continue to run using the simulator.

However, that behavior can mask simple typos in node URLs such that the user might think a successful test run had been made against his (bad) URL but actually wasn't

Instead, if the option value isn't valid, we should report an error and exit.

### Cool Spaceship Picture


![](https://4.bp.blogspot.com/-KeZxbIih9eA/U7GxuK2-G3I/AAAAAAAADX8/FWVa7h1JXIc/s1600/spacingguild.jpg)

