### PR TITLE
contract_deployer: Redeploy if track field is set to false.

### DIFF
--- a/lib/modules/deployment/contract_deployer.js
+++ b/lib/modules/deployment/contract_deployer.js
@@ -150,6 +150,11 @@ class ContractDeployer {
           if (!trackedContract.address) {
             return self.deployContract(contract, next);
           }
+          // deploy the contract regardless if track field is defined and set to false
+          if (trackedContract.track === false) {
+            self.logFunction(contract)(contract.className.bold.cyan + __(" will be redeployed").green);
+            return self.deployContract(contract, next);
+          }
 
           self.blockchain.getCode(trackedContract.address, function(_getCodeErr, codeInChain) {
             if (codeInChain !== "0x") {


### PR DESCRIPTION
## Overview
Always deploy the contract regardless if already deployed
when 'track' field in the contract configuration is specified
and set to false.

In line with #938 requirements:

* If a contract has the track field set to false, that contract
  will always deploy.
* If the track field is set to true, then the existing deployment
  tracking mechanism will be active for that contract.
* If the field is not set, it should be assumed to true by default

Refs: https://github.com/embark-framework/embark/issues/938

Example log:

```
========================
Welcome to Embark 3.2.1
========================
loaded plugins: embark-solc
ready to watch file changes
Starting Blockchain node in another process
IPFS node not found, attempting to start own node
Starting ipfs process
webserver available at http://localhost:8000
Blockchain node is ready
ipfs process started
Ethereum node detected..
embark-solc: compiling solidity contracts with command line solc...
IPFS node detected..
deploying contracts
SimpleStorage will be redeployed
deploying SimpleStorage with 136550 gas at the price of 1 Wei, estimated cost: 136550 Wei
SimpleStorage deployed at 0x0aF8b251C3A457A3eebA32323870F05007289962 using 134157 gas
finished deploying contracts
Deployment Done
```

### Questions

### Review


### Cool Spaceship Picture
![space1](https://user-images.githubusercontent.com/20819151/46523904-7abac200-c887-11e8-914d-e4bba7b84712.gif)
