### PR TITLE
add CORS URL for local ipfs' own server

### DIFF
--- a/lib/modules/storage/storageProcessesLauncher.js
+++ b/lib/modules/storage/storageProcessesLauncher.js
@@ -42,7 +42,6 @@ class StorageProcessesLauncher {
     // add all dapp connection storage
     if(this.storageConfig.enabled) {
       this.storageConfig.dappConnection.forEach(dappConn => {
-        if(dappConn.provider === storageName) return; // do not add CORS URL for ourselves
         if(dappConn.getUrl || dappConn.host){
 
           // if getUrl is specified in the config, that needs to be included in cors

--- a/lib/modules/storage/storageProcessesLauncher.js
+++ b/lib/modules/storage/storageProcessesLauncher.js
@@ -39,12 +39,12 @@ class StorageProcessesLauncher {
       else corsParts.push('http://localhost:8000');
     }
 
-    // add all dapp connection storage 
+    // add all dapp connection storage
     if(this.storageConfig.enabled) {
       this.storageConfig.dappConnection.forEach(dappConn => {
         if(dappConn.provider === storageName) return; // do not add CORS URL for ourselves
         if(dappConn.getUrl || dappConn.host){
-          
+
           // if getUrl is specified in the config, that needs to be included in cors
           // instead of the concatenated protocol://host:port
           if(dappConn.getUrl) {

--- a/lib/modules/storage/storageProcessesLauncher.js
+++ b/lib/modules/storage/storageProcessesLauncher.js
@@ -28,7 +28,7 @@ class StorageProcessesLauncher {
     });
   }
 
-  buildCors(storageName)
+  buildCors()
   {
     let corsParts = [];
     // add our webserver CORS
@@ -113,7 +113,7 @@ class StorageProcessesLauncher {
         action: constants.blockchain.init, options: {
           storageConfig: self.storageConfig,
           blockchainConfig: self.blockchainConfig,
-          cors: self.buildCors(storageName)
+          cors: self.buildCors()
         }
       });
 


### PR DESCRIPTION
## Overview

CORS URL for the local ipfs' own server (default `localhost:8080`) should be added, otherwise when the DApp is loaded from that server it raises CORS exceptions.

The XHR that fails is trying to talk to `localhost:5001`, the DApp having been served from `localhost:8080`. So the CORS being added for `localhost:8080` is really for the benefit of the ipfs process handling requests on `localhost:5001`.

### Cool Spaceship Picture

![](https://i.pinimg.com/originals/60/e6/dc/60e6dc7a0ae2d562cd690d65b701bd76.jpg)
