### PR TITLE
cli and config options for browser auto-open

### DIFF
--- a/cmd/cmd.js
+++ b/cmd/cmd.js
@@ -168,6 +168,7 @@ class Cmd {
       .option('-b, --host [host]', __('host to run the dev webserver (default: %s)', 'localhost'))
       .option('--noserver', __('disable the development webserver'))
       .option('--nodashboard', __('simple mode, disables the dashboard'))
+      .option('--nobrowser', __('prevent the development webserver from opening your default web browser'))
       .option('--no-color', __('no colors in case it\'s needed for compatbility purposes'))
       .option('--logfile [logfile]', __('filename to output logs (default: %s)', 'none'))
       .option('--loglevel [loglevel]', __('level of logging to display') + ' ["error", "warn", "info", "debug", "trace"]', /^(error|warn|info|debug|trace)$/i, 'debug')
@@ -187,7 +188,8 @@ class Cmd {
           useDashboard: !options.nodashboard,
           logFile: options.logfile,
           logLevel: options.loglevel,
-          webpackConfigName: options.pipeline || 'development'
+          webpackConfigName: options.pipeline || 'development',
+          openBrowser: options.nobrowser == null ? null : !options.nobrowser,
         });
       });
   }

--- a/cmd/cmd.js
+++ b/cmd/cmd.js
@@ -168,7 +168,7 @@ class Cmd {
       .option('-b, --host [host]', __('host to run the dev webserver (default: %s)', 'localhost'))
       .option('--noserver', __('disable the development webserver'))
       .option('--nodashboard', __('simple mode, disables the dashboard'))
-      .option('--nobrowser', __('prevent the development webserver from opening your default web browser'))
+      .option('--nobrowser', __('prevent the development webserver from automatically opening a web browser'))
       .option('--no-color', __('no colors in case it\'s needed for compatbility purposes'))
       .option('--logfile [logfile]', __('filename to output logs (default: %s)', 'none'))
       .option('--loglevel [loglevel]', __('level of logging to display') + ' ["error", "warn", "info", "debug", "trace"]', /^(error|warn|info|debug|trace)$/i, 'debug')

--- a/cmd/cmd.js
+++ b/cmd/cmd.js
@@ -178,10 +178,11 @@ class Cmd {
       .action(function(env, options) {
         checkDeps();
         i18n.setOrDetectLocale(options.locale);
+        const nullify = (v) => (!v || typeof v !== 'string') ? null : v;
         embark.run({
           env: env || 'development',
-          serverPort: options.port,
-          serverHost: options.host,
+          serverPort: nullify(options.port),
+          serverHost: nullify(options.host),
           client: options.client || 'geth',
           locale: options.locale,
           runWebserver: !options.noserver,

--- a/cmd/cmd.js
+++ b/cmd/cmd.js
@@ -185,7 +185,7 @@ class Cmd {
           serverHost: nullify(options.host),
           client: options.client || 'geth',
           locale: options.locale,
-          runWebserver: !options.noserver,
+          runWebserver: options.noserver == null ? null : !options.noserver,
           useDashboard: !options.nodashboard,
           logFile: options.logfile,
           logLevel: options.loglevel,

--- a/cmd/cmd_controller.js
+++ b/cmd/cmd_controller.js
@@ -154,11 +154,8 @@ class EmbarkController {
           engine.events.emit("status", __("Ready").green);
         });
 
-        if (options.runWebserver) {
-          engine.startService("webServer", {
-            host: options.serverHost,
-            port: options.serverPort
-          });
+        if (webServerConfig.enabled !== false) {
+          engine.startService("webServer");
         }
         engine.startService("fileWatcher");
         callback();

--- a/cmd/cmd_controller.js
+++ b/cmd/cmd_controller.js
@@ -56,15 +56,22 @@ class EmbarkController {
     self.context = options.context || [constants.contexts.run, constants.contexts.build];
     let Dashboard = require('./dashboard/dashboard.js');
 
-    let webServerConfig = {
-      enabled: options.runWebserver
-    };
+    const webServerConfig = {};
 
-    if (options.serverHost) {
+    if (options.runWebserver != null) {
+      webServerConfig.enabled = options.runWebserver;
+    }
+
+    if (options.serverHost != null) {
       webServerConfig.host = options.serverHost;
     }
-    if (options.serverPort) {
+
+    if (options.serverPort != null) {
       webServerConfig.port = options.serverPort;
+    }
+
+    if (options.openBrowser != null) {
+      webServerConfig.openBrowser = options.openBrowser;
     }
 
     const Engine = require('../lib/core/engine.js');

--- a/lib/core/config.js
+++ b/lib/core/config.js
@@ -314,6 +314,7 @@ Config.prototype.loadWebServerConfigFile = function() {
   var configObject = {
     "enabled": true,
     "host": defaultHost,
+    "openBrowser": true,
     "port": 8000
   };
 

--- a/lib/core/engine.js
+++ b/lib/core/engine.js
@@ -226,9 +226,8 @@ class Engine {
     this.watch.start();
   }
 
-  webServerService(_options) {
-    _options.buildDir = this.config.buildDir;
-    this.registerModule('webserver', _options);
+  webServerService() {
+    this.registerModule('webserver');
   }
 
   storageService(_options) {

--- a/lib/modules/webserver/index.js
+++ b/lib/modules/webserver/index.js
@@ -10,18 +10,16 @@ const Templates = {
 };
 
 class WebServer {
-  constructor(embark, options) {
+  constructor(embark) {
     this.embark = embark;
     this.logger = embark.logger;
     this.events = embark.events;
-    this.buildDir = options.buildDir;
+    this.buildDir = embark.config.buildDir;
     this.webServerConfig = embark.config.webServerConfig;
     if (!this.webServerConfig.enabled) {
       return;
     }
 
-    this.host = options.host || this.webServerConfig.host;
-    this.port = options.port || this.webServerConfig.port;
 
     this.events.emit("status", __("Starting Server"));
 

--- a/lib/modules/webserver/index.js
+++ b/lib/modules/webserver/index.js
@@ -20,6 +20,7 @@ class WebServer {
       return;
     }
 
+    this._openBrowser = this.webServerConfig.openBrowser;
 
     this.events.emit("status", __("Starting Server"));
 
@@ -128,6 +129,9 @@ class WebServer {
   }
 
   openBrowser(cb) {
+    if (!this._openBrowser) {
+      return cb();
+    }
     const _cb = () => { cb(); };
     return opn(
       `http://${canonicalHost(this.server.hostname)}:${this.server.port}`,

--- a/lib/modules/webserver/index.js
+++ b/lib/modules/webserver/index.js
@@ -21,7 +21,7 @@ class WebServer {
     }
 
     this.host = this.webServerConfig.host;
-    this.port = parseInt(this.webServerConfig.port);
+    this.port = parseInt(this.webServerConfig.port, 10);
     this._openBrowser = this.webServerConfig.openBrowser;
 
     this.events.emit("status", __("Starting Server"));

--- a/lib/modules/webserver/index.js
+++ b/lib/modules/webserver/index.js
@@ -22,7 +22,6 @@ class WebServer {
 
     this.host = this.webServerConfig.host;
     this.port = parseInt(this.webServerConfig.port, 10);
-    this._openBrowser = this.webServerConfig.openBrowser;
 
     this.events.emit("status", __("Starting Server"));
 
@@ -30,7 +29,8 @@ class WebServer {
       buildDir: this.buildDir,
       events: this.events,
       host: this.host,
-      port: this.port
+      port: this.port,
+      openBrowser: this.webServerConfig.openBrowser
     });
 
     this.events.on('webserver:config:change', () => {
@@ -136,9 +136,6 @@ class WebServer {
   }
 
   openBrowser(cb) {
-    if (!this._openBrowser) {
-      return cb();
-    }
     const _cb = () => { cb(); };
     return opn(
       `http://${canonicalHost(this.server.hostname)}:${this.server.port}`,

--- a/lib/modules/webserver/index.js
+++ b/lib/modules/webserver/index.js
@@ -20,6 +20,7 @@ class WebServer {
       return;
     }
 
+    this.port = parseInt(this.webServerConfig.port);
     this._openBrowser = this.webServerConfig.openBrowser;
 
     this.events.emit("status", __("Starting Server"));

--- a/lib/modules/webserver/index.js
+++ b/lib/modules/webserver/index.js
@@ -65,6 +65,11 @@ class WebServer {
   }
 
   testPort(done) {
+    if (this.port === 0) {
+      this.logger.warn(__('Assigning an available port'));
+      this.server.port = 0;
+      return done();
+    }
     utils.pingEndpoint(this.host, this.port, 'http', 'http', '', (err) => {
       if (err) { // Port is ok
         return done();

--- a/lib/modules/webserver/index.js
+++ b/lib/modules/webserver/index.js
@@ -20,6 +20,7 @@ class WebServer {
       return;
     }
 
+    this.host = this.webServerConfig.host;
     this.port = parseInt(this.webServerConfig.port);
     this._openBrowser = this.webServerConfig.openBrowser;
 

--- a/lib/modules/webserver/server.js
+++ b/lib/modules/webserver/server.js
@@ -13,6 +13,7 @@ class Server {
     this.hostname = dockerHostSwap(options.host) || defaultHost;
     this.isFirstStart = true;
     this.opened = false;
+    this.openBrowser = options.openBrowser;
   }
 
   start(callback) {
@@ -45,7 +46,7 @@ class Server {
         });
       },
       function openBrowser(next) {
-        if (self.opened) {
+        if (!self.openBrowser || self.opened) {
           return next();
         }
         self.opened = true;

--- a/templates/boilerplate/config/webserver.js
+++ b/templates/boilerplate/config/webserver.js
@@ -1,5 +1,6 @@
 module.exports = {
   enabled: true,
   host: "localhost",
+  openBrowser: true,
   port: 8000
 };

--- a/templates/demo/config/webserver.js
+++ b/templates/demo/config/webserver.js
@@ -1,5 +1,6 @@
 module.exports = {
   enabled: true,
   host: "localhost",
+  openBrowser: true,
   port: 8000
 };


### PR DESCRIPTION
## Overview

Automatic opening of the default web browser (when embark's development webserver starts) can be disabled via `--nobrowser` cli option or `openBrowser: false` in a DApp's `webserver.js` config file.

Some aspects of how the webserver's config and cli options are handled have been modified to ensure that not specifying a cli option doesn't effectively override what's in the DApp's config. Merging the cli and config options is now entirely the responsibility of `core/config`; previously, it was done by both the webserver module and core/config, which is redundant and could be confusing.

### Cool Spaceship Picture


![](http://i26.tinypic.com/2qteq0g.jpg)
