### PR TITLE
Prevents continuous transactions when numAccounts === 0

### DIFF
--- a/lib/modules/blockchain_process/dev_funds.js
+++ b/lib/modules/blockchain_process/dev_funds.js
@@ -95,7 +95,7 @@ class DevFunds {
   }
 
   createFundAndUnlockAccounts(cb) {
-    if (!this.web3) {
+    if (!this.web3 || !this.numAccounts) {
       return cb();
     }
     async.waterfall([


### PR DESCRIPTION
## Overview
**TL;DR**
`dev_funds` provides functionality to create, fund, and unlock accounts, as well as send continuous transactions to accounts controlled by the node. The purpose of the continuous transactions was to prevent transactions from getting “stuck” in development.

**BEFORE**
Regardless of the `config/blockchain` > `account` > `numAccounts` setting, the continuous transactions would occur.

**AFTER**
Continuous transactions will only occur if `config/blockchain` > `account` > `numAccounts` is greater than `0`.

## More info
Merging this PR is completely optional, and I’m not sure that we want to stop continuous txs from occurring as it may help in other situations.

Continuous txs may also appear that `mineWhenNeeded` is broken, as txs continuously occur.

### Cool Spaceship Picture
![Spaceballs ship](https://cnet4.cbsistatic.com/img/zMrZ3thVPnDygbAJmXED3g63uIQ=/2017/06/08/34bf7cbc-4d59-411a-b97a-517dff83bdb1/spaceballswinnebago.jpg)
