### PR TITLE
Remove undefined printed

### DIFF
--- a/cmd/cmd_controller.js
+++ b/cmd/cmd_controller.js
@@ -233,12 +233,7 @@ class EmbarkController {
           callback(err, true);
         });
       }
-    ], function (err, canExit) {
-      if (err) {
-        engine.logger.error(err.message);
-        engine.logger.debug(err.stack);
-      }
-
+    ], function (_err, canExit) {
       // TODO: this should be moved out and determined somewhere else
       if (canExit || !engine.config.contractsConfig.afterDeploy || !engine.config.contractsConfig.afterDeploy.length) {
         process.exit();


### PR DESCRIPTION
## Overview
**TL;DR**
The pipeline and the contracts compiler print the error themselves.
For example doing: `err || err.message` is causing double printing

### Cool Spaceship Picture

![5145e8d1d7a23a6634dff8f83fa2259c](https://user-images.githubusercontent.com/491074/46148075-2ac47580-c25f-11e8-9017-56204d4090e5.jpg)
