### PR TITLE
Geth creates new account - add password warning

### DIFF
--- a/lib/modules/blockchain_process/geth_commands.js
+++ b/lib/modules/blockchain_process/geth_commands.js
@@ -63,6 +63,9 @@ class GethCommands {
   }
 
   newAccountCommand() {
+    if (!(this.config.account && this.config.account.password)){
+      console.warn(__('Your blockchain is missing a password and creating an account may fail. Please consider updating ').yellow + __('config/blockchain > account > password').cyan + __(' then re-run the command').yellow);
+    }
     return this.geth_bin + " " + this.commonOptions().join(' ') + " account new ";
   }
 


### PR DESCRIPTION
## Overview
**TL;DR**
When `isDev` is false, and `mineWhenNeeded` is true, embark attempts to create a new account using `geth account new`, and uses the password file specified in `blockchain/config > accounts > password`. This warning informs the user that the create account command may fail if the password is missing.

This is the second part of the `mineWhenNeeded` issue where the user gets "stuck" on `geth account new` when running `embark blockchain`.

### Questions
Should we offer an example of what to include in the config, ie `"password": "config/privatenet/password"`?

### Cool Spaceship Picture
![Spaceballs](https://3dwarehouse.sketchup.com/warehouse/getpubliccontent?contentId=3a132ff6-955c-4f10-a1dd-532be9d8694a)