### PR TITLE
Support if statements without a list of statements

### DIFF
--- a/lib/modules/coverage/contract_source.js
+++ b/lib/modules/coverage/contract_source.js
@@ -167,13 +167,13 @@ class ContractSource {
 
           let trueExpression = (node.trueBody && node.trueBody.statements && node.trueBody.statements[0]) || node.trueBody;
           if(trueExpression) {
-            children = children.concat([].concat(trueExpression));
+            children = children.concat(trueExpression);
             trueExpression._parent = {type: 'b', id: node.id, idx: 0};
           }
 
           let falseExpression = (node.falseBody && node.falseBody.statements && node.falseBody.statements[0]) || node.falseBody;
           if(falseExpression) {
-            children = children.concat([].concat(falseExpression));
+            children = children.concat(falseExpression);
             falseExpression._parent = {type: 'b', id: node.id, idx: 1};
           }
 

--- a/lib/modules/coverage/contract_source.js
+++ b/lib/modules/coverage/contract_source.js
@@ -162,19 +162,19 @@ class ContractSource {
             line: location.start.line
           };
 
-          children = [node.condition]
-            .concat(node.trueBody.statements);
-
-          if(node.falseBody) children = children.concat(node.falseBody.statements);
-
           markLocations = [declarationLocation];
+          children = [node.condition];
 
-          if(node.trueBody.statements[0]) {
-            node.trueBody.statements[0]._parent = {type: 'b', id: node.id, idx: 0};
+          let trueExpression = (node.trueBody && node.trueBody.statements && node.trueBody.statements[0]) || node.trueBody;
+          if(trueExpression) {
+            children = children.concat([].concat(trueExpression));
+            trueExpression._parent = {type: 'b', id: node.id, idx: 0};
           }
 
-          if(node.falseBody && node.falseBody.statements[0]) {
-            node.falseBody.statements[0]._parent = {type: 'b', id: node.id, idx: 1};
+          let falseExpression = (node.falseBody && node.falseBody.statements && node.falseBody.statements[0]) || node.falseBody;
+          if(falseExpression) {
+            children = children.concat([].concat(falseExpression));
+            falseExpression._parent = {type: 'b', id: node.id, idx: 1};
           }
 
           sourceMapToNodeType[node.src] = [{type: 'b', id: node.id, body: {loc: location}}];

--- a/lib/modules/coverage/contract_source.js
+++ b/lib/modules/coverage/contract_source.js
@@ -102,7 +102,7 @@ class ContractSource {
       Object.values(this.contractBytecode).every((contractBytecode) => { return (Object.values(contractBytecode).length <= 1); });
   }
 
-  /*eslint complexity: ["error", 38]*/
+  /*eslint complexity: ["error", 39]*/
   generateCodeCoverage(trace) {
     if(!this.ast || !this.contractBytecode) throw new Error('Error generating coverage: solc output was not assigned');
 

--- a/test_apps/coverage_app/contracts/branches.sol
+++ b/test_apps/coverage_app/contracts/branches.sol
@@ -32,4 +32,9 @@ contract Branches {
   function get() public view returns (uint retVal) {
     return storedData;
   }
+
+  function smallFunctionWithoutStatements() public view returns (uint retVal) {
+    if(false) return storedData * 10;
+    if(true) return storedData * 20;
+  }
 }

--- a/test_apps/coverage_app/test/branches_spec.js
+++ b/test_apps/coverage_app/test/branches_spec.js
@@ -28,4 +28,8 @@ contract("Branches", function() {
   it("should return the smaller number", function(done) {
     Branches.methods.smaller(10).send().then(() => { done(); });
   });
+
+  it("should not crash code coverage on `if` without statements", function(done) {
+    Branches.methods.smallFunctionWithoutStatements().call().then(() => { done(); });
+  });
 });


### PR DESCRIPTION
## Overview
**TL;DR**
Handle `if` statements without a body in the Solidity coverage report, ie.

```javascript
// this used to be supported
if(someCondition) {
  doThis();
  doThat();
}

// this crashed the coverage tool
if(someCondition) doTheOtherThing();
```

Fixes #909 

### Cool Spaceship Picture
![Predator](https://i.pinimg.com/originals/00/ac/d5/00acd501804def8d421e07c1d1270381.jpg)
