### PR TITLE
configure travis to test on both Linux and macOS

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,7 @@
 language: node_js
+os:
+  - linux
+  - osx
 node_js:
     - "8"
 addons:


### PR DESCRIPTION
## Overview

Since we support the "big 3" platforms — Linux, macOS, Windows — I think it makes sense to have travis run tests on both Linux and macOS, with appveyor responsible for testing on Windows. 

### Cool Spaceship Picture

![](https://vignette.wikia.nocookie.net/en.futurama/images/c/c1/Futurama_Planet_Express_spaceship.jpg)
