### PR TITLE
Filter out interfaces from the coverage report

### DIFF
--- a/lib/modules/coverage/contract_source.js
+++ b/lib/modules/coverage/contract_source.js
@@ -97,6 +97,11 @@ class ContractSource {
     }
   }
 
+  isInterface() {
+    return this.contractBytecode !== undefined &&
+      Object.values(this.contractBytecode).every((contractBytecode) => { return (Object.values(contractBytecode).length <= 1); });
+  }
+
   /*eslint complexity: ["error", 38]*/
   generateCodeCoverage(trace) {
     if(!this.ast || !this.contractBytecode) throw new Error('Error generating coverage: solc output was not assigned');

--- a/lib/modules/coverage/contract_sources.js
+++ b/lib/modules/coverage/contract_sources.js
@@ -60,6 +60,7 @@ class ContractSources {
     var coverageReport = {};
 
     for(var file in this.files) {
+      if(this.files[file].isInterface()) continue;
       coverageReport[file] = this.files[file].generateCodeCoverage(trace);
     }
 


### PR DESCRIPTION
## Overview
**TL;DR**
This PR will only filter out contract files from the coverage report that only contain interfaces. If, for instance, a contract file contains both an interface and runnable code, it will not be filtered out.

### Cool Spaceship Picture
![Narada (Star Trek)](
http://cdn-static.denofgeek.com/sites/denofgeek/files/styles/insert_main_wide_image/public/4/09//narada-star-trek.jpg?itok=SOnVTvMG)