### PR TITLE
fix for instance contracts not redploying when parent changes

### DIFF
--- a/lib/modules/contracts_manager/index.js
+++ b/lib/modules/contracts_manager/index.js
@@ -194,6 +194,7 @@ class ContractsManager {
 
           contract.code = parentContract.code;
           contract.runtimeBytecode = parentContract.runtimeBytecode;
+          contract.realRuntimeBytecode = (parentContract.realRuntimeBytecode || parentContract.runtimeBytecode);
           contract.gasEstimates = parentContract.gasEstimates;
           contract.functionHashes = parentContract.functionHashes;
           contract.abiDefinition = parentContract.abiDefinition;


### PR DESCRIPTION
## Overview

A contract that's an `instanceOf` another contract needs to reference its parent's `realRuntimeBytecode` code in order to be detected as having changed when the parent changes.

### Cool Spaceship Picture

![](https://i.imgur.com/YOmnC3f.jpg)
