### PR TITLE
chore(blockchainProcess): improve error message when blockchain clien…

### DIFF
--- a/lib/modules/blockchain_process/blockchainProcessLauncher.js
+++ b/lib/modules/blockchain_process/blockchainProcessLauncher.js
@@ -14,7 +14,7 @@ class BlockchainProcessLauncher {
   }
 
   processEnded(code) {
-    this.logger.error(__('Blockchain process ended before the end of this process. Code: %s', code));
+    this.logger.error(__('Blockchain process ended before the end of this process. Try running blockchain in a separate process using `$ embark blockchain`. Code: %s', code));
   }
 
   startBlockchainNode() {


### PR DESCRIPTION
…t exits early

In cases a blockchain client exits before Embark is done doing its work,
the current error message doesn't provide any pointers to why this
happened.

Running `$ embark blockchain` separately could yield more information by
the underlying process.

**Steps to reproduce:**

There's probably smarter ways but I've made `blockchainProcess` to emit an exit event after a timeout within ready handler:

```
  blockchainReady() {
    blockchainProcess.send({result: constants.blockchain.blockchainReady});

    setTimeout(() => {
      this.blockchainExit();
    }, 15000)
  }
```

Then: `$ embark run [--nobrowser]`

### Cool Spaceship Picture
