### PR TITLE
Fix for embark run crashing after console connects to it

### DIFF
--- a/lib/core/modules/coderunner/runCode.js
+++ b/lib/core/modules/coderunner/runCode.js
@@ -29,7 +29,16 @@ class RunCode {
   }
 
   getWeb3Config() {
-    return {defaultAccount: this.context.web3.eth.defaultAccount, providerUrl: this.context.web3.currentProvider.connection._url};
+    const Web3 = require('web3');
+    const provider = this.context.web3.currentProvider;
+    let providerUrl;
+    if(provider instanceof Web3.providers.HttpProvider){
+      providerUrl = provider.host;
+    }
+    else if(provider instanceof Web3.provider.WebsocketProvider){
+      providerUrl = provider.connection._url;
+    }
+    return {defaultAccount: this.context.web3.eth.defaultAccount, providerUrl: providerUrl};
   }
 }
 


### PR DESCRIPTION
## Overview
**TL;DR**
The providerUrl being provided to the console VM was looking for a WebsocketProvider-specific property which did not exist on the HttpProvider.

Type checking was added to provide the necessary type-dependent property.

### Cool Spaceship Picture
![Cool Spaceship Picture](https://data1.ibtimes.co.in/cache-img-0-450/en/full/631135/1482899131_uss-discovery-one.jpg)