### PR TITLE
Remove parallel contract deployment

### DIFF
--- a/lib/modules/deployment/index.js
+++ b/lib/modules/deployment/index.js
@@ -82,7 +82,7 @@ class DeployManager {
             });
 
             try {
-              async.auto(contractDeploys, function(_err, _results) {
+              async.auto(contractDeploys, 1, function(_err, _results) {
                 if (errors.length) {
                   _err = __("Error deploying contracts. Please fix errors to continue.");
                   self.logger.error(_err);


### PR DESCRIPTION
 ## Overview
**TL;DR**
Parallel contract deployment causes issues with the nonce increment in web3's providers. Removing parallel contract deployment is one, less ideal, solution, although it’s much much slower without it. 

This PR serves as a backup in case we cannot come up with a better solution.

### Cool Spaceship Picture
![https://vignette.wikia.nocookie.net/nondisneyvillains/images/7/77/Spripe_Spider.jpg/revision/latest?cb=20100826033110](https://vignette.wikia.nocookie.net/nondisneyvillains/images/7/77/Spripe_Spider.jpg/revision/latest?cb=20100826033110)
Sorry, this one is a gremlin!