### PR TITLE
upload command should unconditionally start the "namingSystem" service

### DIFF
--- a/cmd/cmd_controller.js
+++ b/cmd/cmd_controller.js
@@ -487,9 +487,7 @@ class EmbarkController {
         engine.startService("deployment");
         engine.startService("storage");
         engine.startService("codeGenerator");
-        if(options.ensDomain) {
-          engine.startService("namingSystem");
-        }
+        engine.startService("namingSystem");
         callback();
       },
       function listLoadedPlugin(callback) {


### PR DESCRIPTION
## Overview

This PR has `embark upload` start the `namingSystem` service unconditionally.  `associateToENS` still happens conditionally, though the `--ens` cli option to activate it [is disabled on embark's `next` branch](https://github.com/embark-framework/embark/blob/next/cmd/cmd.js#L303).

If the `namingSystem` service is not started, then the code gen step for including `__embarkENS.setProvider = function (config) {...}` within `.embark/embark.js` never happens, and when the DApp is served from local ipfs `localhost:8080`, ENS is broken as a result.

### Cool Spaceship Picture

![](https://vignette.wikia.nocookie.net/starwars/images/6/63/FirstOrderDreadnought.png/revision/latest?cb=20170925003110)