### PR TITLE
Fetch IPFS dir hash deterministically

### DIFF
--- a/lib/modules/ipfs/upload.js
+++ b/lib/modules/ipfs/upload.js
@@ -2,8 +2,9 @@ require('colors');
 let async = require('async');
 let shelljs = require('shelljs');
 
-class IPFS {
+const path = require('path');
 
+class IPFS {
   constructor(options) {
     this.options = options;
     this.buildDir = options.buildDir || 'dist/';
@@ -35,11 +36,11 @@ class IPFS {
         });
       },
       function getHashFromOutput(result, callback) {
-        let rows = result.split("\n");
-        let dir_row = rows[rows.length - 2];
-        let dir_hash = dir_row.split(" ")[1];
+        const pattern = `added ([a-zA-Z1-9]{46}) ${path.basename(self.buildDir)}\n`;
+        const regex = RegExp(pattern, 'm');
+        const dirHash = result.match(regex)[1];
 
-        callback(null, dir_hash);
+        callback(null, dirHash);
       },
       function printUrls(dir_hash, callback) {
         console.log(("=== " + __("DApp available at") + " http://localhost:8080/ipfs/" + dir_hash + "/").green);


### PR DESCRIPTION
## Overview
**TL;DR**
This ensures that, regardless of the IPFS output order, we're always able to get the directory hash.

### Overview
In some cases, IPFS output interpolated progress bars that interfered with fetching the directory hash. Because the previous solution fetched the penultimate line, it sometimes fetched the wrong information. This way, we ensure that we're able to pick it regardless of the order in which the output comes with.

### Cool Spaceship Picture
![](http://cdn1us.denofgeek.com/sites/denofgeekus/files/styles/main_wide/public/2016/09/space-ships.png?itok=iRK6EVbV)