### PR TITLE
Add missing config

### DIFF
--- a/lib/core/engine.js
+++ b/lib/core/engine.js
@@ -197,7 +197,7 @@ class Engine {
     this.registerModule('deploytracker', {trackContracts: options.trackContracts});
     this.registerModule('specialconfigs');
     this.registerModule('console_listener', {ipc: self.ipc});
-    this.registerModule('contracts_manager');
+    this.registerModule('contracts_manager', {compileOnceOnly: options.compileOnceOnly});
     this.registerModule('deployment', {plugins: this.plugins, onlyCompile: options.onlyCompile});
 
     this.events.on('file-event', function (fileType) {

--- a/lib/modules/contracts_manager/index.js
+++ b/lib/modules/contracts_manager/index.js
@@ -83,7 +83,6 @@ class ContractsManager {
       function compileContracts(callback) {
         self.events.emit("status", __("Compiling..."));
         if (self.compileOnceOnly && self.compiledContracts && Object.keys(self.compiledContracts).length) {
-          // Only compile once for tests
           return callback();
         }
         self.events.request("compiler:contracts", self.contractsFiles, compilerOptions, function (err, compiledObject) {


### PR DESCRIPTION
The configuration for test is not passed via the engine

## Overview
**TL;DR**

It seems to be a missing config, it used to check for process.env.Test but when compileOnceOnly has been introduce, it hasn't been added to the engine

### Cool Spaceship Picture
![421bbc748341b9ade616f3c92e68ac29](https://user-images.githubusercontent.com/491074/46208217-ef3eaf80-c321-11e8-83ec-20a33ede86c9.png)