### PR TITLE
Delay the start of the proxy

### DIFF
--- a/lib/modules/blockchain_process/blockchain.js
+++ b/lib/modules/blockchain_process/blockchain.js
@@ -58,8 +58,6 @@ var Blockchain = function(options) {
     verbosity: this.blockchainConfig.verbosity
   };
 
-  this.setupProxy();
-
   if (this.blockchainConfig === {} || JSON.stringify(this.blockchainConfig) === '{"enabled":true}') {
     this.config.account = {};
     this.config.account.password = fs.embarkPath("templates/boilerplate/config/development/password");
@@ -80,26 +78,28 @@ var Blockchain = function(options) {
     console.error(__(spaceMessage, 'genesisBlock'));
     process.exit();
   }
-
+  this.initProxy();
   this.client = new options.client({config: this.config, env: this.env, isDev: this.isDev});
 };
 
-Blockchain.prototype.setupProxy = function() {
+Blockchain.prototype.initProxy = function() {
   this.config.proxy = true;
   if (this.blockchainConfig.proxy === false) {
     this.config.proxy = false;
     return;
   }
 
+  this.config.rpcPort += constants.blockchain.servicePortOnProxy;
+  this.config.wsPort += constants.blockchain.servicePortOnProxy;
+};
+
+Blockchain.prototype.setupProxy = function() {
   const proxy = require('./proxy');
   const Ipc = require('../../core/ipc');
 
   let ipcObject = new Ipc({ipcRole: 'client'});
-
   this.rpcProxy = proxy.serve(ipcObject, this.config.rpcHost, this.config.rpcPort, false);
   this.wsProxy = proxy.serve(ipcObject, this.config.wsHost, this.config.wsPort, true);
-  this.config.rpcPort += constants.blockchain.servicePortOnProxy;
-  this.config.wsPort += constants.blockchain.servicePortOnProxy;
 };
 
 Blockchain.prototype.shutdownProxy = function() {
@@ -126,7 +126,6 @@ Blockchain.prototype.run = function() {
   console.log(__("Embark Blockchain Using: %s", this.client.name.underline).magenta);
   console.log("===============================================================================".magenta);
   console.log("===============================================================================".magenta);
-
   this.checkPathLength();
   let address = '';
   async.waterfall([
@@ -150,6 +149,9 @@ Blockchain.prototype.run = function() {
     },
     function getMainCommand(next) {
       self.client.mainCommand(address, function(cmd, args) {
+        if (self.config.proxy) {
+          self.setupProxy();
+        }
         next(null, cmd, args);
       }, true);
     }
@@ -163,7 +165,6 @@ Blockchain.prototype.run = function() {
     let full_cmd = cmd + " " + args.join(' ');
     console.log(__("running: %s", full_cmd.underline).green);
     self.child = child_process.spawn(cmd, args, {cwd: process.cwd()});
-
     self.child.on('error', (err) => {
       err = err.toString();
       console.error('Blockchain error: ', err);

--- a/lib/modules/blockchain_process/proxy.js
+++ b/lib/modules/blockchain_process/proxy.js
@@ -67,7 +67,7 @@ exports.serve = function (ipc, host, port, ws) {
   let proxy = httpProxy.createProxyServer({
     target: {
       host: canonicalHost(host),
-      port: port + constants.blockchain.servicePortOnProxy
+      port: port
     },
     ws: ws
   });
@@ -126,7 +126,7 @@ exports.serve = function (ipc, host, port, ws) {
 
     });
   }
-
-  server.listen(port, defaultHost);
+  const listenPort = port - constants.blockchain.servicePortOnProxy;
+  server.listen(listenPort, defaultHost);
   return server;
 };

--- a/test/blockchain.js
+++ b/test/blockchain.js
@@ -52,7 +52,6 @@ describe('embark.Blockchain', function () {
           config.rpcPort += constants.blockchain.servicePortOnProxy;
         }
         assert.deepEqual(blockchain.config, config);
-        blockchain.kill();
         done();
       });
     });
@@ -97,7 +96,6 @@ describe('embark.Blockchain', function () {
         }
 
         assert.deepEqual(blockchain.config, config);
-        blockchain.kill();
         done();
       });
     });


### PR DESCRIPTION
## Overview
**TL;DR**

There is no difference in output except that:
```
[Error forwarding requests to blockchain/simulator,connect ECONNREFUSED 127.0.0.1:8556]
```
should not appear anymore

### Rationale
The proxy was started before geth client and was causing this error.
To solve it, move the proxy start after the gets command.

Let me know if you still experimence this error. I haven't since this change

### Cool Spaceship Picture
![mtyehjswcaxgyndfaatzbf-650-80](https://user-images.githubusercontent.com/491074/45686450-59966980-bb44-11e8-84c3-9fb8f40e5e5b.jpg)
