### PR TITLE
test node current release (10) in addition to node LTS release (8)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: node_js
 node_js:
     - "8"
+    - "10"
 addons:
     code_climate:
         repo_token: 7454b1a666015e244c384d19f48c34e35d1ae58c3aa428ec542f10bbcb848358

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,6 +1,8 @@
 # Test against the latest version of this Node.js version
 environment:
-  nodejs_version: "8"
+  matrix:
+    - nodejs_version: "8"
+    - nodejs_version: "10"
 
 # Install scripts. (runs after repo cloning)
 install:


### PR DESCRIPTION
## Overview

Revise `.travis.yml` and `appveyor.yml` so that tests are run on Node.js current (v10) and LTS (v8) releases.

### Cool Spaceship Picture

![](http://sparkleberrysprings.com/v-web/b2/images/entertainment/contact17.jpg)
