### PR TITLE
cmd, run_tests: Add --nobrowser option for runCoverage.

### DIFF
--- a/cmd/cmd.js
+++ b/cmd/cmd.js
@@ -273,6 +273,7 @@ class Cmd {
               '                       <endpoint> - ' + __('connect to and use the specified node'))
       .option('-d , --gasDetails', __('print the gas cost for each contract deployment when running the tests'))
       .option('-c , --coverage', __('generate a coverage report after running the tests (vm only)'))
+      .option('--nobrowser', __('do not start browser after coverage report is generated'))
       .option('--locale [locale]', __('language to use (default: en)'))
       .option('--loglevel [loglevel]', __('level of logging to display') + ' ["error", "warn", "info", "debug", "trace"]', /^(error|warn|info|debug|trace)$/i, 'warn')
       .description(__('run tests'))
@@ -293,7 +294,7 @@ class Cmd {
         checkDeps();
         i18n.setOrDetectLocale(options.locale);
         embark.runTests({file, loglevel: options.loglevel, gasDetails: options.gasDetails,
-          node: options.node, coverage: options.coverage});
+          node: options.node, coverage: options.coverage, noBrowser: options.nobrowser});
       });
   }
 

--- a/lib/tests/run_tests.js
+++ b/lib/tests/run_tests.js
@@ -140,6 +140,9 @@ module.exports = {
               console.log(`Coverage report created. You can find it here: ${fs.dappPath('coverage/__root__/index.html')}\n`);
               const opn = require('opn');
               const _next = () => { next(); };
+              if (options.noBrowser) {
+                return next();
+              }
               opn(fs.dappPath('coverage/__root__/index.html'), {wait: false})
                 .then(() => new Promise(resolve => setTimeout(resolve, 1000)))
                 .then(_next, _next);


### PR DESCRIPTION
## Overview
**TL;DR**
Do not start browser during coverage run when --nobrowser option is passed.

Refs: https://github.com/embark-framework/embark/issues/941

### Questions
None

### Review


### Cool Spaceship Picture
![rkhn](https://user-images.githubusercontent.com/20819151/46307149-72783380-c5b6-11e8-9bf4-f8034a849e57.gif)
