### PR TITLE
always add ens contracts source so abi definition is always available

### DIFF
--- a/lib/modules/ens/index.js
+++ b/lib/modules/ens/index.js
@@ -305,11 +305,11 @@ class ENS {
     config.privatenet = config.development;
     this.embark.registerContractConfiguration(config);
 
-    if (this.isDev || this.env === 'privatenet') {
+    //if (this.isDev || this.env === 'privatenet') {
       this.embark.events.request("config:contractsFiles:add", this.embark.pathToFile('./contracts/ENSRegistry.sol'));
       this.embark.events.request("config:contractsFiles:add", this.embark.pathToFile('./contracts/FIFSRegistrar.sol'));
       this.embark.events.request("config:contractsFiles:add", this.embark.pathToFile('./contracts/Resolver.sol'));
-    }
+    //}
   }
 
   addSetProvider(config) {


### PR DESCRIPTION
* fixes ens issues in environment in which the address is already defined

### Cool Spaceship Picture

![did_7_of_9_increase_audiences](https://i.pinimg.com/originals/d2/ac/9b/d2ac9b71fdd8477a87b77f79e588b525.jpg)