### PR TITLE
proxy should try to wait on target endpoint

### DIFF
--- a/lib/modules/blockchain_process/blockchain.js
+++ b/lib/modules/blockchain_process/blockchain.js
@@ -153,13 +153,10 @@ Blockchain.prototype.run = function() {
     },
     function getMainCommand(next) {
       self.client.mainCommand(address, function(cmd, args) {
-        if (self.config.proxy) {
-          self.setupProxy();
-        }
         next(null, cmd, args);
       }, true);
     }
-  ], function (err, cmd, args) {
+  ], async function (err, cmd, args) {
     if (err) {
       console.error(err.message);
       return;
@@ -182,10 +179,13 @@ Blockchain.prototype.run = function() {
       console.error(`Geth error: ${data}`);
     });
     // Geth logs appear in stderr somehow
-    self.child.stderr.on('data', (data) => {
+    self.child.stderr.on('data', async (data) => {
       data = data.toString();
       if (!self.readyCalled && data.indexOf('WebSocket endpoint opened') > -1) {
         if (self.isDev) {
+          if (self.config.proxy) {
+            await self.setupProxy();
+          }
           self.createFundAndUnlockAccounts((err) => {
             // TODO: this is never called!
             if(err) console.error('Error creating, unlocking, and funding accounts', err);

--- a/lib/modules/blockchain_process/blockchain.js
+++ b/lib/modules/blockchain_process/blockchain.js
@@ -18,6 +18,7 @@ var Blockchain = function(options) {
   this.isDev = options.isDev;
   this.onReadyCallback = options.onReadyCallback || (() => {});
   this.onExitCallback = options.onExitCallback;
+  this.proxyIpc = null;
 
   if ((this.blockchainConfig === {} || JSON.stringify(this.blockchainConfig) === '{"enabled":true}') && this.env !== 'development') {
     console.log("===> " + __("warning: running default config on a non-development environment"));
@@ -93,17 +94,18 @@ Blockchain.prototype.initProxy = function() {
   this.config.wsPort += constants.blockchain.servicePortOnProxy;
 };
 
-Blockchain.prototype.setupProxy = async function() {
+Blockchain.prototype.setupProxy = async function(type) {
   const proxy = require('./proxy');
   const Ipc = require('../../core/ipc');
 
-  let ipcObject = new Ipc({ipcRole: 'client'});
-  const [rpcProxy, wsProxy] = await Promise.all([
-    proxy.serve(ipcObject, this.config.rpcHost, this.config.rpcPort, false),
-    proxy.serve(ipcObject, this.config.wsHost, this.config.wsPort, true, this.config.wsOrigins)
-  ]);
-  this.rpcProxy = rpcProxy;
-  this.wsProxy = wsProxy;
+  if(!this.proxyIpc) this.proxyIpc = new Ipc({ipcRole: 'client'});
+  
+  if (type === 'rpc') {
+    this.rpcProxy = await proxy.serve(this.proxyIpc, this.config.rpcHost, this.config.rpcPort, false);
+  }
+  else if (type === 'ws'){
+    this.wsProxy = await proxy.serve(this.proxyIpc, this.config.wsHost, this.config.wsPort, true, this.config.wsOrigins);
+  }
 };
 
 Blockchain.prototype.shutdownProxy = function() {
@@ -111,8 +113,8 @@ Blockchain.prototype.shutdownProxy = function() {
     return;
   }
 
-  this.rpcProxy.close();
-  this.wsProxy.close();
+  if(this.rpcProxy) this.rpcProxy.close();
+  if(this.wsProxy) this.wsProxy.close();
 };
 
 Blockchain.prototype.runCommand = function(cmd, options, callback) {
@@ -181,9 +183,12 @@ Blockchain.prototype.run = function() {
     // Geth logs appear in stderr somehow
     self.child.stderr.on('data', async (data) => {
       data = data.toString();
+      if (!self.readyCalled && data.indexOf('HTTP endpoint opened') > -1 && self.config.proxy) {
+        await self.setupProxy('rpc');
+      }
       if (!self.readyCalled && data.indexOf('WebSocket endpoint opened') > -1) {
         if (self.config.proxy) {
-          await self.setupProxy();
+          await self.setupProxy('ws');
         }
         if (self.isDev) {
           self.createFundAndUnlockAccounts((err) => {

--- a/lib/modules/blockchain_process/blockchain.js
+++ b/lib/modules/blockchain_process/blockchain.js
@@ -94,18 +94,21 @@ Blockchain.prototype.initProxy = function() {
   this.config.wsPort += constants.blockchain.servicePortOnProxy;
 };
 
-Blockchain.prototype.setupProxy = async function(type) {
+Blockchain.prototype.setupProxy = async function() {
   const proxy = require('./proxy');
   const Ipc = require('../../core/ipc');
 
   if(!this.proxyIpc) this.proxyIpc = new Ipc({ipcRole: 'client'});
   
-  if (type === 'rpc') {
-    this.rpcProxy = await proxy.serve(this.proxyIpc, this.config.rpcHost, this.config.rpcPort, false);
+  let wsProxy;
+  if(this.config.wsRPC) {
+    wsProxy = proxy.serve(this.proxyIpc, this.config.wsHost, this.config.wsPort, true, this.config.wsOrigins);
   }
-  else if (type === 'ws'){
-    this.wsProxy = await proxy.serve(this.proxyIpc, this.config.wsHost, this.config.wsPort, true, this.config.wsOrigins);
-  }
+  
+  [this.rpcProxy, this.wsProxy] = await Promise.all([
+    proxy.serve(this.proxyIpc, this.config.rpcHost, this.config.rpcPort, false),
+    wsProxy
+  ]);
 };
 
 Blockchain.prototype.shutdownProxy = function() {
@@ -180,25 +183,33 @@ Blockchain.prototype.run = function() {
     self.child.stdout.on('data', (data) => {
       console.error(`Geth error: ${data}`);
     });
+    let httpReady = false;
+    let wsReady = !self.config.wsRPC;
     // Geth logs appear in stderr somehow
     self.child.stderr.on('data', async (data) => {
       data = data.toString();
-      if (!self.readyCalled && data.indexOf('HTTP endpoint opened') > -1 && self.config.proxy) {
-        await self.setupProxy('rpc');
+      if (data.indexOf('HTTP endpoint opened') > -1) {
+        httpReady = true;
       }
-      if (!self.readyCalled && data.indexOf('WebSocket endpoint opened') > -1) {
-        if (self.config.proxy) {
-          await self.setupProxy('ws');
-        }
+
+      if (data.indexOf('WebSocket endpoint opened') > -1) {
+        wsReady = true;
+      }
+
+      if (!self.readyCalled && wsReady && httpReady) {
+        self.readyCalled = true;
         if (self.isDev) {
           self.createFundAndUnlockAccounts((err) => {
             // TODO: this is never called!
             if(err) console.error('Error creating, unlocking, and funding accounts', err);
           });
         }
-        self.readyCalled = true;
+        if (self.config.proxy) {
+          await self.setupProxy();
+        }
         self.readyCallback();
       }
+
       console.log('Geth: ' + data);
     });
     self.child.on('exit', (code) => {

--- a/lib/modules/blockchain_process/blockchain.js
+++ b/lib/modules/blockchain_process/blockchain.js
@@ -156,7 +156,7 @@ Blockchain.prototype.run = function() {
         next(null, cmd, args);
       }, true);
     }
-  ], async function (err, cmd, args) {
+  ], function (err, cmd, args) {
     if (err) {
       console.error(err.message);
       return;

--- a/lib/modules/blockchain_process/blockchain.js
+++ b/lib/modules/blockchain_process/blockchain.js
@@ -93,13 +93,17 @@ Blockchain.prototype.initProxy = function() {
   this.config.wsPort += constants.blockchain.servicePortOnProxy;
 };
 
-Blockchain.prototype.setupProxy = function() {
+Blockchain.prototype.setupProxy = async function() {
   const proxy = require('./proxy');
   const Ipc = require('../../core/ipc');
 
   let ipcObject = new Ipc({ipcRole: 'client'});
-  this.rpcProxy = proxy.serve(ipcObject, this.config.rpcHost, this.config.rpcPort, false);
-  this.wsProxy = proxy.serve(ipcObject, this.config.wsHost, this.config.wsPort, true);
+  const [rpcProxy, wsProxy] = await Promise.all([
+    proxy.serve(ipcObject, this.config.rpcHost, this.config.rpcPort, false),
+    proxy.serve(ipcObject, this.config.wsHost, this.config.wsPort, true, this.config.wsOrigins)
+  ]);
+  this.rpcProxy = rpcProxy;
+  this.wsProxy = wsProxy;
 };
 
 Blockchain.prototype.shutdownProxy = function() {

--- a/lib/modules/blockchain_process/blockchain.js
+++ b/lib/modules/blockchain_process/blockchain.js
@@ -182,10 +182,10 @@ Blockchain.prototype.run = function() {
     self.child.stderr.on('data', async (data) => {
       data = data.toString();
       if (!self.readyCalled && data.indexOf('WebSocket endpoint opened') > -1) {
+        if (self.config.proxy) {
+          await self.setupProxy();
+        }
         if (self.isDev) {
-          if (self.config.proxy) {
-            await self.setupProxy();
-          }
           self.createFundAndUnlockAccounts((err) => {
             // TODO: this is never called!
             if(err) console.error('Error creating, unlocking, and funding accounts', err);

--- a/lib/modules/blockchain_process/proxy.js
+++ b/lib/modules/blockchain_process/proxy.js
@@ -69,7 +69,7 @@ exports.serve = async function (ipc, host, port, ws, origin) {
   const start = Date.now();
 
   function awaitTarget() {
-    return new Promise((resolve, reject) => {
+    return new Promise(resolve => {
       utils.pingEndpoint(
         canonicalHost(host), port, ws ? 'ws': false, 'http', _origin, async (err) => {
           if (!err || (Date.now() - start > 10000)) {

--- a/lib/modules/blockchain_process/proxy.js
+++ b/lib/modules/blockchain_process/proxy.js
@@ -73,14 +73,8 @@ exports.serve = async function (ipc, host, port, ws, origin) {
       utils.pingEndpoint(
         canonicalHost(host), port, ws ? 'ws': false, 'http', _origin, async (err) => {
           if (!err || (Date.now() - start > 10000)) {
-            // if (Date.now() - start > 10000) {
-            //   console.warn('!!! TIMEOUT !!!');
-            // } else {
-            //   console.warn('!!! CONNECT !!!');
-            // }
             return resolve();
           }
-          // console.warn('!!! WAITING !!!');
           await utils.timer(250).then(awaitTarget).then(resolve);
         }
       );
@@ -152,6 +146,9 @@ exports.serve = async function (ipc, host, port, ws, origin) {
     });
   }
   const listenPort = port - constants.blockchain.servicePortOnProxy;
-  server.listen(listenPort, defaultHost);
-  return server;
+  return new Promise(resolve => {
+    server.listen(listenPort, defaultHost, () => {
+      resolve(server);
+    });
+  });
 };

--- a/lib/modules/blockchain_process/proxy.js
+++ b/lib/modules/blockchain_process/proxy.js
@@ -1,6 +1,7 @@
 const httpProxy = require('http-proxy');
 const http = require('http');
 const constants = require('../../constants.json');
+const utils = require('../../utils/utils');
 
 let commList = {};
 let transactions = {};
@@ -63,7 +64,31 @@ const parseResponse = function (ipc, resBody) {
   }
 };
 
-exports.serve = function (ipc, host, port, ws) {
+exports.serve = async function (ipc, host, port, ws, origin) {
+  const _origin = origin ? origin.split(',')[0] : void 0;
+  const start = Date.now();
+
+  function awaitTarget() {
+    return new Promise((resolve, reject) => {
+      utils.pingEndpoint(
+        canonicalHost(host), port, ws ? 'ws': false, 'http', _origin, async (err) => {
+          if (!err || (Date.now() - start > 10000)) {
+            // if (Date.now() - start > 10000) {
+            //   console.warn('!!! TIMEOUT !!!');
+            // } else {
+            //   console.warn('!!! CONNECT !!!');
+            // }
+            return resolve();
+          }
+          // console.warn('!!! WAITING !!!');
+          await utils.timer(250).then(awaitTarget).then(resolve);
+        }
+      );
+    });
+  }
+
+  await awaitTarget();
+
   let proxy = httpProxy.createProxyServer({
     target: {
       host: canonicalHost(host),

--- a/lib/modules/blockchain_process/proxy.js
+++ b/lib/modules/blockchain_process/proxy.js
@@ -65,7 +65,7 @@ const parseResponse = function (ipc, resBody) {
 };
 
 exports.serve = async function (ipc, host, port, ws, origin) {
-  const _origin = origin ? origin.split(',')[0] : void 0;
+  const _origin = origin ? origin.split(',')[0] : undefined;
   const start = Date.now();
 
   function awaitTarget() {

--- a/lib/modules/blockchain_process/simulator.js
+++ b/lib/modules/blockchain_process/simulator.js
@@ -30,7 +30,7 @@ class Simulator {
     let useProxy = this.blockchainConfig.proxy || false;
     let host = (dockerHostSwap(options.host || this.blockchainConfig.rpcHost) || defaultHost);
     let port = (options.port || this.blockchainConfig.rpcPort || 8545);
-    port = parseInt(port) + (useProxy ? constants.blockchain.servicePortOnProxy : 0);
+    port = parseInt(port, 10) + (useProxy ? constants.blockchain.servicePortOnProxy : 0);
 
     cmds.push("-p " + port);
     cmds.push("-h " + host);

--- a/lib/modules/blockchain_process/simulator.js
+++ b/lib/modules/blockchain_process/simulator.js
@@ -30,8 +30,9 @@ class Simulator {
     let useProxy = this.blockchainConfig.proxy || false;
     let host = (dockerHostSwap(options.host || this.blockchainConfig.rpcHost) || defaultHost);
     let port = (options.port || this.blockchainConfig.rpcPort || 8545);
+    port = parseInt(port) + (useProxy ? constants.blockchain.servicePortOnProxy : 0);
 
-    cmds.push("-p " + (port + (useProxy ? constants.blockchain.servicePortOnProxy : 0)));
+    cmds.push("-p " + port);
     cmds.push("-h " + host);
     cmds.push("-a " + (options.numAccounts || 10));
     cmds.push("-e " + (options.defaultBalance || 100));

--- a/lib/utils/utils.js
+++ b/lib/utils/utils.js
@@ -490,6 +490,10 @@ function errorMessage(e) {
   return e;
 }
 
+async function timer(ms) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
 module.exports = {
   joinPath,
   dirname,
@@ -532,5 +536,6 @@ module.exports = {
   sample,
   last,
   interceptLogs,
-  errorMessage
+  errorMessage,
+  timer
 };

--- a/lib/utils/utils.js
+++ b/lib/utils/utils.js
@@ -490,8 +490,8 @@ function errorMessage(e) {
   return e;
 }
 
-async function timer(ms) {
-  return new Promise((resolve) => setTimeout(resolve, ms));
+function timer(ms) {
+  return new Promise(resolve => setTimeout(resolve, ms));
 }
 
 module.exports = {


### PR DESCRIPTION
## Overview

When a proxy is being created, attempt to wait for the target endpoint to be live before connecting the proxy. If it takes longer than 10 seconds, then go ahead — we'll get an error as before, and something is probably wrong in any case.

Owing to the placement of the proxy setup call for a real blockchain, there is hardly any delay before the proxy is available (a few ms, assuming nothing is wrong with the invocation of geth). For the simulator, it takes a few seconds.

### Cool Spaceship Picture

![](https://vignette.wikia.nocookie.net/startrek/images/9/9f/Bsphere.jpg)
