### PR TITLE
Make possible for deploy:contract:beforeDeploy plugin to modify arguments

### DIFF
--- a/lib/modules/deployment/contract_deployer.js
+++ b/lib/modules/deployment/contract_deployer.js
@@ -116,6 +116,11 @@ class ContractDeployer {
           next();
         });
       },
+      function applyArgumentPlugins(next) {
+        self.plugins.emitAndRunActionsForEvent('deploy:contract:arguments', {contract: contract}, (_params) => {
+          next();
+        });
+      },
       function _determineArguments(next) {
         self.determineArguments(params || contract.args, contract, accounts, (err, realArgs) => {
           if (err) {
@@ -189,7 +194,6 @@ class ContractDeployer {
 
   deployContract(contract, callback) {
     let self = this;
-    let contractParams = (contract.realArgs || contract.args).slice();
     let deployObject;
 
     async.waterfall([
@@ -239,6 +243,7 @@ class ContractDeployer {
       function createDeployObject(next) {
         let contractCode   = contract.code;
         let contractObject = self.blockchain.ContractObject({abi: contract.abiDefinition});
+        let contractParams = (contract.realArgs || contract.args).slice();
 
         try {
           const dataCode = contractCode.startsWith('0x') ? contractCode : "0x" + contractCode;


### PR DESCRIPTION
## Overview
We are using plugin that modifies bytecode and contract arguments based on future contract's address.
Contracts are tracked by name, constructor's bytecode and arguments.
New event "deploy:contract:arguments" added before "_determineArguments" to give plugin an opportunity to calculate dynamic arguments before DeployTracker's check, so arguments actually applied to contract in beforeDeploy will match arguments that DeployTracker checks against.

### Cool Spaceship Picture
spaceship.jpg