### PR TITLE
clarify 'new' help output

### DIFF
--- a/cmd/cmd.js
+++ b/cmd/cmd.js
@@ -94,7 +94,7 @@ class Cmd {
       .description(__('New Application'))
       .option('--simple', __('create a barebones project meant only for contract development'))
       .option('--locale [locale]', __('language to use (default: en)'))
-      .option('--template [url]', __('download template'))
+      .option('--template [url]', __('download template from a GitHub repository'))
       .action(function(name, options) {
         i18n.setOrDetectLocale(options.locale);
         if (name === undefined) {


### PR DESCRIPTION
## Overview

Embark's template downloader only supports GitHub repos, so I changed the output of `embark new --help` to mention GitHub.

### Cool Spaceship Picture

![](https://vignette.wikia.nocookie.net/horrormovies/images/7/79/Prometheus-movie-poop-ship.jpg)