### PR TITLE
Resolve private key path instead of forcing inside dApp root

### DIFF
--- a/lib/utils/accountParser.js
+++ b/lib/utils/accountParser.js
@@ -4,6 +4,8 @@ const ethereumjsWallet = require('ethereumjs-wallet');
 const fs = require('../core/fs');
 const {getHexBalanceFromString} = require('../utils/utils');
 
+const path = require('path');
+
 class AccountParser {
   static parseAccountsConfig(accountsConfig, web3, logger) {
     let accounts = [];
@@ -49,7 +51,8 @@ class AccountParser {
     }
 
     if (accountConfig.privateKeyFile) {
-      let fileContent = fs.readFileSync(fs.dappPath(accountConfig.privateKeyFile)).toString();
+      let privateKeyFile = path.resolve(fs.dappPath(), accountConfig.privateKeyFile);
+      let fileContent = fs.readFileSync(privateKeyFile).toString();
       if (accountConfig.password) {
         try {
           fileContent = JSON.parse(fileContent);


### PR DESCRIPTION
## Overview
**TL;DR**
Change the way that the absolute path for `privateKeyFile` gets calculated.

| Value | Before | After |
| --- | --- | --- |
| `somedir/keyfile` | `/dapp/somedir/keyfile` | `/dapp/somedir/keyfile` |
| `/somedir/keyfile` | `/dapp/somedir/keyfile` | `/somedir/keyfile` |

### Cool Spaceship Picture
![SPACESHIIIIP](https://c1.staticflickr.com/6/5589/14299798257_4e6f0cd9a1_k.jpg)