### PR TITLE
allow for '/' in branch name when handling github shortcuts

### DIFF
--- a/lib/utils/template_generator.js
+++ b/lib/utils/template_generator.js
@@ -127,8 +127,9 @@ class TemplateGenerator {
 
   getExternalProject(uri) {
     let url, folder;
-    if (uri.split('/').length === 2) {
-      //e.g embark-framework/embark
+    const regex = /^((git@)?(www\.)?github\.com\/)|(https?:\/\/)/;
+    if (!uri.match(regex) && uri.split('/').length >= 2) {
+      //e.g embark-framework/embark, embark-framework/embark#branch, embark-framework/embark#features/branch
       let repoPartAndBranch = uri.split('#');
       let repoPart = repoPartAndBranch[0];
       let branchName = (repoPartAndBranch.length === 2)? repoPartAndBranch[1] : "master";


### PR DESCRIPTION
## Overview

When running `embark new --template` and specifying a github shortcut like `status-im/dappcon-workshop-dapp#branch`, if the `branch` part contained `/` then it wasn't being handled correctly. This PR fixes it so that an arbitrary number of `/` characters may appear in the branch part.

### Cool Spaceship Picture

![](https://vignette.wikia.nocookie.net/memoryalpha/images/b/b0/Kreechta.jpg/revision/latest?cb=20161120032837&path-prefix=en)
