### PR TITLE
Fix websocket not open

### DIFF
--- a/lib/modules/webserver/server.js
+++ b/lib/modules/webserver/server.js
@@ -6,6 +6,8 @@ const express = require('express');
 const fs = require('../../core/fs');
 require('http-shutdown').extend();
 
+const WEB_SOCKET_STATE_OPEN = 1;
+
 class Server {
   constructor(options) {
     this.buildDir = options.buildDir;
@@ -31,15 +33,17 @@ class Server {
     const main = serveStatic(this.buildDir, {'index': ['index.html', 'index.htm']});
 
     this.app = express();
+    expressWebSocket(this.app);
+
     this.app.use(main);
     this.app.use('/coverage', coverage);
     this.app.use(coverageStyle);
 
-    expressWebSocket(this.app);
-
     this.app.ws('/', function(ws, _req) {
       self.events.on('outputDone', () => {
-        ws.send('outputDone');
+        if (ws.readyState === WEB_SOCKET_STATE_OPEN) {
+          ws.send('outputDone');
+        }
       });
     });
 

--- a/lib/modules/webserver/server.js
+++ b/lib/modules/webserver/server.js
@@ -42,8 +42,13 @@ class Server {
     this.app.ws('/', function(ws, _req) {
       self.events.on('outputDone', () => {
         if (ws.readyState === WEB_SOCKET_STATE_OPEN) {
-          ws.send('outputDone');
+          return ws.send('outputDone');
         }
+        // if the socket wasn't yet opened, listen for the 'open' event,
+        // then send the 'outputDone' data
+        ws.addEventListener('open', _event => {
+          ws.send('outputDone');
+        });
       });
     });
 


### PR DESCRIPTION
## Overview
**TL;DR**
Make sure the connection is open before sending the event.

I was getting this error:
```
Ready
/Users/anthony/code/embark-framework/embark/node_modules/express-ws/node_modules/ws/lib/websocket.js:320
      throw err;
      ^

Error: WebSocket is not open: readyState 3 (CLOSED)
    at WebSocket.send (/Users/anthony/code/embark-framework/embark/node_modules/express-ws/node_modules/ws/lib/websocket.js:314:19)
    at EventEmitter.self.events.on (/Users/anthony/code/embark-framework/embark/lib/modules/webserver/server.js:42:12)
    at EventEmitter.emit (events.js:187:15)
    at pipeline.build (/Users/anthony/code/embark-framework/embark/lib/core/engine.js:121:23)
    at /Users/anthony/code/embark-framework/embark/node_modules/async/dist/async.js:473:16
    at next (/Users/anthony/code/embark-framework/embark/node_modules/async/dist/async.js:5329:29)
    at /Users/anthony/code/embark-framework/embark/node_modules/async/dist/async.js:969:16
    at fs.rename.err (/Users/anthony/code/embark-framework/embark/node_modules/fs-extra/lib/move/index.js:42:26)
    at FSReqWrap.oncomplete (fs.js:145:20)
```
