### PR TITLE
cli shim

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ templates/demo/node_modules/
 templates/boilerplate/dist/
 docs/_build
 docs/utils/__pycache_
+test/cli_shim/.cid
 test_apps/test_app/dist/
 test_apps/test_app/.embark/development/
 test_apps/test_app/config/production/password

--- a/bin/embark
+++ b/bin/embark
@@ -1,15 +1,1023 @@
 #!/usr/bin/env node
 
-try {
-  eval('let __nodeTest = 123;');
-} catch(e) {
-  if (e.name === 'SyntaxError') {
-    console.error("unsupported version of NodeJS. Make sure you are running nodejs 8.11.3 or above");
+/* global __dirname __filename process require */
 
-    process.exit();
+// This script doesn't use JS syntax, packages, or APIs *un*supported by any
+// node version >=4.0.0, so unsupported versions from v4.0.0+ will get the
+// intended error messages. A future version of this script could instead rely
+// on babel to achieve the same goal.
+// See: https://node.green/
+
+// KEY ASSUMPTION: for a DApp to be valid, from embark's perspective, it must
+// have a parsable embark.json file in its top-level directory; if that
+// requirement changes in the future then this script must be revised.
+// Hypothetical example of such a change: embark config info may be included in
+// package.json under `{"embark": {...}}` -or- stored in an embark.json file.
+
+function main() {
+  whenNoShim();
+  var invoked = thisEmbark();
+  var embarkJson = findEmbarkJson();
+  var dappPath = embarkJson.dirname;
+  process.chdir(dappPath);
+  process.env.DAPP_PATH = dappPath;
+  process.env.PWD = dappPath;
+
+  /* attempt to find a "local" embark in or above but not below dappPath
+
+     let `dappPath/(([../])*)bin/embark` be a "containing" embark
+
+     let `dappPath/(([../])*)node_modules/embark/bin/embark` be an "installed"
+     embark
+
+     if containing and installed embarks are both found, and if containing
+     embark is higher in the dir structure than installed embark, then
+     containing embark will be selected
+
+     according to the rule above: if an installed embark is found within a
+     containing embark's own node_modules (that would be odd), installed embark
+     will be selected
+
+     invoked embark may find itself as local embark, but that is detected by
+     comparing `binrealpath` props to avoid double-checking and infinite loops
+
+     if no local embark is found then cmd execution will use invoked embark */
+
+  var containing = findBinContaining(dappPath, invoked);
+  var installed = findBinInstalled(dappPath, invoked);
+  var local = selectLocal(containing, installed);
+  var pkgJson = findPkgJson(dappPath, embarkJson, local);
+  process.env.PKG_PATH = pkgJson.dirname;
+  var embark = select(invoked, local);
+  process.env.EMBARK_PATH = embark.pkgDir;
+  embark.exec();
+}
+
+// -----------------------------------------------------------------------------
+
+var checkDeps = require('check-dependencies');
+var npmlog = require('npmlog');
+var findUp = require('find-up');
+var fs = require('fs');
+var path = require('path');
+var parseJsonWithErrors = require('json-parse-better-errors');
+var pkgUp = require('pkg-up');
+var semver = require('semver');
+var subdir = require('subdir');
+
+// -- embark bins --------------------------------------------------------------
+
+function EmbarkBin(binpath, kind) {
+  this.binpath = binpath;
+  this.binrealpath = undefined;
+  this.kind = kind || 'invoked';
+  this.pkgDir = undefined;
+  this.pkgJson = undefined;
+}
+
+EmbarkBin.prototype.exec = function () {
+  var Cmd = require('../cmd/cmd');
+  var cli = new Cmd();
+  if(_logged) { console[this.loglevel](); }
+  cli.process(process.argv);
+};
+
+EmbarkBin.prototype.handle = function () {
+  this.setup();
+  this.log();
+  return this;
+};
+
+EmbarkBin.prototype.log = function () {
+  this.logMissingBin();
+  this.pkgJson.log();
+};
+
+EmbarkBin.prototype.loglevel = 'info';
+
+EmbarkBin.prototype.logMissingBin = function () {
+  var oldlevel = this.loglevel;
+  this.loglevel = 'error';
+  if (!this.binrealpath) {
+    reportMissingFile_EmbarkBin(this.binpath, this.kind, this.loglevel);
+    exitWithError();
+  }
+  this.loglevel = oldlevel;
+};
+
+EmbarkBin.prototype.setBinrealpath = function () {
+  if (this.binpath) {
+    this.binrealpath = realpath(this.binpath);
+  }
+};
+
+EmbarkBin.prototype.setPkgDir = function () {
+  if (this.binpath) {
+    this.pkgDir = path.join(path.dirname(this.binpath), '..');
+  }
+};
+
+EmbarkBin.prototype.setPkgJson = function () {
+  if (this.binrealpath) {
+    this.pkgJson = (
+      new PkgJsonEmbark(
+        path.join(this.pkgDir, 'package.json'),
+        this.kind
+      )
+    );
+    var upNodeModules = findUp.sync(
+      'node_modules',
+      {cwd: path.join(path.dirname(this.binrealpath), '../..')}
+    );
+    this.pkgJson.noCheck = (
+      upNodeModules ? subdir(upNodeModules, this.binrealpath) : false
+    );
+    this.pkgJson.setup();
+  }
+};
+
+EmbarkBin.prototype.setup = function () {
+  this.setBinrealpath();
+  this.setPkgDir();
+  this.setPkgJson();
+  return this;
+};
+
+// -- bin/embark :: local ------------------------------------------------------
+
+function EmbarkBinLocal(binpath, invokedEmbark) {
+  EmbarkBin.call(this, binpath, 'local');
+  this.invokedEmbark = invokedEmbark;
+}
+setupProto(EmbarkBinLocal, EmbarkBin);
+
+EmbarkBinLocal.prototype.exec = function () {
+  process.argv[1] = this.binpath;
+  process.env.EMBARK_NO_SHIM = true;
+  console[this.loglevel]();
+  require(this.binpath);
+};
+
+EmbarkBinLocal.prototype.log = function () {
+  if (this.binrealpath !== this.invokedEmbark.binrealpath) {
+    this.logSwitching();
+    EmbarkBin.prototype.log.call(this);
+  }
+};
+
+EmbarkBinLocal.prototype.logSwitching = function () {
+  reportSwitching(
+    this.invokedEmbark.binpath,
+    this.binpath,
+    this.loglevel,
+    this.invokedEmbark.pkgJson.pkg,
+    this.pkgJson.pkg
+  );
+};
+
+EmbarkBinLocal.prototype.setup = function () {
+  this.setBinrealpath();
+  this.setPkgDir();
+  if (this.binrealpath !== this.invokedEmbark.binrealpath) {
+    this.setPkgJson();
+  }
+  return this;
+};
+
+// -- bin/embark :: local containing -------------------------------------------
+
+function EmbarkBinLocalContaining(binpath, invokedEmbark) {
+  EmbarkBinLocal.call(this, binpath, invokedEmbark);
+}
+setupProto(EmbarkBinLocalContaining, EmbarkBinLocal);
+
+EmbarkBinLocalContaining.prototype.setPkgJson = function () {
+  if (this.binrealpath) {
+    this.pkgJson = (
+      new PkgJsonEmbark(
+        path.join(this.pkgDir, 'package.json'),
+        this.kind
+      )
+    );
+    this.pkgJson.noCheck = false;
+    this.pkgJson.setup();
+  }
+};
+
+// -- bin/embark :: local installed --------------------------------------------
+
+function EmbarkBinLocalInstalled(binpath, invokedEmbark) {
+  EmbarkBinLocal.call(this, binpath, invokedEmbark);
+}
+setupProto(EmbarkBinLocalInstalled, EmbarkBinLocal);
+
+EmbarkBinLocalInstalled.prototype.log = function () {
+  EmbarkBinLocal.prototype.log.call(this);
+  this.pkgJsonLocalExpected.log();
+};
+
+EmbarkBinLocalInstalled.prototype.setPkgJson = function () {
+  if (this.binrealpath) {
+    this.pkgJson = (
+      new PkgJsonEmbark(
+        path.join(this.pkgDir, 'package.json'),
+        this.kind
+      )
+    ).setup();
+  }
+};
+
+EmbarkBinLocalInstalled.prototype.setPkgJsonLocalExpected = function () {
+  if (this.binrealpath) {
+    this.pkgJsonLocalExpected = (
+      new PkgJsonLocalExpected(path.join(this.pkgDir, '../../package.json'))
+    ).setup();
+  }
+};
+
+EmbarkBinLocalInstalled.prototype.setup = function () {
+  EmbarkBinLocal.prototype.setup.call(this);
+  this.setPkgJsonLocalExpected();
+  return this;
+};
+
+// -- finders ------------------------------------------------------------------
+
+function findBin(dappPath, find, invoked, Kind) {
+  return (
+    new Kind(
+      findUp.sync(find, {cwd: dappPath}),
+      invoked
+    )
+  ).setup();
+}
+
+function findBinContaining(dappPath, invoked) {
+  return findBin(
+    dappPath,
+    'bin/embark',
+    invoked,
+    EmbarkBinLocalContaining
+  );
+}
+
+function findBinInstalled(dappPath, invoked) {
+  return findBin(
+    dappPath,
+    'node_modules/embark/bin/embark',
+    invoked,
+    EmbarkBinLocalInstalled
+  );
+}
+
+function findEmbarkJson() {
+  // findUp search begins in process.cwd() by default, but embark.json could
+  // be in a subdir if embark was invoked via `npm run` (which changes cwd to
+  // package.json's dir) and the package.json is in a dir above the top-level
+  // DApp dir; so start at INIT_CWD if that has been set (by npm, presumably)
+  // See: https://docs.npmjs.com/cli/run-script
+  var startDir = initCwd();
+  return (new EmbarkJson(
+    findUp.sync('embark.json', {cwd: startDir}) ||
+      path.join(startDir, 'embark.json'),
+    process.argv[2]
+  )).handle();
+}
+
+function findPkgJson(dappPath, embarkJson, local) {
+  var skipDirs = [];
+  if (local) {
+    if (local instanceof EmbarkBinLocalContaining) {
+      skipDirs.push(local.pkgDir);
+    }
+    if (local instanceof EmbarkBinLocalInstalled) {
+      skipDirs.push(local.pkgJsonLocalExpected.dirname);
+    }
+  }
+  var closest, dir, found;
+  var startDir = dappPath;
+
+  /* let `dappPath/(([../])*)package.json` be a "local" package.json */
+
+  // look for local package.json files starting from dappPath
+  function stop() {
+    found = pkgUp.sync(startDir);
+    if (found && !closest) {
+      closest = found;
+    }
+    dir = found ? path.dirname(found) : found;
+    var stop = !dir || !isDappCmd(embarkJson.cmd);
+    if (!stop) {
+      startDir = path.join(dir, '..');
+    }
+    return stop;
+  }
+  while (!stop()) {
+    if (skipDirs.indexOf(dir) === -1) {
+      (new PkgJsonLocal(found)).handle();
+    }
+  }
+  if (isDappCmd(embarkJson.cmd) && !closest) {
+    var loglevel = 'error';
+    reportMissingFile(path.join(dappPath, 'package.json'), loglevel);
+    reportMissingFile_DappJson(embarkJson.cmd, loglevel, 'package', 'in or above');
+    exitWithError();
+  }
+  return (
+    closest || (new PkgJsonLocal(path.join(startDir, 'package.json'))).setup()
+  );
+}
+
+// -- json files ---------------------------------------------------------------
+
+function Json(filepath) {
+  this.filepath = filepath;
+  this.dirname = undefined;
+  this.json = undefined;
+  this.realpath = undefined;
+}
+
+Json.prototype.handle = function () {
+  this.setup();
+  this.log();
+  return this;
+};
+
+Json.prototype.log = function () {
+  this.logMissingFile();
+  this.logUnparsable();
+};
+
+Json.prototype.loglevel = 'warn';
+
+Json.prototype.logMissingFile = function () {
+  var missing;
+  if (!this.realpath) {
+    missing = true;
+    reportMissingFile(this.filepath, this.loglevel);
+  }
+  return missing;
+};
+
+Json.prototype.logUnparsable = function () {
+  var unparsable;
+  if (this.realpath && !this.json) {
+    unparsable = true;
+    reportUnparsable(this.filepath, this.loglevel);
+  }
+  return unparsable;
+};
+
+Json.prototype.setDirname = function () {
+  if (this.filepath) {
+    this.dirname = path.dirname(this.filepath);
+  }
+};
+
+Json.prototype.setJson = function () {
+  if (this.realpath) {
+    this.json = parseJson(this.filepath);
+  }
+};
+
+Json.prototype.setRealpath = function () {
+  if (this.filepath) {
+    this.realpath = realpath(this.filepath);
+  }
+};
+
+Json.prototype.setup = function () {
+  this.setDirname();
+  this.setRealpath();
+  this.setJson();
+  return this;
+};
+
+// -- embark.json --------------------------------------------------------------
+
+function EmbarkJson(filepath, cmd) {
+  Json.call(this, filepath);
+  this.cmd = cmd;
+}
+setupProto(EmbarkJson, Json);
+
+EmbarkJson.prototype.loglevel = 'error';
+
+EmbarkJson.prototype.log = function () {
+  this.logMissingFile();
+  this.logUnparsable();
+};
+
+EmbarkJson.prototype.logMissingFile = function () {
+  if (isDappCmd(this.cmd) && Json.prototype.logMissingFile.call(this)) {
+    reportMissingFile_DappJson(this.cmd, this.loglevel, 'embark', 'in');
+    exitWithError();
+  }
+};
+
+EmbarkJson.prototype.logUnparsable = function () {
+  if (isDappCmd(this.cmd) && Json.prototype.logUnparsable.call(this)) {
+    reportUnparsable_EmbarkJson(this.loglevel);
+    exitWithError();
+  }
+};
+
+// -- package.json -------------------------------------------------------------
+
+function PkgJson(filepath) {
+  Json.call(this, filepath);
+}
+setupProto(PkgJson, Json);
+
+PkgJson.prototype.log = function () {
+  Json.prototype.log.call(this);
+  this.logPkgErrors();
+};
+
+PkgJson.prototype.logPkgErrors = function () {
+  var pkgErrors;
+  if (this.json && !this.noCheck) {
+    pkgErrors = checkPkg(this.dirname);
+  }
+  if (pkgErrors) {
+    reportPkgErrors(pkgErrors, this.filepath, this.loglevel);
+  }
+  return !!pkgErrors;
+};
+
+PkgJson.prototype.noCheck = false;
+
+// -- package.json :: of an embark pkg -----------------------------------------
+
+function PkgJsonEmbark(filepath, kind) {
+  PkgJson.call(this, filepath);
+  this.kind = kind || 'invoked';
+  this.nodeRange = undefined;
+  this.pkg = undefined;
+  this.version = undefined;
+}
+setupProto(PkgJsonEmbark, PkgJson);
+
+PkgJsonEmbark.prototype.log = function () {
+  PkgJson.prototype.log.call(this);
+  this.logMissingVersion();
+  this.logUnsupportedNode();
+};
+
+PkgJsonEmbark.prototype.loglevel = 'error';
+
+PkgJsonEmbark.prototype.logMissingFile = function () {
+  if (PkgJson.prototype.logMissingFile.call(this)) {
+    reportMissingFile_PkgJsonEmbark(this.kind, this.loglevel);
+    exitWithError();
+  }
+};
+
+PkgJsonEmbark.prototype.logMissingVersion = function () {
+  var missing;
+  var oldlevel = this.loglevel;
+  this.loglevel = 'warn';
+  if (this.json && this.version === '???') {
+    missing = true;
+    reportMissingVersion(this.filepath, this.kind, this.loglevel);
+  }
+  this.loglevel = oldlevel;
+  return missing;
+};
+
+PkgJsonEmbark.prototype.logPkgErrors = function () {
+  if (PkgJson.prototype.logPkgErrors.call(this)) {
+    reportPkgErrors_PkgJsonEmbark(this.dirname, this.kind, this.loglevel);
+    exitWithError();
+  }
+};
+
+PkgJsonEmbark.prototype.logUnparsable = function () {
+  if (PkgJson.prototype.logUnparsable.call(this)) {
+    reportUnparsable_PkgJsonEmbark(this.kind, this.loglevel);
+    exitWithError();
+  }
+};
+
+PkgJsonEmbark.prototype.logUnsupportedNode = function () {
+  var missing;
+  var range = this.nodeRange;
+  if (typeof range === 'undefined') {
+    missing = true;
+    range = this.nodeRangeDefault;
+  }
+  var bad;
+  range = parseRange(range);
+  if (!range) {
+    bad = true;
+    range = this.nodeRangeDefault;
+  }
+  var procVer = semver.clean(process.version);
+  this.loglevel = 'error';
+  if (!semver.satisfies(procVer, range)) {
+    reportUnsupportedNode(
+      bad,
+      this.filepath,
+      this.kind,
+      this.loglevel,
+      missing,
+      this.nodeRangeDefault,
+      this.nodeRange,
+      this.pkg,
+      procVer,
+      range
+    );
+    exitWithError();
+  }
+};
+
+PkgJsonEmbark.prototype.noCheck = true;
+
+// if changing to the `nodeRangeDefault` value, make sure to manually check
+// that it's a valid semver range, otherwise fallback logic in the prototype
+// methods won't be reliable
+PkgJsonEmbark.prototype.nodeRangeDefault = semver.Range('>=8.11.3').range;
+
+PkgJsonEmbark.prototype.setNodeRange = function () {
+  if (isObject(this.json) &&
+      this.json.hasOwnProperty('engines') &&
+      this.json.engines.hasOwnProperty('node')) {
+    this.nodeRange = this.json.engines.node;
+  }
+};
+
+PkgJsonEmbark.prototype.setPkg = function () {
+  this.pkg = `embark@${this.version}`;
+};
+
+PkgJsonEmbark.prototype.setVersion = function () {
+  if (isObject(this.json) && this.json.version) {
+    this.version = this.json.version;
+  } else {
+    this.version = '???';
+  }
+};
+
+PkgJsonEmbark.prototype.setup = function () {
+  PkgJson.prototype.setup.call(this);
+  this.setVersion();
+  this.setPkg();
+  this.setNodeRange();
+  return this;
+};
+
+// -- package.json :: local to DApp --------------------------------------------
+
+function PkgJsonLocal(filepath) {
+  PkgJson.call(this, filepath);
+}
+setupProto(PkgJsonLocal, PkgJson);
+
+PkgJsonLocal.prototype.loglevel = 'error';
+
+PkgJsonLocal.prototype.logMissingFile = function () {
+  if (PkgJson.prototype.logMissingFile.call(this)) {
+    reportMissingFile_PkgJsonLocal(this.loglevel);
+    exitWithError();
+  }
+};
+
+PkgJsonLocal.prototype.logPkgErrors = function () {
+  if (PkgJson.prototype.logPkgErrors.call(this)) {
+    reportPkgErrors_PkgJsonLocal(this.dirname, this.loglevel);
+    exitWithError();
+  }
+};
+
+PkgJsonLocal.prototype.logUnparsable = function () {
+  if (PkgJson.prototype.logUnparsable.call(this)) {
+    reportUnparsable_PkgJsonLocal(this.loglevel);
+    exitWithError();
+  }
+};
+
+// -- package.json :: local to DApp, expected by local installed embark --------
+
+function PkgJsonLocalExpected(filepath) {
+  PkgJsonLocal.call(this, filepath);
+  this.embarkDep = undefined;
+}
+setupProto(PkgJsonLocalExpected, PkgJsonLocal);
+
+PkgJsonLocalExpected.prototype.log = function () {
+  PkgJsonLocal.prototype.log.call(this);
+  this.logMissingEmbarkDep();
+};
+
+PkgJsonLocalExpected.prototype.logMissingEmbarkDep = function () {
+  if (this.json && !this.embarkDep) {
+    reportMissingEmbarkDep(this.filepath, this.dirname, this.loglevel);
+    exitWithError();
+  }
+};
+
+PkgJsonLocalExpected.prototype.logMissingFile = function () {
+  // PkgJson.prototype NOT PkgJsonLocal.prototype
+  if (PkgJson.prototype.logMissingFile.call(this)) {
+    reportMissingFile_PkgJsonLocalExpected(this.dirname, this.loglevel);
+    exitWithError();
+  }
+};
+
+PkgJsonLocalExpected.prototype.setEmbarkDep = function () {
+  if (isObject(this.json)) {
+    if (this.json.dependencies) {
+      this.embarkDep = this.json.dependencies.embark;
+    } else if (this.json.devDependencies) {
+      this.embarkDep = this.json.devDependencies.embark;
+    }
+  }
+};
+
+PkgJsonLocalExpected.prototype.setup = function () {
+  PkgJsonLocal.prototype.setup.call(this);
+  this.setEmbarkDep();
+  return this;
+};
+
+// -- loggers ------------------------------------------------------------------
+
+var embarklog = npmlog;
+embarklog.heading = 'embark';
+
+var _logged = false;
+function logged(which) {
+  var embarklog_which = embarklog[which];
+  return function () {
+    _logged = true;
+    embarklog_which.apply(embarklog, arguments);
+  };
+}
+
+embarklog.error = logged('error');
+embarklog.info = logged('info');
+embarklog.warn = logged('warn');
+
+function blankLineMaybe(which) {
+  if (_logged) {
+    console[which]();
   }
 }
 
-var Cmd = require('../cmd/cmd');
-var cli = new Cmd();
-cli.process(process.argv);
+var isNpmRun = process.env.hasOwnProperty('npm_lifecycle_script');
+function blankLineTrailingMaybe(which) {
+  if (isNpmRun) {
+    console[which]();
+  }
+}
+
+// -- processors ---------------------------------------------------------------
+
+function checkPkg(pkgDir, scopes) {
+  var errors;
+  try {
+    var config = {packageDir: pkgDir};
+    if (scopes) {
+      config.scopeList = scopes;
+    }
+    var checked = checkDeps.sync(config);
+    if (checked.error.length) {
+      errors = checked.error;
+    }
+  } finally {
+    // eslint-disable-next-line no-unsafe-finally
+    return errors;
+  }
+}
+
+function parseJson(filepath) {
+  var parsed;
+  try {
+    parsed = require(filepath);
+  } finally {
+    // eslint-disable-next-line no-unsafe-finally
+    return parsed;
+  }
+}
+
+function parseRange(range) {
+  var parsed;
+  try {
+    parsed = semver.Range(range).range;
+  } finally {
+    // eslint-disable-next-line no-unsafe-finally
+    return parsed;
+  }
+}
+
+function realpath(filepath) {
+  var resolved;
+  try {
+    resolved = fs.realpathSync(filepath);
+  } finally {
+    // eslint-disable-next-line no-unsafe-finally
+    return resolved;
+  }
+}
+
+function thisEmbark() {
+  return (new EmbarkBin(__filename)).handle();
+}
+
+function whenNoShim() {
+  var noShim = false;
+  if (process.env.EMBARK_NO_SHIM) {
+    noShim = true;
+  }
+  var idx = process.argv.indexOf('--no-shim');
+  if (idx > -1) {
+    process.argv.splice(idx, 1);
+    noShim = true;
+  }
+  if (noShim) {
+    EmbarkBin.prototype.exec();
+  }
+}
+
+// -- reporters ----------------------------------------------------------------
+
+function reportMissingEmbarkDep(filepath, dirname, loglevel) {
+  blankLineMaybe(loglevel);
+  embarklog[loglevel]('file', filepath);
+  embarklog[loglevel](
+    '',
+    [
+      `Could not find embark specified in "dependencies" or "devDependencies" of local package.json file`,
+      `But embark was found in node_modules relative to that file:`,
+      `${dirname}/node_modules/embark/`
+    ].join('\n')
+  );
+}
+
+function reportMissingFile(filepath, loglevel) {
+  try {
+    // force the exception
+    fs.realpathSync(filepath);
+  } catch (e) {
+    blankLineMaybe(loglevel);
+    embarklog[loglevel]('path', e.path);
+    embarklog[loglevel]('code', e.code);
+    embarklog[loglevel]('errno', e.errno);
+    embarklog[loglevel]('syscall', e.syscall);
+    embarklog[loglevel](e.code.toLowerCase(), e.message);
+  }
+}
+
+function reportMissingFile_DappJson(cmd, loglevel, kind, where) {
+  blankLineMaybe(loglevel);
+  embarklog[loglevel](
+    '',
+    `Could not locate your DApp's ${kind}.json file`
+  );
+  embarklog[loglevel](
+    '',
+    `Make sure a valid ${kind}.json file exists ${where} your DApp's top-level directory`
+  );
+  embarklog[loglevel](
+    '',
+    `Embark command '${cmd}' can only be used inside a valid DApp directory structure`
+  );
+}
+
+function reportMissingFile_EmbarkBin(binpath, kind, loglevel) {
+  reportMissingFile(binpath, loglevel);
+  console[loglevel]();
+  embarklog[loglevel](
+    '',
+    [
+      `Could not resolve ${kind} embark command path with require('fs').realpathSync`,
+      `Maybe a broken symbolic link?`
+    ].join('\n')
+  );
+}
+
+function reportMissingFile_PkgJsonEmbark(kind, loglevel) {
+  console[loglevel]();
+  embarklog[loglevel](
+    '',
+    `Could not locate ${kind} embark's package.json file`
+  );
+}
+
+function reportMissingFile_PkgJsonLocal(loglevel) {
+  console[loglevel]();
+  embarklog[loglevel](
+    '',
+    [
+      `Could not resolve local package.json path with require('fs').realpathSync`,
+      `Maybe a broken symbolic link?`
+    ].join('\n')
+  );
+}
+
+function reportMissingFile_PkgJsonLocalExpected(dirname, loglevel) {
+  console[loglevel]();
+  embarklog[loglevel](
+    '',
+    [
+      `Could not find expected local package.json relative to embark found in:`,
+      `${dirname}/node_modules/embark/`
+    ].join('\n')
+  );
+}
+
+function reportMissingVersion(filepath, kind, loglevel) {
+  blankLineMaybe(loglevel);
+  embarklog[loglevel]('file', filepath);
+  embarklog[loglevel](
+    '',
+    `No version is specified in ${kind} embark's package.json file`
+  );
+}
+
+function reportPkgErrors(errors, filepath, loglevel) {
+  blankLineMaybe(loglevel);
+  embarklog[loglevel]('file', filepath);
+  embarklog[loglevel]('code', `EPKGCHK`);
+  embarklog[loglevel]('package', errors.join('\n'));
+}
+
+function reportPkgErrors_PkgJsonEmbark(dirname, kind, loglevel) {
+  console[loglevel]();
+  embarklog[loglevel](
+    '',
+    [
+      `Dependencies are missing relative to ${kind} embark's package.json in:`,
+      `${dirname}/`
+    ].join('\n')
+  );
+}
+
+function reportPkgErrors_PkgJsonLocal(dirname, loglevel) {
+  console[loglevel]();
+  embarklog[loglevel](
+    '',
+    [
+      `Dependencies are missing relative to local package.json in:`,
+      `${dirname}/`
+    ].join('\n')
+  );
+}
+
+function reportSwitching(binpathFrom, binpathTo, loglevel, pkgFrom, pkgTo) {
+  blankLineMaybe(loglevel);
+  embarklog[loglevel]('invoked', binpathFrom);
+  embarklog[loglevel]('located', binpathTo);
+  embarklog[loglevel](
+    '',
+    `Switching from ${pkgFrom} to ${pkgTo}`
+  );
+}
+
+function reportUnparsable(filepath, loglevel) {
+  try {
+    // force the exception
+    parseJsonWithErrors(stripBOM(fs.readFileSync(filepath)));
+  } catch (e) {
+    var basename = path.basename(filepath);
+    blankLineMaybe(loglevel);
+    embarklog[loglevel]('file', filepath);
+    embarklog[loglevel]('code', `EJSONPARSE`);
+    embarklog[loglevel]('JSON parse', `Failed to parse json`);
+    embarklog[loglevel]('JSON parse', e.message);
+    embarklog[loglevel]('JSON parse', `Failed to parse ${basename} data.`);
+    embarklog[loglevel]('JSON parse', `${basename} must be actual JSON, not just JavaScript.`);
+  }
+}
+
+function reportUnparsable_EmbarkJson(loglevel) {
+  console[loglevel]();
+  embarklog[loglevel]('', `Could not parse your DApp's embark.json file`);
+}
+
+function reportUnparsable_PkgJsonEmbark(kind, loglevel) {
+  console[loglevel]();
+  embarklog[loglevel](
+    `Could not parse ${kind} embark's package.json file`
+  );
+}
+
+function reportUnparsable_PkgJsonLocal(loglevel) {
+  embarklog[loglevel]('', `Could not parse a local package.json file`);
+}
+
+function reportUnsupportedNode(
+  bad, filepath, kind, loglevel, missing, rangeDefault, rangeSupplied, pkg,
+  procVer, range) {
+  blankLineMaybe(loglevel);
+  function report(qual, invalid) {
+    embarklog[loglevel]('file', filepath);
+    embarklog[loglevel](
+      'engine',
+      `package.json of ${kind} ${pkg} does not specify ${qual ? qual : ''}%j`,
+      {engines: {node: '[semver]'}}
+    );
+    if (invalid) {
+      embarklog[loglevel](
+        'engine',
+        `Specified: %j`, {engines: {node: rangeSupplied}}
+      );
+    }
+    embarklog[loglevel](
+      'engine',
+      `Defaulting to: %j`, {engines: {node: rangeDefault}}
+    );
+    console[loglevel]();
+  }
+  if (missing) { report(); }
+  if (bad) { report('a valid ', true); }
+  embarklog[loglevel]('notsup', `Unsupported runtime`);
+  embarklog[loglevel](
+    'notsup',
+    `${kind} ${pkg} is not compatible with your version of node`
+  );
+  embarklog[loglevel]('notsup', `Required:`, range);
+  embarklog[loglevel]('notsup', `Actual:`, procVer);
+}
+
+// -- selectors ----------------------------------------------------------------
+
+function select(invoked, local) {
+  var embark;
+  if (local && local.binrealpath !== invoked.binrealpath) {
+    embark = local;
+  } else {
+    embark = invoked;
+  }
+  return embark;
+}
+
+function selectLocal(containing, installed) {
+  var local;
+  if (containing.binrealpath &&
+      (!installed.binrealpath ||
+       subdir(
+         installed.pkgJsonLocalExpected.dirname,
+         containing.pkgDir
+       ))) {
+    local = containing;
+  }
+  if (installed.binrealpath &&
+      (!containing.binrealpath ||
+       subdir(containing.pkgDir, installed.pkgDir))) {
+    local = installed;
+  }
+  if (local) { local.log(); }
+  return local;
+}
+
+// -- utils --------------------------------------------------------------------
+
+function exitWithError(code) {
+  blankLineTrailingMaybe('error');
+  process.exit(code || 1);
+}
+
+function initCwd() {
+  var initCwd = process.env.INIT_CWD || process.cwd();
+  // allow for env override
+  initCwd = process.env.DAPP_PATH || initCwd;
+  return initCwd;
+}
+
+function isDappCmd(cmd) {
+  return [
+    undefined,
+    '-V',
+    '--version',
+    '-h',
+    '--help',
+    'new',
+    'demo',
+    'version',
+    'help'
+  ].indexOf(cmd) === -1;
+}
+
+function isObject(val) {
+  // eslint-disable-next-line no-eq-null
+  return val != null && typeof val === 'object' && Array.isArray(val) === false;
+}
+
+function setupProto(Sub, Par) {
+  Sub.prototype = Object.create(Par.prototype);
+  Sub.prototype.constructor = Sub;
+}
+
+// See: https://github.com/npm/cli/blob/v6.4.1/lib/utils/parse-json.js#L16
+function stripBOM (content) {
+  content = content.toString();
+  if (content.charCodeAt(0) === 0xFEFF) {
+    content = content.slice(1);
+  }
+  return content;
+}
+
+// -----------------------------------------------------------------------------
+
+main();

--- a/bin/embark
+++ b/bin/embark
@@ -729,11 +729,6 @@ function whenNoShim() {
   if (process.env.EMBARK_NO_SHIM) {
     noShim = true;
   }
-  var idx = process.argv.indexOf('--no-shim');
-  if (idx > -1) {
-    process.argv.splice(idx, 1);
-    noShim = true;
-  }
   if (noShim) {
     EmbarkBin.prototype.exec();
   }

--- a/cmd/cmd.js
+++ b/cmd/cmd.js
@@ -20,6 +20,11 @@ if (!process.env.EMBARK_PATH) {
   process.env.EMBARK_PATH = utils.joinPath(__dirname, '..');
 }
 
+// set the anchor for embark's fs.pkgPath()
+if (!process.env.PKG_PATH) {
+  process.env.PKG_PATH = process.env.PWD;
+}
+
 // NOTE: setting NODE_PATH at runtime won't effect lookup behavior in the
 // current process, but will take effect in child processes; this enables
 // lookup of *global* embark's own node_modules from within dapp scripts (such

--- a/cmd/cmd.js
+++ b/cmd/cmd.js
@@ -37,25 +37,6 @@ process.env.NODE_PATH = utils.joinPath(process.env.EMBARK_PATH, 'node_modules') 
 
 process.env.DEFAULT_DIAGRAM_PATH = utils.joinPath(process.env.DAPP_PATH, 'diagram.svg');
 
-function checkDeps() {
-  const path = require('path');
-  try {
-    const dappPackage = require(path.join(process.cwd(), 'package.json'));
-    require(path.join(process.cwd(), 'embark.json')); // Make sure we are in a Dapp
-    require('check-dependencies')(dappPackage, (state) => {
-      if (state.status) {
-        require('colors');
-        console.error('\nMissing dependencies. Please run npm install'.red);
-        process.exit();
-      }
-      return true;
-    });
-  } catch (_e) {
-    // We are not in a Dapp
-    return true;
-  }
-}
-
 class Cmd {
   constructor() {
     program.version(embark.version);
@@ -155,7 +136,6 @@ class Cmd {
       .option('--pipeline [pipeline]', __('webpack config to use (default: production)'))
       .description(__('deploy and build dapp at ') + 'dist/ (default: development)')
       .action(function(env, _options) {
-        checkDeps();
         i18n.setOrDetectLocale(_options.locale);
         _options.env = env || 'development';
         _options.logFile = _options.logfile; // fix casing
@@ -183,7 +163,6 @@ class Cmd {
       .option('--pipeline [pipeline]', __('webpack config to use (default: development)'))
       .description(__('run dapp (default: %s)', 'development'))
       .action(function(env, options) {
-        checkDeps();
         i18n.setOrDetectLocale(options.locale);
         const nullify = (v) => (!v || typeof v !== 'string') ? null : v;
         embark.run({
@@ -212,7 +191,6 @@ class Cmd {
       .option('--pipeline [pipeline]', __('webpack config to use (default: development)'))
       .description(__('Start the Embark console'))
       .action(function(env, options) {
-        checkDeps();
         i18n.setOrDetectLocale(options.locale);
         embark.console({
           env: env || 'development',
@@ -232,7 +210,6 @@ class Cmd {
       .option('--locale [locale]', __('language to use (default: en)'))
       .description(__('run blockchain server (default: %s)', 'development'))
       .action(function(env, options) {
-        checkDeps();
         i18n.setOrDetectLocale(options.locale);
         embark.initConfig(env || 'development', {
           embarkConfig: 'embark.json',
@@ -255,7 +232,6 @@ class Cmd {
       .option('--locale [locale]', __('language to use (default: en)'))
 
       .action(function(env, options) {
-        checkDeps();
         i18n.setOrDetectLocale(options.locale);
         embark.initConfig(env || 'development', {
           embarkConfig: 'embark.json',
@@ -299,7 +275,6 @@ class Cmd {
           options.outputHelp();
           process.exit(1);
         }
-        checkDeps();
         i18n.setOrDetectLocale(options.locale);
         embark.runTests({file, solc:options.solc, loglevel: options.loglevel, gasDetails: options.gasDetails,
           node: options.node, coverage: options.coverage, noBrowser: options.nobrowser});
@@ -317,7 +292,6 @@ class Cmd {
       .option('--pipeline [pipeline]', __('webpack config to use (default: production)'))
       .description(__('Upload your dapp to a decentralized storage') + '.')
       .action(function(env, _options) {
-        checkDeps();
         i18n.setOrDetectLocale(_options.locale);
         if (env === "ipfs" || env === "swarm") {
           console.warn(("did you mean " + "embark upload".bold + " ?").underline);
@@ -343,7 +317,6 @@ class Cmd {
       .option('--output [svgfile]', __('filepath to output SVG graph to (default: %s)', process.env['DEFAULT_DIAGRAM_PATH']))
       .description(__('generates documentation based on the smart contracts configured'))
       .action(function(env, options) {
-        checkDeps();
         i18n.setOrDetectLocale(options.locale);
         embark.graph({
           env: env || 'development',

--- a/lib/core/fs.js
+++ b/lib/core/fs.js
@@ -106,6 +106,10 @@ function dappPath() {
   return anchoredPath('DAPP_PATH', ...arguments);
 }
 
+function pkgPath() {
+  return anchoredPath('PKG_PATH', ...arguments);
+}
+
 function createWriteStream() {
   return fs.createWriteStream.apply(fs.createWriteStream, arguments);
 }
@@ -156,6 +160,7 @@ module.exports = {
   removeSync,
   embarkPath,
   dappPath,
+  pkgPath,
   createWriteStream,
   tmpDir,
   copyPreserve

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -836,7 +836,7 @@
     },
     "@sinonjs/formatio": {
       "version": "2.0.0",
-      "resolved": "http://registry.npmjs.org/@sinonjs/formatio/-/formatio-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/@sinonjs/formatio/-/formatio-2.0.0.tgz",
       "integrity": "sha512-ls6CAMA6/5gG+O/IdsBcblvnd8qcO/l1TYoNeAzp3wcISOxlPXQEus0mLcdwazEkWjaBdaJ3TaxmNgCLWwvWzg==",
       "dev": true,
       "requires": {
@@ -1132,7 +1132,7 @@
       "dependencies": {
         "acorn": {
           "version": "3.3.0",
-          "resolved": "http://registry.npmjs.org/acorn/-/acorn-3.3.0.tgz",
+          "resolved": "https://registry.npmjs.org/acorn/-/acorn-3.3.0.tgz",
           "integrity": "sha1-ReN/s56No/JbruP/U2niu18iAXo="
         }
       }
@@ -1165,7 +1165,7 @@
     },
     "ambi": {
       "version": "2.5.0",
-      "resolved": "http://registry.npmjs.org/ambi/-/ambi-2.5.0.tgz",
+      "resolved": "https://registry.npmjs.org/ambi/-/ambi-2.5.0.tgz",
       "integrity": "sha1-fI43K+SIkRV+fOoBy2+RQ9H3QiA=",
       "requires": {
         "editions": "^1.1.1",
@@ -1491,7 +1491,7 @@
         },
         "chalk": {
           "version": "1.1.3",
-          "resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
           "requires": {
             "ansi-styles": "^2.2.1",
@@ -1786,57 +1786,57 @@
     },
     "babel-plugin-syntax-async-functions": {
       "version": "6.13.0",
-      "resolved": "http://registry.npmjs.org/babel-plugin-syntax-async-functions/-/babel-plugin-syntax-async-functions-6.13.0.tgz",
+      "resolved": "https://registry.npmjs.org/babel-plugin-syntax-async-functions/-/babel-plugin-syntax-async-functions-6.13.0.tgz",
       "integrity": "sha1-ytnK0RkbWtY0vzCuCHI5HgZHvpU="
     },
     "babel-plugin-syntax-async-generators": {
       "version": "6.13.0",
-      "resolved": "http://registry.npmjs.org/babel-plugin-syntax-async-generators/-/babel-plugin-syntax-async-generators-6.13.0.tgz",
+      "resolved": "https://registry.npmjs.org/babel-plugin-syntax-async-generators/-/babel-plugin-syntax-async-generators-6.13.0.tgz",
       "integrity": "sha1-a8lj67FuzLrmuStZbrfzXDQqi5o="
     },
     "babel-plugin-syntax-class-constructor-call": {
       "version": "6.18.0",
-      "resolved": "http://registry.npmjs.org/babel-plugin-syntax-class-constructor-call/-/babel-plugin-syntax-class-constructor-call-6.18.0.tgz",
+      "resolved": "https://registry.npmjs.org/babel-plugin-syntax-class-constructor-call/-/babel-plugin-syntax-class-constructor-call-6.18.0.tgz",
       "integrity": "sha1-nLnTn+Q8hgC+yBRkVt3L1OGnZBY="
     },
     "babel-plugin-syntax-class-properties": {
       "version": "6.13.0",
-      "resolved": "http://registry.npmjs.org/babel-plugin-syntax-class-properties/-/babel-plugin-syntax-class-properties-6.13.0.tgz",
+      "resolved": "https://registry.npmjs.org/babel-plugin-syntax-class-properties/-/babel-plugin-syntax-class-properties-6.13.0.tgz",
       "integrity": "sha1-1+sjt5oxf4VDlixQW4J8fWysJ94="
     },
     "babel-plugin-syntax-decorators": {
       "version": "6.13.0",
-      "resolved": "http://registry.npmjs.org/babel-plugin-syntax-decorators/-/babel-plugin-syntax-decorators-6.13.0.tgz",
+      "resolved": "https://registry.npmjs.org/babel-plugin-syntax-decorators/-/babel-plugin-syntax-decorators-6.13.0.tgz",
       "integrity": "sha1-MSVjtNvePMgGzuPkFszurd0RrAs="
     },
     "babel-plugin-syntax-do-expressions": {
       "version": "6.13.0",
-      "resolved": "http://registry.npmjs.org/babel-plugin-syntax-do-expressions/-/babel-plugin-syntax-do-expressions-6.13.0.tgz",
+      "resolved": "https://registry.npmjs.org/babel-plugin-syntax-do-expressions/-/babel-plugin-syntax-do-expressions-6.13.0.tgz",
       "integrity": "sha1-V0d1YTmqJtOQ0JQQsDdEugfkeW0="
     },
     "babel-plugin-syntax-dynamic-import": {
       "version": "6.18.0",
-      "resolved": "http://registry.npmjs.org/babel-plugin-syntax-dynamic-import/-/babel-plugin-syntax-dynamic-import-6.18.0.tgz",
+      "resolved": "https://registry.npmjs.org/babel-plugin-syntax-dynamic-import/-/babel-plugin-syntax-dynamic-import-6.18.0.tgz",
       "integrity": "sha1-jWomIpyDdFqZgqRBBRVyyqF5sdo="
     },
     "babel-plugin-syntax-exponentiation-operator": {
       "version": "6.13.0",
-      "resolved": "http://registry.npmjs.org/babel-plugin-syntax-exponentiation-operator/-/babel-plugin-syntax-exponentiation-operator-6.13.0.tgz",
+      "resolved": "https://registry.npmjs.org/babel-plugin-syntax-exponentiation-operator/-/babel-plugin-syntax-exponentiation-operator-6.13.0.tgz",
       "integrity": "sha1-nufoM3KQ2pUoggGmpX9BcDF4MN4="
     },
     "babel-plugin-syntax-export-extensions": {
       "version": "6.13.0",
-      "resolved": "http://registry.npmjs.org/babel-plugin-syntax-export-extensions/-/babel-plugin-syntax-export-extensions-6.13.0.tgz",
+      "resolved": "https://registry.npmjs.org/babel-plugin-syntax-export-extensions/-/babel-plugin-syntax-export-extensions-6.13.0.tgz",
       "integrity": "sha1-cKFITw+QiaToStRLrDU8lbmxJyE="
     },
     "babel-plugin-syntax-function-bind": {
       "version": "6.13.0",
-      "resolved": "http://registry.npmjs.org/babel-plugin-syntax-function-bind/-/babel-plugin-syntax-function-bind-6.13.0.tgz",
+      "resolved": "https://registry.npmjs.org/babel-plugin-syntax-function-bind/-/babel-plugin-syntax-function-bind-6.13.0.tgz",
       "integrity": "sha1-SMSV8Xe98xqYHnMvVa3AvdJgH0Y="
     },
     "babel-plugin-syntax-object-rest-spread": {
       "version": "6.13.0",
-      "resolved": "http://registry.npmjs.org/babel-plugin-syntax-object-rest-spread/-/babel-plugin-syntax-object-rest-spread-6.13.0.tgz",
+      "resolved": "https://registry.npmjs.org/babel-plugin-syntax-object-rest-spread/-/babel-plugin-syntax-object-rest-spread-6.13.0.tgz",
       "integrity": "sha1-/WU28rzhODb/o6VFjEkDpZe7O/U="
     },
     "babel-plugin-syntax-trailing-function-commas": {
@@ -2455,7 +2455,7 @@
     },
     "babelify": {
       "version": "7.3.0",
-      "resolved": "http://registry.npmjs.org/babelify/-/babelify-7.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/babelify/-/babelify-7.3.0.tgz",
       "integrity": "sha1-qlau3nBn/XvVSWZu4W3ChQh+iOU=",
       "requires": {
         "babel-core": "^6.0.14",
@@ -2553,10 +2553,6 @@
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/big.js/-/big.js-3.2.0.tgz",
       "integrity": "sha512-+hN/Zh2D08Mx65pZ/4g5bsmNiZUuChDiQfTUQ7qJr4/kuopCr88xZsAXv6mBoZEsUI4OuGHlX59qE94K2mMW8Q=="
-    },
-    "bignumber.js": {
-      "version": "git+https://github.com/frozeman/bignumber.js-nolookahead.git#57692b3ecfc98bbdd6b3a516cb2353652ea49934",
-      "from": "git+https://github.com/frozeman/bignumber.js-nolookahead.git"
     },
     "binary-extensions": {
       "version": "1.11.0",
@@ -2712,7 +2708,7 @@
     },
     "browserify-aes": {
       "version": "1.2.0",
-      "resolved": "http://registry.npmjs.org/browserify-aes/-/browserify-aes-1.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/browserify-aes/-/browserify-aes-1.2.0.tgz",
       "integrity": "sha512-+7CHXqGuspUn/Sl5aO7Ea0xWGAtETPXNSAjHo48JfLdPWcMng33Xe4znFvQweqc/uzk5zSOI3H52CYnjCfb5hA==",
       "requires": {
         "buffer-xor": "^1.0.3",
@@ -2746,7 +2742,7 @@
     },
     "browserify-rsa": {
       "version": "4.0.1",
-      "resolved": "http://registry.npmjs.org/browserify-rsa/-/browserify-rsa-4.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/browserify-rsa/-/browserify-rsa-4.0.1.tgz",
       "integrity": "sha1-IeCr+vbyApzy+vsTNWenAdQTVSQ=",
       "requires": {
         "bn.js": "^4.1.0",
@@ -2818,7 +2814,7 @@
     },
     "buffer": {
       "version": "3.6.0",
-      "resolved": "http://registry.npmjs.org/buffer/-/buffer-3.6.0.tgz",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-3.6.0.tgz",
       "integrity": "sha1-pyyTb3e5a/UvX357RnGAYoVR3vs=",
       "requires": {
         "base64-js": "0.0.8",
@@ -2857,7 +2853,7 @@
     },
     "buffer-loader": {
       "version": "0.0.1",
-      "resolved": "http://registry.npmjs.org/buffer-loader/-/buffer-loader-0.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/buffer-loader/-/buffer-loader-0.0.1.tgz",
       "integrity": "sha1-TWd8qS3YiTEIeLAqL7z6txICTPI="
     },
     "buffer-to-arraybuffer": {
@@ -3045,7 +3041,7 @@
       "dependencies": {
         "minimist": {
           "version": "1.2.0",
-          "resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
           "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
         }
       }
@@ -3533,7 +3529,7 @@
     },
     "create-hash": {
       "version": "1.2.0",
-      "resolved": "http://registry.npmjs.org/create-hash/-/create-hash-1.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/create-hash/-/create-hash-1.2.0.tgz",
       "integrity": "sha512-z00bCGNHDG8mHAkP7CtT1qVu+bFQUPjYq/4Iv3C3kWjTFV10zIjfSoeqXo9Asws8gwSHDGj/hl2u4OGIjapeCg==",
       "requires": {
         "cipher-base": "^1.0.1",
@@ -3545,7 +3541,7 @@
     },
     "create-hmac": {
       "version": "1.1.7",
-      "resolved": "http://registry.npmjs.org/create-hmac/-/create-hmac-1.1.7.tgz",
+      "resolved": "https://registry.npmjs.org/create-hmac/-/create-hmac-1.1.7.tgz",
       "integrity": "sha512-MJG9liiZ+ogc4TzUwuvbER1JRdgvUFSB5+VR/g5h82fGaIRWMWddtKBHi7/sVhfjQZ6SehlyhvQYrcYkaUIpLg==",
       "requires": {
         "cipher-base": "^1.0.3",
@@ -3924,7 +3920,7 @@
     },
     "deglob": {
       "version": "1.1.2",
-      "resolved": "http://registry.npmjs.org/deglob/-/deglob-1.1.2.tgz",
+      "resolved": "https://registry.npmjs.org/deglob/-/deglob-1.1.2.tgz",
       "integrity": "sha1-dtV3wl/j9zKUEqK1nq3qV6xQDj8=",
       "requires": {
         "find-root": "^1.0.0",
@@ -4018,7 +4014,7 @@
     },
     "diffie-hellman": {
       "version": "5.0.3",
-      "resolved": "http://registry.npmjs.org/diffie-hellman/-/diffie-hellman-5.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/diffie-hellman/-/diffie-hellman-5.0.3.tgz",
       "integrity": "sha512-kqag/Nl+f3GwyK25fhUMYj81BUOrZ9IuJsjIcDE5icNM9FJHAVm3VcUDxdLPoQtTuUylWm6ZIknYJwwaPxsUzg==",
       "requires": {
         "bn.js": "^4.1.0",
@@ -4065,7 +4061,7 @@
     },
     "duplexer": {
       "version": "0.1.1",
-      "resolved": "http://registry.npmjs.org/duplexer/-/duplexer-0.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/duplexer/-/duplexer-0.1.1.tgz",
       "integrity": "sha1-rOb/gIwc5mtX0ev5eXessCM0z8E="
     },
     "duplexer3": {
@@ -4619,7 +4615,7 @@
         },
         "table": {
           "version": "4.0.3",
-          "resolved": "http://registry.npmjs.org/table/-/table-4.0.3.tgz",
+          "resolved": "https://registry.npmjs.org/table/-/table-4.0.3.tgz",
           "integrity": "sha512-S7rnFITmBH1EnyKcvxBh1LjYeQMmnZtCXSEbHcH6S0NoKit24ZuFO/T1vDcLdYsLQkM188PVVhQmzKIuThNkKg==",
           "dev": true,
           "requires": {
@@ -4661,12 +4657,12 @@
     },
     "eslint-config-standard": {
       "version": "5.3.1",
-      "resolved": "http://registry.npmjs.org/eslint-config-standard/-/eslint-config-standard-5.3.1.tgz",
+      "resolved": "https://registry.npmjs.org/eslint-config-standard/-/eslint-config-standard-5.3.1.tgz",
       "integrity": "sha1-WRyWkVF0QTL1YdO5FagS6kE/5JA="
     },
     "eslint-config-standard-jsx": {
       "version": "1.2.1",
-      "resolved": "http://registry.npmjs.org/eslint-config-standard-jsx/-/eslint-config-standard-jsx-1.2.1.tgz",
+      "resolved": "https://registry.npmjs.org/eslint-config-standard-jsx/-/eslint-config-standard-jsx-1.2.1.tgz",
       "integrity": "sha1-DRmxcF8K1INj7yqLv6cd8BLZibM="
     },
     "eslint-import-resolver-node": {
@@ -4745,7 +4741,7 @@
     },
     "eslint-plugin-import": {
       "version": "2.2.0",
-      "resolved": "http://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.2.0.tgz",
       "integrity": "sha1-crowb60wXWfEgWNIpGmaQimsi04=",
       "requires": {
         "builtin-modules": "^1.1.1",
@@ -4821,12 +4817,12 @@
     },
     "eslint-plugin-promise": {
       "version": "1.3.2",
-      "resolved": "http://registry.npmjs.org/eslint-plugin-promise/-/eslint-plugin-promise-1.3.2.tgz",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-promise/-/eslint-plugin-promise-1.3.2.tgz",
       "integrity": "sha1-/OMy1vX/UjIApTdwSGPsPCQiunw="
     },
     "eslint-plugin-react": {
       "version": "5.2.2",
-      "resolved": "http://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-5.2.2.tgz",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-5.2.2.tgz",
       "integrity": "sha1-fbBo4fVIf2hx5N7vNqOBwwPqwWE=",
       "requires": {
         "doctrine": "^1.2.2",
@@ -4835,7 +4831,7 @@
     },
     "eslint-plugin-standard": {
       "version": "1.3.3",
-      "resolved": "http://registry.npmjs.org/eslint-plugin-standard/-/eslint-plugin-standard-1.3.3.tgz",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-standard/-/eslint-plugin-standard-1.3.3.tgz",
       "integrity": "sha1-owhUUVI0MedvQJxwy4+U4yvw7H8="
     },
     "eslint-scope": {
@@ -4865,7 +4861,7 @@
       "dependencies": {
         "acorn": {
           "version": "3.3.0",
-          "resolved": "http://registry.npmjs.org/acorn/-/acorn-3.3.0.tgz",
+          "resolved": "https://registry.npmjs.org/acorn/-/acorn-3.3.0.tgz",
           "integrity": "sha1-ReN/s56No/JbruP/U2niu18iAXo="
         }
       }
@@ -5140,7 +5136,7 @@
         },
         "uuid": {
           "version": "2.0.1",
-          "resolved": "http://registry.npmjs.org/uuid/-/uuid-2.0.1.tgz",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-2.0.1.tgz",
           "integrity": "sha1-wqMN7bPlNdcsz4LjQ5QaULqFM6w="
         }
       }
@@ -5206,7 +5202,7 @@
     },
     "events": {
       "version": "1.1.1",
-      "resolved": "http://registry.npmjs.org/events/-/events-1.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/events/-/events-1.1.1.tgz",
       "integrity": "sha1-nr23Y1rQmccNzEwqH1AEKI6L2SQ="
     },
     "evp_bytestokey": {
@@ -5299,7 +5295,7 @@
     },
     "express": {
       "version": "4.16.3",
-      "resolved": "http://registry.npmjs.org/express/-/express-4.16.3.tgz",
+      "resolved": "https://registry.npmjs.org/express/-/express-4.16.3.tgz",
       "integrity": "sha1-avilAjUNsyRuzEvs9rWjTSL37VM=",
       "requires": {
         "accepts": "~1.3.5",
@@ -5467,14 +5463,14 @@
       "dependencies": {
         "typechecker": {
           "version": "2.0.8",
-          "resolved": "http://registry.npmjs.org/typechecker/-/typechecker-2.0.8.tgz",
+          "resolved": "https://registry.npmjs.org/typechecker/-/typechecker-2.0.8.tgz",
           "integrity": "sha1-6D2oS7ZMWEzLNFg4V2xAsDN9uC4="
         }
       }
     },
     "external-editor": {
       "version": "2.2.0",
-      "resolved": "http://registry.npmjs.org/external-editor/-/external-editor-2.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/external-editor/-/external-editor-2.2.0.tgz",
       "integrity": "sha512-bSn6gvGxKt+b7+6TKEv1ZycHleA7aHhRHyAqJyp5pbUFuYYNIzpZnQDk7AsYckyWdEnTeAnay0aCy2aV6iTk9A==",
       "dev": true,
       "requires": {
@@ -5552,7 +5548,7 @@
       "dependencies": {
         "typechecker": {
           "version": "2.0.8",
-          "resolved": "http://registry.npmjs.org/typechecker/-/typechecker-2.0.8.tgz",
+          "resolved": "https://registry.npmjs.org/typechecker/-/typechecker-2.0.8.tgz",
           "integrity": "sha1-6D2oS7ZMWEzLNFg4V2xAsDN9uC4="
         }
       }
@@ -5919,24 +5915,24 @@
       "dependencies": {
         "abbrev": {
           "version": "1.1.1",
-          "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
+          "resolved": false,
           "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==",
           "optional": true
         },
         "ansi-regex": {
           "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+          "resolved": false,
           "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
         },
         "aproba": {
           "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/aproba/-/aproba-1.2.0.tgz",
+          "resolved": false,
           "integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw==",
           "optional": true
         },
         "are-we-there-yet": {
           "version": "1.1.4",
-          "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.4.tgz",
+          "resolved": false,
           "integrity": "sha1-u13KOCu5TwXhUZQ3PRb9O6HKEQ0=",
           "optional": true,
           "requires": {
@@ -5946,12 +5942,12 @@
         },
         "balanced-match": {
           "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
+          "resolved": false,
           "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
         },
         "brace-expansion": {
           "version": "1.1.11",
-          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+          "resolved": false,
           "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
           "requires": {
             "balanced-match": "^1.0.0",
@@ -5960,34 +5956,34 @@
         },
         "chownr": {
           "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.0.1.tgz",
+          "resolved": false,
           "integrity": "sha1-4qdQQqlVGQi+vSW4Uj1fl2nXkYE=",
           "optional": true
         },
         "code-point-at": {
           "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
+          "resolved": false,
           "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c="
         },
         "concat-map": {
           "version": "0.0.1",
-          "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+          "resolved": false,
           "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
         },
         "console-control-strings": {
           "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
+          "resolved": false,
           "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4="
         },
         "core-util-is": {
           "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+          "resolved": false,
           "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
           "optional": true
         },
         "debug": {
           "version": "2.6.9",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "resolved": false,
           "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
           "optional": true,
           "requires": {
@@ -5996,25 +5992,25 @@
         },
         "deep-extend": {
           "version": "0.5.1",
-          "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.5.1.tgz",
+          "resolved": false,
           "integrity": "sha512-N8vBdOa+DF7zkRrDCsaOXoCs/E2fJfx9B9MrKnnSiHNh4ws7eSys6YQE4KvT1cecKmOASYQBhbKjeuDD9lT81w==",
           "optional": true
         },
         "delegates": {
           "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
+          "resolved": false,
           "integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o=",
           "optional": true
         },
         "detect-libc": {
           "version": "1.0.3",
-          "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-1.0.3.tgz",
+          "resolved": false,
           "integrity": "sha1-+hN8S9aY7fVc1c0CrFWfkaTEups=",
           "optional": true
         },
         "fs-minipass": {
           "version": "1.2.5",
-          "resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-1.2.5.tgz",
+          "resolved": false,
           "integrity": "sha512-JhBl0skXjUPCFH7x6x61gQxrKyXsxB5gcgePLZCwfyCGGsTISMoIeObbrvVeP6Xmyaudw4TT43qV2Gz+iyd2oQ==",
           "optional": true,
           "requires": {
@@ -6023,13 +6019,13 @@
         },
         "fs.realpath": {
           "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+          "resolved": false,
           "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
           "optional": true
         },
         "gauge": {
           "version": "2.7.4",
-          "resolved": "https://registry.npmjs.org/gauge/-/gauge-2.7.4.tgz",
+          "resolved": false,
           "integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
           "optional": true,
           "requires": {
@@ -6045,7 +6041,7 @@
         },
         "glob": {
           "version": "7.1.2",
-          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
+          "resolved": false,
           "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
           "optional": true,
           "requires": {
@@ -6059,13 +6055,13 @@
         },
         "has-unicode": {
           "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
+          "resolved": false,
           "integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk=",
           "optional": true
         },
         "iconv-lite": {
           "version": "0.4.21",
-          "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.21.tgz",
+          "resolved": false,
           "integrity": "sha512-En5V9za5mBt2oUA03WGD3TwDv0MKAruqsuxstbMUZaj9W9k/m1CV/9py3l0L5kw9Bln8fdHQmzHSYtvpvTLpKw==",
           "optional": true,
           "requires": {
@@ -6074,7 +6070,7 @@
         },
         "ignore-walk": {
           "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/ignore-walk/-/ignore-walk-3.0.1.tgz",
+          "resolved": false,
           "integrity": "sha512-DTVlMx3IYPe0/JJcYP7Gxg7ttZZu3IInhuEhbchuqneY9wWe5Ojy2mXLBaQFUQmo0AW2r3qG7m1mg86js+gnlQ==",
           "optional": true,
           "requires": {
@@ -6083,7 +6079,7 @@
         },
         "inflight": {
           "version": "1.0.6",
-          "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+          "resolved": false,
           "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
           "optional": true,
           "requires": {
@@ -6093,18 +6089,18 @@
         },
         "inherits": {
           "version": "2.0.3",
-          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+          "resolved": false,
           "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
         },
         "ini": {
           "version": "1.3.5",
-          "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.5.tgz",
+          "resolved": false,
           "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==",
           "optional": true
         },
         "is-fullwidth-code-point": {
           "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+          "resolved": false,
           "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
           "requires": {
             "number-is-nan": "^1.0.0"
@@ -6112,13 +6108,13 @@
         },
         "isarray": {
           "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+          "resolved": false,
           "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
           "optional": true
         },
         "minimatch": {
           "version": "3.0.4",
-          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+          "resolved": false,
           "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
           "requires": {
             "brace-expansion": "^1.1.7"
@@ -6126,12 +6122,12 @@
         },
         "minimist": {
           "version": "0.0.8",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+          "resolved": false,
           "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
         },
         "minipass": {
           "version": "2.2.4",
-          "resolved": "https://registry.npmjs.org/minipass/-/minipass-2.2.4.tgz",
+          "resolved": false,
           "integrity": "sha512-hzXIWWet/BzWhYs2b+u7dRHlruXhwdgvlTMDKC6Cb1U7ps6Ac6yQlR39xsbjWJE377YTCtKwIXIpJ5oP+j5y8g==",
           "requires": {
             "safe-buffer": "^5.1.1",
@@ -6140,7 +6136,7 @@
         },
         "minizlib": {
           "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-1.1.0.tgz",
+          "resolved": false,
           "integrity": "sha512-4T6Ur/GctZ27nHfpt9THOdRZNgyJ9FZchYO1ceg5S8Q3DNLCKYy44nCZzgCJgcvx2UM8czmqak5BCxJMrq37lA==",
           "optional": true,
           "requires": {
@@ -6149,7 +6145,7 @@
         },
         "mkdirp": {
           "version": "0.5.1",
-          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+          "resolved": false,
           "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
           "requires": {
             "minimist": "0.0.8"
@@ -6157,13 +6153,13 @@
         },
         "ms": {
           "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "resolved": false,
           "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
           "optional": true
         },
         "needle": {
           "version": "2.2.0",
-          "resolved": "https://registry.npmjs.org/needle/-/needle-2.2.0.tgz",
+          "resolved": false,
           "integrity": "sha512-eFagy6c+TYayorXw/qtAdSvaUpEbBsDwDyxYFgLZ0lTojfH7K+OdBqAF7TAFwDokJaGpubpSGG0wO3iC0XPi8w==",
           "optional": true,
           "requires": {
@@ -6174,7 +6170,7 @@
         },
         "node-pre-gyp": {
           "version": "0.10.0",
-          "resolved": "https://registry.npmjs.org/node-pre-gyp/-/node-pre-gyp-0.10.0.tgz",
+          "resolved": false,
           "integrity": "sha512-G7kEonQLRbcA/mOoFoxvlMrw6Q6dPf92+t/l0DFSMuSlDoWaI9JWIyPwK0jyE1bph//CUEL65/Fz1m2vJbmjQQ==",
           "optional": true,
           "requires": {
@@ -6192,7 +6188,7 @@
         },
         "nopt": {
           "version": "4.0.1",
-          "resolved": "https://registry.npmjs.org/nopt/-/nopt-4.0.1.tgz",
+          "resolved": false,
           "integrity": "sha1-0NRoWv1UFRk8jHUFYC0NF81kR00=",
           "optional": true,
           "requires": {
@@ -6202,13 +6198,13 @@
         },
         "npm-bundled": {
           "version": "1.0.3",
-          "resolved": "https://registry.npmjs.org/npm-bundled/-/npm-bundled-1.0.3.tgz",
+          "resolved": false,
           "integrity": "sha512-ByQ3oJ/5ETLyglU2+8dBObvhfWXX8dtPZDMePCahptliFX2iIuhyEszyFk401PZUNQH20vvdW5MLjJxkwU80Ow==",
           "optional": true
         },
         "npm-packlist": {
           "version": "1.1.10",
-          "resolved": "https://registry.npmjs.org/npm-packlist/-/npm-packlist-1.1.10.tgz",
+          "resolved": false,
           "integrity": "sha512-AQC0Dyhzn4EiYEfIUjCdMl0JJ61I2ER9ukf/sLxJUcZHfo+VyEfz2rMJgLZSS1v30OxPQe1cN0LZA1xbcaVfWA==",
           "optional": true,
           "requires": {
@@ -6218,7 +6214,7 @@
         },
         "npmlog": {
           "version": "4.1.2",
-          "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-4.1.2.tgz",
+          "resolved": false,
           "integrity": "sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==",
           "optional": true,
           "requires": {
@@ -6230,18 +6226,18 @@
         },
         "number-is-nan": {
           "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
+          "resolved": false,
           "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0="
         },
         "object-assign": {
           "version": "4.1.1",
-          "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+          "resolved": false,
           "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
           "optional": true
         },
         "once": {
           "version": "1.4.0",
-          "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+          "resolved": false,
           "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
           "requires": {
             "wrappy": "1"
@@ -6249,19 +6245,19 @@
         },
         "os-homedir": {
           "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
+          "resolved": false,
           "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
           "optional": true
         },
         "os-tmpdir": {
           "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
+          "resolved": false,
           "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
           "optional": true
         },
         "osenv": {
           "version": "0.1.5",
-          "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.5.tgz",
+          "resolved": false,
           "integrity": "sha512-0CWcCECdMVc2Rw3U5w9ZjqX6ga6ubk1xDVKxtBQPK7wis/0F2r9T6k4ydGYhecl7YUBxBVxhL5oisPsNxAPe2g==",
           "optional": true,
           "requires": {
@@ -6271,19 +6267,19 @@
         },
         "path-is-absolute": {
           "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+          "resolved": false,
           "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
           "optional": true
         },
         "process-nextick-args": {
           "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.0.tgz",
+          "resolved": false,
           "integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw==",
           "optional": true
         },
         "rc": {
           "version": "1.2.7",
-          "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.7.tgz",
+          "resolved": false,
           "integrity": "sha512-LdLD8xD4zzLsAT5xyushXDNscEjB7+2ulnl8+r1pnESlYtlJtVSoCMBGr30eDRJ3+2Gq89jK9P9e4tCEH1+ywA==",
           "optional": true,
           "requires": {
@@ -6295,7 +6291,7 @@
           "dependencies": {
             "minimist": {
               "version": "1.2.0",
-              "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+              "resolved": false,
               "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
               "optional": true
             }
@@ -6303,7 +6299,7 @@
         },
         "readable-stream": {
           "version": "2.3.6",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+          "resolved": false,
           "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
           "optional": true,
           "requires": {
@@ -6318,7 +6314,7 @@
         },
         "rimraf": {
           "version": "2.6.2",
-          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.2.tgz",
+          "resolved": false,
           "integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
           "optional": true,
           "requires": {
@@ -6327,42 +6323,42 @@
         },
         "safe-buffer": {
           "version": "5.1.1",
-          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
+          "resolved": false,
           "integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg=="
         },
         "safer-buffer": {
           "version": "2.1.2",
-          "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+          "resolved": false,
           "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
           "optional": true
         },
         "sax": {
           "version": "1.2.4",
-          "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
+          "resolved": false,
           "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==",
           "optional": true
         },
         "semver": {
           "version": "5.5.0",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-5.5.0.tgz",
+          "resolved": false,
           "integrity": "sha512-4SJ3dm0WAwWy/NVeioZh5AntkdJoWKxHxcmyP622fOkgHa4z3R0TdBJICINyaSDE6uNwVc8gZr+ZinwZAH4xIA==",
           "optional": true
         },
         "set-blocking": {
           "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
+          "resolved": false,
           "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
           "optional": true
         },
         "signal-exit": {
           "version": "3.0.2",
-          "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
+          "resolved": false,
           "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
           "optional": true
         },
         "string-width": {
           "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+          "resolved": false,
           "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
           "requires": {
             "code-point-at": "^1.0.0",
@@ -6372,7 +6368,7 @@
         },
         "string_decoder": {
           "version": "1.1.1",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+          "resolved": false,
           "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
           "optional": true,
           "requires": {
@@ -6381,7 +6377,7 @@
         },
         "strip-ansi": {
           "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+          "resolved": false,
           "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
           "requires": {
             "ansi-regex": "^2.0.0"
@@ -6389,13 +6385,13 @@
         },
         "strip-json-comments": {
           "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+          "resolved": false,
           "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
           "optional": true
         },
         "tar": {
           "version": "4.4.1",
-          "resolved": "https://registry.npmjs.org/tar/-/tar-4.4.1.tgz",
+          "resolved": false,
           "integrity": "sha512-O+v1r9yN4tOsvl90p5HAP4AEqbYhx4036AGMm075fH9F8Qwi3oJ+v4u50FkT/KkvywNGtwkk0zRI+8eYm1X/xg==",
           "optional": true,
           "requires": {
@@ -6410,13 +6406,13 @@
         },
         "util-deprecate": {
           "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+          "resolved": false,
           "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
           "optional": true
         },
         "wide-align": {
           "version": "1.1.2",
-          "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.2.tgz",
+          "resolved": false,
           "integrity": "sha512-ijDLlyQ7s6x1JgCLur53osjm/UXUYD9+0PbYKrBsYisYXzCxN+HC3mYDNy/dWdmf3AwqwU3CXwDCvsNgGK1S0w==",
           "optional": true,
           "requires": {
@@ -6425,12 +6421,12 @@
         },
         "wrappy": {
           "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+          "resolved": false,
           "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
         },
         "yallist": {
           "version": "3.0.2",
-          "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.0.2.tgz",
+          "resolved": false,
           "integrity": "sha1-hFK0u36Dx8GI2AQcGoN8dz1ti7k="
         }
       }
@@ -6940,7 +6936,7 @@
       "dependencies": {
         "minimist": {
           "version": "1.2.0",
-          "resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
           "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
         },
         "process": {
@@ -6984,7 +6980,7 @@
     },
     "http-errors": {
       "version": "1.6.3",
-      "resolved": "http://registry.npmjs.org/http-errors/-/http-errors-1.6.3.tgz",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.6.3.tgz",
       "integrity": "sha1-i1VoC7S+KDoLW/TqLjhYC+HZMg0=",
       "requires": {
         "depd": "~1.1.2",
@@ -7148,7 +7144,7 @@
     },
     "inquirer": {
       "version": "0.12.0",
-      "resolved": "http://registry.npmjs.org/inquirer/-/inquirer-0.12.0.tgz",
+      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-0.12.0.tgz",
       "integrity": "sha1-HvK/1jUE3wvHV4X/+MLEHfEvB34=",
       "requires": {
         "ansi-escapes": "^1.1.0",
@@ -7173,7 +7169,7 @@
         },
         "chalk": {
           "version": "1.1.3",
-          "resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
           "requires": {
             "ansi-styles": "^2.2.1",
@@ -7193,7 +7189,7 @@
         },
         "onetime": {
           "version": "1.1.0",
-          "resolved": "http://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz",
+          "resolved": "https://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz",
           "integrity": "sha1-ofeDj4MUxRbwXs78vEzP4EtO14k="
         },
         "restore-cursor": {
@@ -7872,7 +7868,7 @@
     },
     "jsonfile": {
       "version": "2.4.0",
-      "resolved": "http://registry.npmjs.org/jsonfile/-/jsonfile-2.4.0.tgz",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-2.4.0.tgz",
       "integrity": "sha1-NzaitCi4e72gzIO1P6PWM6NcKug=",
       "requires": {
         "graceful-fs": "^4.1.6"
@@ -8009,7 +8005,7 @@
         },
         "readable-stream": {
           "version": "1.1.14",
-          "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
           "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
           "requires": {
             "core-util-is": "~1.0.0",
@@ -8046,7 +8042,7 @@
         },
         "readable-stream": {
           "version": "1.0.34",
-          "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
           "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
           "requires": {
             "core-util-is": "~1.0.0",
@@ -8093,7 +8089,7 @@
     },
     "levenshtein-edit-distance": {
       "version": "1.0.0",
-      "resolved": "http://registry.npmjs.org/levenshtein-edit-distance/-/levenshtein-edit-distance-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/levenshtein-edit-distance/-/levenshtein-edit-distance-1.0.0.tgz",
       "integrity": "sha1-iVuvR4zOi1waDSfkXXwdl4pmHkk="
     },
     "levn": {
@@ -8121,7 +8117,8 @@
         "pem-jwk": "^1.5.1",
         "protons": "^1.0.1",
         "rsa-pem-to-jwk": "^1.1.3",
-        "tweetnacl": "^1.0.0"
+        "tweetnacl": "^1.0.0",
+        "webcrypto-shim": "github:dignifiedquire/webcrypto-shim#190bc9ec341375df6025b17ae12ddb2428ea49c8"
       },
       "dependencies": {
         "base-x": {
@@ -8437,7 +8434,7 @@
       "dependencies": {
         "minimist": {
           "version": "1.2.0",
-          "resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
           "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
           "optional": true
         }
@@ -8565,7 +8562,7 @@
       "dependencies": {
         "minimist": {
           "version": "1.2.0",
-          "resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
           "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
         }
       }
@@ -8597,7 +8594,7 @@
       "dependencies": {
         "async": {
           "version": "1.5.2",
-          "resolved": "http://registry.npmjs.org/async/-/async-1.5.2.tgz",
+          "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
           "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo="
         },
         "ethereumjs-util": {
@@ -8742,7 +8739,7 @@
     },
     "minimist": {
       "version": "0.0.8",
-      "resolved": "http://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
       "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
     },
     "minipass": {
@@ -8823,7 +8820,7 @@
     },
     "mkdirp": {
       "version": "0.5.1",
-      "resolved": "http://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
       "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
       "requires": {
         "minimist": "0.0.8"
@@ -8857,7 +8854,7 @@
       "dependencies": {
         "commander": {
           "version": "2.15.1",
-          "resolved": "http://registry.npmjs.org/commander/-/commander-2.15.1.tgz",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-2.15.1.tgz",
           "integrity": "sha512-VlfT9F3V0v+jr4yxPc5gg9s62/fIVWsd2Bk2iD435um1NlGMYdVCq+MjcXnhYq2icNOizHr1kK+5TI6H0Hy0ag=="
         },
         "debug": {
@@ -9118,7 +9115,7 @@
       "dependencies": {
         "minimist": {
           "version": "1.2.0",
-          "resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
           "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
         }
       }
@@ -9301,7 +9298,7 @@
         },
         "buffer": {
           "version": "4.9.1",
-          "resolved": "http://registry.npmjs.org/buffer/-/buffer-4.9.1.tgz",
+          "resolved": "https://registry.npmjs.org/buffer/-/buffer-4.9.1.tgz",
           "integrity": "sha1-bRu2AbB6TvztlwlBMgkwJ8lbwpg=",
           "requires": {
             "base64-js": "^1.0.2",
@@ -9394,7 +9391,7 @@
         },
         "chalk": {
           "version": "1.1.3",
-          "resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
           "requires": {
             "ansi-styles": "^2.2.1",
@@ -9535,7 +9532,7 @@
         },
         "chalk": {
           "version": "0.4.0",
-          "resolved": "http://registry.npmjs.org/chalk/-/chalk-0.4.0.tgz",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-0.4.0.tgz",
           "integrity": "sha1-UZmj3c0MHv4jvAjBsCewYXbgxk8=",
           "requires": {
             "ansi-styles": "~1.0.0",
@@ -9545,7 +9542,7 @@
         },
         "strip-ansi": {
           "version": "0.1.1",
-          "resolved": "http://registry.npmjs.org/strip-ansi/-/strip-ansi-0.1.1.tgz",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-0.1.1.tgz",
           "integrity": "sha1-OeipjQRNFQZgq+SmgIrPcLt7yZE="
         },
         "underscore": {
@@ -9980,7 +9977,7 @@
     },
     "parse-asn1": {
       "version": "5.1.1",
-      "resolved": "http://registry.npmjs.org/parse-asn1/-/parse-asn1-5.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/parse-asn1/-/parse-asn1-5.1.1.tgz",
       "integrity": "sha512-KPx7flKXg775zZpnp9SxJlz00gTd4BmJ2yJufSc44gMCRrRQ7NSzAcSJQfifuOLgW6bEi+ftrALtsgALeB2Adw==",
       "requires": {
         "asn1.js": "^4.0.0",
@@ -10117,7 +10114,7 @@
     },
     "pause-stream": {
       "version": "0.0.11",
-      "resolved": "http://registry.npmjs.org/pause-stream/-/pause-stream-0.0.11.tgz",
+      "resolved": "https://registry.npmjs.org/pause-stream/-/pause-stream-0.0.11.tgz",
       "integrity": "sha1-/lo0sMvOErWqaitAPuLnO2AvFEU=",
       "requires": {
         "through": "~2.3"
@@ -10444,7 +10441,7 @@
     },
     "public-encrypt": {
       "version": "4.0.2",
-      "resolved": "http://registry.npmjs.org/public-encrypt/-/public-encrypt-4.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/public-encrypt/-/public-encrypt-4.0.2.tgz",
       "integrity": "sha512-4kJ5Esocg8X3h8YgJsKAuoesBgB7mqH3eowiDzMUPKiRDDE7E/BqqZD1hnTByIaAFiwAw246YEltSq7tdrOH0Q==",
       "requires": {
         "bn.js": "^4.1.0",
@@ -10610,7 +10607,7 @@
     },
     "readable-stream": {
       "version": "2.3.6",
-      "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
       "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
       "requires": {
         "core-util-is": "~1.0.0",
@@ -10768,9 +10765,13 @@
           "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
           "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4="
         },
+        "bignumber.js": {
+          "version": "git+https://github.com/frozeman/bignumber.js-nolookahead.git#57692b3ecfc98bbdd6b3a516cb2353652ea49934",
+          "from": "git+https://github.com/frozeman/bignumber.js-nolookahead.git#57692b3ecfc98bbdd6b3a516cb2353652ea49934"
+        },
         "chalk": {
           "version": "1.1.3",
-          "resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
           "requires": {
             "ansi-styles": "^2.2.1",
@@ -10790,7 +10791,7 @@
         },
         "eslint": {
           "version": "2.10.2",
-          "resolved": "http://registry.npmjs.org/eslint/-/eslint-2.10.2.tgz",
+          "resolved": "https://registry.npmjs.org/eslint/-/eslint-2.10.2.tgz",
           "integrity": "sha1-sjCUgv7wQ9MgM2WjIShebM4Bw9c=",
           "requires": {
             "chalk": "^1.1.3",
@@ -10863,7 +10864,7 @@
         },
         "standard": {
           "version": "7.1.2",
-          "resolved": "http://registry.npmjs.org/standard/-/standard-7.1.2.tgz",
+          "resolved": "https://registry.npmjs.org/standard/-/standard-7.1.2.tgz",
           "integrity": "sha1-QBZu7sJAUGXRpPDj8VurxuJ0YH4=",
           "requires": {
             "eslint": "~2.10.2",
@@ -10882,7 +10883,7 @@
         },
         "web3": {
           "version": "0.20.6",
-          "resolved": "http://registry.npmjs.org/web3/-/web3-0.20.6.tgz",
+          "resolved": "https://registry.npmjs.org/web3/-/web3-0.20.6.tgz",
           "integrity": "sha1-PpcwauAk+yThCj11yIQwJWIhUSA=",
           "requires": {
             "bignumber.js": "git+https://github.com/frozeman/bignumber.js-nolookahead.git#57692b3ecfc98bbdd6b3a516cb2353652ea49934",
@@ -10890,6 +10891,12 @@
             "utf8": "^2.1.1",
             "xhr2": "*",
             "xmlhttprequest": "*"
+          },
+          "dependencies": {
+            "bignumber.js": {
+              "version": "git+https://github.com/frozeman/bignumber.js-nolookahead.git#57692b3ecfc98bbdd6b3a516cb2353652ea49934",
+              "from": "git+https://github.com/frozeman/bignumber.js-nolookahead.git"
+            }
           }
         }
       }
@@ -10925,7 +10932,7 @@
         },
         "chalk": {
           "version": "1.1.3",
-          "resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
           "requires": {
             "ansi-styles": "^2.2.1",
@@ -10945,7 +10952,7 @@
         },
         "eslint": {
           "version": "2.10.2",
-          "resolved": "http://registry.npmjs.org/eslint/-/eslint-2.10.2.tgz",
+          "resolved": "https://registry.npmjs.org/eslint/-/eslint-2.10.2.tgz",
           "integrity": "sha1-sjCUgv7wQ9MgM2WjIShebM4Bw9c=",
           "requires": {
             "chalk": "^1.1.3",
@@ -11037,7 +11044,7 @@
           "dependencies": {
             "standard": {
               "version": "7.1.2",
-              "resolved": "http://registry.npmjs.org/standard/-/standard-7.1.2.tgz",
+              "resolved": "https://registry.npmjs.org/standard/-/standard-7.1.2.tgz",
               "integrity": "sha1-QBZu7sJAUGXRpPDj8VurxuJ0YH4=",
               "requires": {
                 "eslint": "~2.10.2",
@@ -11116,7 +11123,7 @@
         },
         "chalk": {
           "version": "1.1.3",
-          "resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
           "requires": {
             "ansi-styles": "^2.2.1",
@@ -11136,7 +11143,7 @@
         },
         "eslint": {
           "version": "2.10.2",
-          "resolved": "http://registry.npmjs.org/eslint/-/eslint-2.10.2.tgz",
+          "resolved": "https://registry.npmjs.org/eslint/-/eslint-2.10.2.tgz",
           "integrity": "sha1-sjCUgv7wQ9MgM2WjIShebM4Bw9c=",
           "requires": {
             "chalk": "^1.1.3",
@@ -11195,7 +11202,7 @@
         },
         "standard": {
           "version": "7.1.2",
-          "resolved": "http://registry.npmjs.org/standard/-/standard-7.1.2.tgz",
+          "resolved": "https://registry.npmjs.org/standard/-/standard-7.1.2.tgz",
           "integrity": "sha1-QBZu7sJAUGXRpPDj8VurxuJ0YH4=",
           "requires": {
             "eslint": "~2.10.2",
@@ -11239,14 +11246,6 @@
           "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.6.tgz",
           "integrity": "sha1-UzRK2xRhehP26N0s4okF0cC6MhU="
         },
-        "debug": {
-          "version": "2.6.9",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-          "requires": {
-            "ms": "2.0.0"
-          }
-        },
         "eth-lib": {
           "version": "0.1.27",
           "resolved": "https://registry.npmjs.org/eth-lib/-/eth-lib-0.1.27.tgz",
@@ -11283,12 +11282,12 @@
         },
         "uuid": {
           "version": "2.0.1",
-          "resolved": "http://registry.npmjs.org/uuid/-/uuid-2.0.1.tgz",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-2.0.1.tgz",
           "integrity": "sha1-wqMN7bPlNdcsz4LjQ5QaULqFM6w="
         },
         "web3": {
           "version": "1.0.0-beta.34",
-          "resolved": "http://registry.npmjs.org/web3/-/web3-1.0.0-beta.34.tgz",
+          "resolved": "https://registry.npmjs.org/web3/-/web3-1.0.0-beta.34.tgz",
           "integrity": "sha1-NH5WG3hAmMtVYzFfSQR5odkfKrE=",
           "requires": {
             "web3-bzz": "1.0.0-beta.34",
@@ -11506,6 +11505,28 @@
             "underscore": "1.8.3",
             "web3-core-helpers": "1.0.0-beta.34",
             "websocket": "git://github.com/frozeman/WebSocket-Node.git#6c72925e3f8aaaea8dc8450f97627e85263999f2"
+          },
+          "dependencies": {
+            "websocket": {
+              "version": "git://github.com/frozeman/WebSocket-Node.git#6c72925e3f8aaaea8dc8450f97627e85263999f2",
+              "from": "git://github.com/frozeman/WebSocket-Node.git#browserifyCompatible",
+              "requires": {
+                "debug": "^2.2.0",
+                "nan": "^2.3.3",
+                "typedarray-to-buffer": "^3.1.2",
+                "yaeti": "^0.0.6"
+              },
+              "dependencies": {
+                "debug": {
+                  "version": "2.6.9",
+                  "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+                  "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+                  "requires": {
+                    "ms": "2.0.0"
+                  }
+                }
+              }
+            }
           }
         },
         "web3-shh": {
@@ -11537,7 +11558,6 @@
           "version": "git://github.com/frozeman/WebSocket-Node.git#6c72925e3f8aaaea8dc8450f97627e85263999f2",
           "from": "git://github.com/frozeman/WebSocket-Node.git#browserifyCompatible",
           "requires": {
-            "debug": "^2.2.0",
             "nan": "^2.3.3",
             "typedarray-to-buffer": "^3.1.2",
             "yaeti": "^0.0.6"
@@ -11822,7 +11842,7 @@
       "dependencies": {
         "os-locale": {
           "version": "1.4.0",
-          "resolved": "http://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
+          "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
           "integrity": "sha1-IPnxeuKe00XoveWDsT0gCYA8FNk=",
           "requires": {
             "lcid": "^1.0.0"
@@ -12000,7 +12020,7 @@
       "dependencies": {
         "commander": {
           "version": "2.8.1",
-          "resolved": "http://registry.npmjs.org/commander/-/commander-2.8.1.tgz",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-2.8.1.tgz",
           "integrity": "sha1-Br42f+v9oMMwqh4qBy09yXYkJdQ=",
           "requires": {
             "graceful-readlink": ">= 1.0.0"
@@ -12128,7 +12148,7 @@
     },
     "sha.js": {
       "version": "2.4.11",
-      "resolved": "http://registry.npmjs.org/sha.js/-/sha.js-2.4.11.tgz",
+      "resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.4.11.tgz",
       "integrity": "sha512-QMEp5B7cftE7APOjk5Y6xgrbWu+WkLVQwk8JNjZ8nKRciZaByEW6MubieAiToS7+dwvrjGhH8jRXz3MVd0AYqQ==",
       "requires": {
         "inherits": "^2.0.1",
@@ -12261,7 +12281,7 @@
     },
     "sinon": {
       "version": "4.5.0",
-      "resolved": "http://registry.npmjs.org/sinon/-/sinon-4.5.0.tgz",
+      "resolved": "https://registry.npmjs.org/sinon/-/sinon-4.5.0.tgz",
       "integrity": "sha512-trdx+mB0VBBgoYucy6a9L7/jfQOmvGeaKZT4OOJ+lPAtI8623xyGr8wLiE4eojzBS8G9yXbhx42GHUOVLr4X2w==",
       "dev": true,
       "requires": {
@@ -12601,7 +12621,7 @@
         },
         "chalk": {
           "version": "1.1.3",
-          "resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
           "requires": {
             "ansi-styles": "^2.2.1",
@@ -12755,7 +12775,7 @@
         },
         "minimist": {
           "version": "1.2.0",
-          "resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
           "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
         },
         "ms": {
@@ -12803,7 +12823,7 @@
     },
     "standard-engine": {
       "version": "4.1.3",
-      "resolved": "http://registry.npmjs.org/standard-engine/-/standard-engine-4.1.3.tgz",
+      "resolved": "https://registry.npmjs.org/standard-engine/-/standard-engine-4.1.3.tgz",
       "integrity": "sha1-ejGq1U8D2fOTVfQzic4GlPQJQVU=",
       "requires": {
         "defaults": "^1.0.2",
@@ -12818,7 +12838,7 @@
       "dependencies": {
         "minimist": {
           "version": "1.2.0",
-          "resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
           "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
         }
       }
@@ -12866,7 +12886,7 @@
     },
     "stream-combiner": {
       "version": "0.2.2",
-      "resolved": "http://registry.npmjs.org/stream-combiner/-/stream-combiner-0.2.2.tgz",
+      "resolved": "https://registry.npmjs.org/stream-combiner/-/stream-combiner-0.2.2.tgz",
       "integrity": "sha1-rsjLrBd7Vrb0+kec7YwZEs7lKFg=",
       "requires": {
         "duplexer": "~0.1.1",
@@ -13041,6 +13061,11 @@
           }
         }
       }
+    },
+    "subdir": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/subdir/-/subdir-0.0.3.tgz",
+      "integrity": "sha1-2afT+MIhoNlRscoc/PWjFH3D4aE="
     },
     "supports-color": {
       "version": "5.5.0",
@@ -13347,7 +13372,7 @@
     },
     "table": {
       "version": "3.8.3",
-      "resolved": "http://registry.npmjs.org/table/-/table-3.8.3.tgz",
+      "resolved": "https://registry.npmjs.org/table/-/table-3.8.3.tgz",
       "integrity": "sha1-K7xULw/amGGnVdOUf+/Ys/UThV8=",
       "requires": {
         "ajv": "^4.7.0",
@@ -13384,7 +13409,7 @@
         },
         "chalk": {
           "version": "1.1.3",
-          "resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
           "requires": {
             "ansi-styles": "^2.2.1",
@@ -13452,7 +13477,7 @@
       "dependencies": {
         "minimist": {
           "version": "1.2.0",
-          "resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
           "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
         },
         "resolve": {
@@ -13512,7 +13537,7 @@
       "dependencies": {
         "bluebird": {
           "version": "2.11.0",
-          "resolved": "http://registry.npmjs.org/bluebird/-/bluebird-2.11.0.tgz",
+          "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-2.11.0.tgz",
           "integrity": "sha1-U0uQM8AiyVecVro7Plpcqvu2UOE="
         },
         "mout": {
@@ -13575,7 +13600,7 @@
     },
     "through": {
       "version": "2.3.8",
-      "resolved": "http://registry.npmjs.org/through/-/through-2.3.8.tgz",
+      "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
       "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU="
     },
     "through2": {
@@ -13773,7 +13798,7 @@
     },
     "typechecker": {
       "version": "2.1.0",
-      "resolved": "http://registry.npmjs.org/typechecker/-/typechecker-2.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/typechecker/-/typechecker-2.1.0.tgz",
       "integrity": "sha1-0cIJOlT/ihn1jP+HfuqlTyJC04M="
     },
     "typedarray": {
@@ -14310,6 +14335,14 @@
           "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.6.tgz",
           "integrity": "sha1-UzRK2xRhehP26N0s4okF0cC6MhU="
         },
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
         "eth-lib": {
           "version": "0.1.27",
           "resolved": "https://registry.npmjs.org/eth-lib/-/eth-lib-0.1.27.tgz",
@@ -14592,29 +14625,8 @@
           "integrity": "sha512-wAnENuZx75T5ZSrT2De2LOaUuPf2yRjq1VfcbD7+Zd79F3DZZLBJcPyCNVQ1U0fAXt0wfgCKl7sVw5pffqR9Bw==",
           "requires": {
             "underscore": "1.8.3",
-            "web3-core-helpers": "1.0.0-beta.36"
-          },
-          "dependencies": {
-            "websocket": {
-              "version": "git://github.com/frozeman/WebSocket-Node.git#6c72925e3f8aaaea8dc8450f97627e85263999f2",
-              "from": "git://github.com/frozeman/WebSocket-Node.git#6c72925e3f8aaaea8dc8450f97627e85263999f2",
-              "requires": {
-                "debug": "^2.2.0",
-                "nan": "^2.3.3",
-                "typedarray-to-buffer": "^3.1.2",
-                "yaeti": "^0.0.6"
-              },
-              "dependencies": {
-                "debug": {
-                  "version": "2.6.9",
-                  "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-                  "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-                  "requires": {
-                    "ms": "2.0.0"
-                  }
-                }
-              }
-            }
+            "web3-core-helpers": "1.0.0-beta.36",
+            "websocket": "git://github.com/frozeman/WebSocket-Node.git#6c72925e3f8aaaea8dc8450f97627e85263999f2"
           }
         },
         "web3-shh": {
@@ -14644,8 +14656,9 @@
         },
         "websocket": {
           "version": "git://github.com/frozeman/WebSocket-Node.git#6c72925e3f8aaaea8dc8450f97627e85263999f2",
-          "from": "git://github.com/frozeman/WebSocket-Node.git#6c72925e3f8aaaea8dc8450f97627e85263999f2",
+          "from": "git://github.com/frozeman/WebSocket-Node.git#browserifyCompatible",
           "requires": {
+            "debug": "^2.2.0",
             "nan": "^2.3.3",
             "typedarray-to-buffer": "^3.1.2",
             "yaeti": "^0.0.6"
@@ -14728,7 +14741,7 @@
       "dependencies": {
         "bluebird": {
           "version": "3.3.1",
-          "resolved": "http://registry.npmjs.org/bluebird/-/bluebird-3.3.1.tgz",
+          "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.3.1.tgz",
           "integrity": "sha1-+Xrhlw9B2FF3KDBT6aEgFg5mxh0="
         },
         "eventemitter3": {
@@ -14847,7 +14860,7 @@
       "dependencies": {
         "bluebird": {
           "version": "3.3.1",
-          "resolved": "http://registry.npmjs.org/bluebird/-/bluebird-3.3.1.tgz",
+          "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.3.1.tgz",
           "integrity": "sha1-+Xrhlw9B2FF3KDBT6aEgFg5mxh0="
         },
         "eth-lib": {
@@ -14867,7 +14880,7 @@
         },
         "uuid": {
           "version": "2.0.1",
-          "resolved": "http://registry.npmjs.org/uuid/-/uuid-2.0.1.tgz",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-2.0.1.tgz",
           "integrity": "sha1-wqMN7bPlNdcsz4LjQ5QaULqFM6w="
         }
       }
@@ -14918,6 +14931,14 @@
           "version": "4.11.6",
           "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.6.tgz",
           "integrity": "sha1-UzRK2xRhehP26N0s4okF0cC6MhU="
+        },
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "requires": {
+            "ms": "2.0.0"
+          }
         },
         "eth-lib": {
           "version": "0.1.27",
@@ -15120,29 +15141,8 @@
           "integrity": "sha512-wAnENuZx75T5ZSrT2De2LOaUuPf2yRjq1VfcbD7+Zd79F3DZZLBJcPyCNVQ1U0fAXt0wfgCKl7sVw5pffqR9Bw==",
           "requires": {
             "underscore": "1.8.3",
-            "web3-core-helpers": "1.0.0-beta.36"
-          },
-          "dependencies": {
-            "websocket": {
-              "version": "git://github.com/frozeman/WebSocket-Node.git#6c72925e3f8aaaea8dc8450f97627e85263999f2",
-              "from": "git://github.com/frozeman/WebSocket-Node.git#6c72925e3f8aaaea8dc8450f97627e85263999f2",
-              "requires": {
-                "debug": "^2.2.0",
-                "nan": "^2.3.3",
-                "typedarray-to-buffer": "^3.1.2",
-                "yaeti": "^0.0.6"
-              },
-              "dependencies": {
-                "debug": {
-                  "version": "2.6.9",
-                  "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-                  "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-                  "requires": {
-                    "ms": "2.0.0"
-                  }
-                }
-              }
-            }
+            "web3-core-helpers": "1.0.0-beta.36",
+            "websocket": "git://github.com/frozeman/WebSocket-Node.git#6c72925e3f8aaaea8dc8450f97627e85263999f2"
           }
         },
         "web3-utils": {
@@ -15161,8 +15161,9 @@
         },
         "websocket": {
           "version": "git://github.com/frozeman/WebSocket-Node.git#6c72925e3f8aaaea8dc8450f97627e85263999f2",
-          "from": "git://github.com/frozeman/WebSocket-Node.git#6c72925e3f8aaaea8dc8450f97627e85263999f2",
+          "from": "git://github.com/frozeman/WebSocket-Node.git#browserifyCompatible",
           "requires": {
+            "debug": "^2.2.0",
             "nan": "^2.3.3",
             "typedarray-to-buffer": "^3.1.2",
             "yaeti": "^0.0.6"
@@ -15322,6 +15323,10 @@
           "integrity": "sha1-LgHbAvfY0JRPdxBPFgnrDDBM92g="
         }
       }
+    },
+    "webcrypto-shim": {
+      "version": "github:dignifiedquire/webcrypto-shim#190bc9ec341375df6025b17ae12ddb2428ea49c8",
+      "from": "github:dignifiedquire/webcrypto-shim#master"
     },
     "webpack": {
       "version": "4.19.0",
@@ -15523,7 +15528,7 @@
     },
     "wrap-ansi": {
       "version": "2.1.0",
-      "resolved": "http://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
       "integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
       "requires": {
         "string-width": "^1.0.1",
@@ -15666,7 +15671,7 @@
     },
     "yargs": {
       "version": "4.8.1",
-      "resolved": "http://registry.npmjs.org/yargs/-/yargs-4.8.1.tgz",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-4.8.1.tgz",
       "integrity": "sha1-wMQpJMpKqmsObaFznfshZDn53cA=",
       "requires": {
         "cliui": "^3.2.0",
@@ -15687,7 +15692,7 @@
       "dependencies": {
         "os-locale": {
           "version": "1.4.0",
-          "resolved": "http://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
+          "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
           "integrity": "sha1-IPnxeuKe00XoveWDsT0gCYA8FNk=",
           "requires": {
             "lcid": "^1.0.0"

--- a/package.json
+++ b/package.json
@@ -82,6 +82,7 @@
     "node-ipc": "9.1.1",
     "node-netcat": "1.4.8",
     "node-sass": "4.9.3",
+    "npmlog": "4.1.2",
     "opn": "5.3.0",
     "ora": "2.1.0",
     "os-locale": "2.1.0",

--- a/package.json
+++ b/package.json
@@ -73,6 +73,7 @@
     "ipfs-api": "17.2.4",
     "is-valid-domain": "0.0.5",
     "istanbul": "0.4.5",
+    "json-parse-better-errors": "1.0.2",
     "live-plugin-manager-git-fix": "0.12.1",
     "lodash.clonedeep": "4.5.0",
     "merge": "1.2.0",

--- a/package.json
+++ b/package.json
@@ -58,6 +58,7 @@
     "express-ws": "4.0.0",
     "file-loader": "2.0.0",
     "finalhandler": "1.1.1",
+    "find-up": "2.1.0",
     "flatted": "0.2.3",
     "follow-redirects": "1.5.7",
     "fs-extra": "2.1.2",

--- a/package.json
+++ b/package.json
@@ -101,6 +101,7 @@
     "solc": "0.4.25",
     "string-replace-async": "1.2.1",
     "style-loader": "0.23.0",
+    "subdir": "0.0.3",
     "swarm-api": "0.1.2",
     "tar": "3.2.1",
     "toposort": "1.0.7",

--- a/package.json
+++ b/package.json
@@ -92,6 +92,7 @@
     "remix-tests": "0.0.13",
     "request": "2.88.0",
     "sass-loader": "7.1.0",
+    "semver": "5.5.1",
     "serve-static": "1.13.2",
     "shelljs": "0.5.3",
     "simples": "0.8.8",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "3.2.1",
   "description": "Embark is a framework that allows you to easily develop and deploy DApps",
   "scripts": {
-    "lint": "eslint lib/",
+    "lint": "eslint bin/embark lib/",
     "test": "npm-run-all lint test:*",
     "test:embark": "mocha test/ --no-timeouts --exit",
     "test:test_app": "cross-env DAPP=\"test_app\" npm run test_dapp",

--- a/test/cli_shim/demo.sh
+++ b/test/cli_shim/demo.sh
@@ -1,0 +1,434 @@
+#!/usr/bin/env bash
+
+# rebase this out prior to PR:
+# ------------------------------------------------------------------------------
+# don't forget to do an asciicast w/ asciinema, make sure to speed it up 3x;
+# provide a short version, just the demos; and long version, full build and
+# demos
+
+reset_shim_demo() {
+    local EMBARK_DOCKER_IMAGE="${EMBARK_DOCKER_IMAGE:-statusim/embark}"
+    local EMBARK_DOCKER_TAG="${EMBARK_DOCKER_TAG:-latest}"
+    local EMBARK_DOCKERFILE="${EMBARK_DOCKERFILE}"
+    local shim_demo_tag
+    if [[ (! -z "$EMBARK_DOCKERFILE") \
+              && "$EMBARK_DOCKER_TAG" = "latest" ]]; then
+        shim_demo_tag="shim-demo"
+    else
+        shim_demo_tag="${EMBARK_DOCKER_TAG}-shim-demo"
+    fi
+    local step
+    if [[ -z "$1" ]]; then
+        step="step-0"
+    else
+        step="$1"
+    fi
+    docker rmi "${EMBARK_DOCKER_IMAGE}:${shim_demo_tag}-${step}" &> /dev/null
+}
+export -f reset_shim_demo
+
+run_shim_demo () {
+    local EMBARK_BRANCH="${EMBARK_BRANCH:-features/cli-shim}"
+    # ^ once the PR is ready to merge this should be bumped to :-develop
+    local EMBARK_DOCKER_IMAGE="${EMBARK_DOCKER_IMAGE:-statusim/embark}"
+    local EMBARK_DOCKER_RUN
+    local EMBARK_DOCKER_RUN_INTERACTIVE
+    local EMBARK_DOCKER_RUN_OPTS_REPLACE
+    local EMBARK_DOCKER_RUN_RM
+    local EMBARK_DOCKER_TAG="${EMBARK_DOCKER_TAG:-latest}"
+    local EMBARK_DOCKERFILE="${EMBARK_DOCKERFILE}"
+    # ^ can override with a local path:
+    #   /path/to/embark-docker/Dockerfile
+    # or a url such as:
+    #   https://github.com/embark-framework/embark-docker.git#master
+    # if EMBARK_DOCKERFILE is not empty, it will trigger `docker build` instead
+    # of `docker pull` in step-0 below
+    local url_regex='^(https?|ftp|file)://[-A-Za-z0-9\+&@#/%?=~_|!:,.;]*[-A-Za-z0-9\+&@#/%=~_|]'
+    if [[ ! "$EMBARK_DOCKERFILE" =~ $url_regex ]]; then
+        EMBARK_DOCKERFILE="${EMBARK_DOCKERFILE%/*}"
+    fi
+    local EMBARK_SHIM_DEMO_DEV=${EMBARK_SHIM_DEMO_DEV:-false}
+    local EMBARK_VERSION="${EMBARK_VERSION:latest}"
+    # ^ only kicks in for `docker build`, not `docker pull`
+    local REAL="${REAL:-https://gist.githubusercontent.com/michaelsbradleyjr/87b5a99ad551e04cbad9c0c1d3af412b/raw/bfec2e589a91302b30f1d7cac8c2df71e5ebabe0/real.sh}"
+    local RUNNER="${RUNNER:-https://raw.githubusercontent.com/embark-framework/embark-docker/master/run.sh}"
+
+    local shim_demo_tag
+    if [[ (! -z "$EMBARK_DOCKERFILE") \
+              && "$EMBARK_DOCKER_TAG" = "latest" ]]; then
+        shim_demo_tag="shim-demo"
+    else
+        shim_demo_tag="${EMBARK_DOCKER_TAG}-shim-demo"
+    fi
+    local __shim_demo_tag="$shim_demo_tag"
+    local was_reset=false
+    local work_dir="$PWD"
+    if [[ "$REAL" =~ $url_regex ]]; then
+        source <(curl "$REAL" 2> /dev/null)
+    else
+        source "$REAL"
+    fi
+    local script_dir="$(real_dir "$BASH_SOURCE")"
+    local embark_dir="$(real_dir "$script_dir/../..")"
+    local cid_file="$script_dir/.cid"
+    if [[ "$RUNNER" =~ $url_regex ]]; then
+        source <(curl "$RUNNER" 2> /dev/null)
+    else
+        source "$RUNNER"
+    fi
+
+    check_image () {
+        local tag
+        if [[ -z "$1" ]]; then
+            tag="${__shim_demo_tag}-step-0"
+        else
+            tag="${__shim_demo_tag}-$1"
+        fi
+        local iid="$(docker images -q ${EMBARK_DOCKER_IMAGE}:${tag} 2> /dev/null)"
+        if [[ "$iid" = "" ]]; then
+            return 1
+        fi
+    }
+
+    cleanup () {
+        local retval=$?
+        unset check_image
+        unset cleanup
+        rm -f "$cid_file"
+        cd "$work_dir"
+        return $retval
+    }
+
+    # -- step 0 ----------------------------------------------------------------
+
+    echo '-----------------------------------'
+    echo 'setup - STEP 0'
+    echo '-----------------------------------'
+
+    shim_demo_tag="${__shim_demo_tag}-step-0"
+    if ! check_image; then
+        was_reset=true
+        if [[ ! -z "$EMBARK_DOCKERFILE" ]]; then
+            # could expand the --build-arg list (and list of locals at top of
+            # function) w/ all the build args supported by embark-docker's
+            # Dockerfile; should probably be the responsibility of a
+            # build_embark.sh script/function in embark-docker repo that parses
+            # and dedupes all ARG variables in embark-docker's Dockerfile
+            docker build \
+                   --build-arg EMBARK_VERSION="$EMBARK_VERSION" \
+                   -t "${EMBARK_DOCKER_IMAGE}:${EMBARK_DOCKER_TAG}" \
+                   "$EMBARK_DOCKERFILE" \
+                   || cleanup || return
+        else
+            docker pull "${EMBARK_DOCKER_IMAGE}:${EMBARK_DOCKER_TAG}" \
+                || cleanup || return
+        fi
+        docker tag \
+               "${EMBARK_DOCKER_IMAGE}:${EMBARK_DOCKER_TAG}" \
+               "${EMBARK_DOCKER_IMAGE}:${shim_demo_tag}" \
+            || cleanup || return
+    else
+        echo "cached..."
+    fi
+
+    # -- step 1 ----------------------------------------------------------------
+
+    echo '-----------------------------------'
+    echo 'setup - STEP 1'
+    echo '-----------------------------------'
+
+    if (! check_image step-1) || [[ $was_reset = true ]]; then
+        was_reset=true
+        rm -f "$cid_file"
+        EMBARK_DOCKER_TAG="$shim_demo_tag" \
+                         run_embark \
+                         --cidfile "$cid_file" \
+                         -d \
+                         -- bash -c 'trap "exit 0" SIGINT \
+                                         && while true; do sleep 1; done' \
+            || cleanup || return
+        docker exec \
+               -it \
+               $(cat "$cid_file") \
+               bash -c 'apt-get update && apt-get install -y rsync' \
+            || cleanup || return
+        shim_demo_tag="${__shim_demo_tag}-step-1"
+        docker commit \
+               --pause \
+               $(cat "$cid_file") \
+               "${EMBARK_DOCKER_IMAGE}:${shim_demo_tag}" \
+            || cleanup || return
+        docker stop $(cat "$cid_file") \
+            || cleanup || return
+        rm -f "$cid_file"
+    else
+        shim_demo_tag="${__shim_demo_tag}-step-1"
+        echo "cached..."
+    fi
+
+    # -- step 2 ----------------------------------------------------------------
+
+    echo '-----------------------------------'
+    echo 'setup - STEP 2'
+    echo '-----------------------------------'
+
+    local td_dapp="${HOME}/temp/$(basename $(mktemp -d))"
+    mkdir -p "$td_dapp"
+
+    if (! check_image step-2) || [[ $was_reset = true ]]; then
+        was_reset=true
+        rm -f "$cid_file"
+        # do not alter indentation, tabs in lines below
+        local step_2=$(cat <<- 'SCRIPT'
+	#!/bin/bash
+	simple_nodeenv 8.11.2 pre-8.11.3
+	simple_nodeenv 4.0.0 4.0.0
+	simple_nodeenv 8.12.0 lts
+	npm install -g npm@latest
+	npm install -g json
+	nac default
+	SCRIPT
+        )
+        # do not alter indentation, tabs in lines above
+        cd "$td_dapp"
+        EMBARK_DOCKER_RUN_RM=false
+        EMBARK_DOCKER_RUN=<(echo "$step_2") \
+                         EMBARK_DOCKER_TAG="$shim_demo_tag" \
+                         run_embark \
+                         --cidfile "$cid_file" \
+                         -- \
+            || cleanup || return
+        EMBARK_DOCKER_RUN_RM=true
+        shim_demo_tag="${__shim_demo_tag}-step-2"
+        docker commit $(cat "$cid_file") "${EMBARK_DOCKER_IMAGE}:${shim_demo_tag}" \
+            || cleanup || return
+        docker rm $(cat "$cid_file") \
+            || cleanup || return
+        rm -f "$cid_file"
+        cd "$work_dir"
+    else
+        shim_demo_tag="${__shim_demo_tag}-step-2"
+        echo "cached..."
+    fi
+
+    # -- step 3 ----------------------------------------------------------------
+
+    echo '-----------------------------------'
+    echo 'setup - STEP 3'
+    echo '-----------------------------------'
+
+    if (! check_image step-3) || [[ $was_reset = true ]]; then
+        was_reset=true
+        rm -f "$cid_file"
+        # do not alter indentation, tabs in lines below
+        local step_3=$(cat <<- 'SCRIPT'
+	#!/bin/bash
+	dev=$1
+	embark_branch="$2"
+	if [[ "$dev" = false ]]; then
+	    mkdir -p ~/repos/embark
+	    git clone https://github.com/embark-framework/embark.git \
+	              ~/repos/embark
+	    pushd "$PWD" &> /dev/null
+	    cd ~/repos/embark \
+	        && git checkout "$embark_branch" \
+	        && popd &> /dev/null
+	fi
+	mkdir -p ~/working/embark
+	rsync -a \
+	      --exclude=.git \
+	      --exclude=node_modules \
+	      --exclude=test/cli_shim/.cid \
+	      ~/repos/embark \
+	      ~/working/
+	pushd "$PWD" &> /dev/null
+	cd ~/working/embark
+	git config --global user.email "foo@bar"
+	git config --global user.name "Foo Bar"
+	git init
+	git add -A
+	git commit -m 'synced!'
+	nac lts
+	npm install
+	npm link
+	popd &> /dev/null
+	nac default
+	SCRIPT
+        )
+        # do not alter indentation, tabs in lines above
+        cd "$td_dapp"
+        local -a run_opts_step_3=(
+            "--cidfile"
+            "$cid_file"
+        )
+        if [[ $EMBARK_SHIM_DEMO_DEV = true ]]; then
+            run_opts_step_3=(
+                "${run_opts_step_3[@]}"
+                "-v"
+                "${embark_dir}:/home/embark/repos/embark"
+            )
+        fi
+        EMBARK_DOCKER_RUN_RM=false
+        EMBARK_DOCKER_RUN=<(echo "$step_3") \
+                         EMBARK_DOCKER_TAG="$shim_demo_tag" \
+                         run_embark \
+                         "${run_opts_step_3[@]}" \
+                         -- \
+                         $EMBARK_SHIM_DEMO_DEV \
+                         "$EMBARK_BRANCH" \
+            || cleanup || return
+        EMBARK_DOCKER_RUN_RM=true
+        shim_demo_tag="${__shim_demo_tag}-step-3"
+        docker commit $(cat "$cid_file") "${EMBARK_DOCKER_IMAGE}:${shim_demo_tag}" \
+            || cleanup || return
+        docker rm $(cat "$cid_file") \
+            || cleanup || return
+        rm -f "$cid_file"
+        cd "$work_dir"
+    else
+        shim_demo_tag="${__shim_demo_tag}-step-3"
+        echo "cached..."
+    fi
+
+    # -- step 4 ----------------------------------------------------------------
+
+    echo '-----------------------------------'
+    echo 'setup - STEP 4'
+    echo '-----------------------------------'
+
+    if (! check_image step-4) || [[ $was_reset = true ]]; then
+        was_reset=true
+        rm -f "$cid_file"
+        # do not alter indentation, tabs in lines below
+        local step_4=$(cat <<- 'SCRIPT'
+	#!/bin/bash
+	dev=$1
+	if [[ "$dev" = true ]]; then
+	    rsync -a \
+	          --exclude=.git \
+	          --exclude=node_modules \
+	          --exclude=test/cli_shim/.cid \
+	          ~/repos/embark \
+	          ~/working/
+	fi
+	pushd "$PWD" &> /dev/null
+	cd ~/working/embark
+	git add -A
+	git commit -m 'synced!'
+	cd ~
+	nac default
+	embark demo
+	cd embark_demo
+	git init
+	git add -A
+	git commit -m 'committed!'
+	popd &> /dev/null
+	SCRIPT
+        )
+        # do not alter indentation, tabs in lines above
+        cd "$td_dapp"
+        local -a run_opts_step_4=(
+            "--cidfile"
+            "$cid_file"
+        )
+        if [[ $EMBARK_SHIM_DEMO_DEV = true ]]; then
+            run_opts_step_4=(
+                "${run_opts_step_4[@]}"
+                "-v"
+                "${embark_dir}:/home/embark/repos/embark"
+            )
+        fi
+        EMBARK_DOCKER_RUN_RM=false
+        EMBARK_DOCKER_RUN=<(echo "$step_4") \
+                         EMBARK_DOCKER_TAG="$shim_demo_tag" \
+                         run_embark \
+                         "${run_opts_step_4[@]}" \
+                         -- \
+                         $EMBARK_SHIM_DEMO_DEV \
+            || cleanup || return
+        EMBARK_DOCKER_RUN_RM=true
+        shim_demo_tag="${__shim_demo_tag}-step-4"
+        docker commit $(cat "$cid_file") "${EMBARK_DOCKER_IMAGE}:${shim_demo_tag}" \
+            || cleanup || return
+        docker rm $(cat "$cid_file") \
+            || cleanup || return
+        rm -f "$cid_file"
+        cd "$work_dir"
+    else
+        shim_demo_tag="${__shim_demo_tag}-step-4"
+        echo "cached..."
+    fi
+
+    # -- DEMO ------------------------------------------------------------------
+
+    echo '-----------------------------------'
+    echo 'DEMO'  🎉
+    echo '-----------------------------------'
+
+    # do not alter indentation, tabs in lines below
+    local demo=$(cat <<- SCRIPT
+	#!/bin/bash
+	dev=\$1
+	if [[ "\$dev" = true ]]; then
+	    rsync -a \
+	          --exclude=.git \
+	          --exclude=node_modules \
+	          --exclude=test/cli_shim/.cid \
+	          ~/repos/embark \
+	          ~/working/
+	fi
+	pushd "$PWD" &> /dev/null
+	cd ~/working/embark
+	git add -A
+	git commit -m 'synced!'
+	popd &> /dev/null
+	txtbld=\$(tput bold)
+	txtrst=\$(tput sgr0)
+	bldcyn=\${txtbld}\$(tput setaf 6)
+	say () {
+	    local msg="\$1"
+	    msg="\$([[ "\$msg" =~ \
+	              [[:space:]]*([^[:space:]]|[^[:space:]].*[^[:space:]])[[:space:]]* ]]; \
+	              echo -n "\${BASH_REMATCH[1]}")"
+	    echo
+	    echo
+	    echo "\${bldcyn}\${msg}\${txtrst}"
+	}
+	export -f say
+	export PROMPT_COMMAND="echo; echo"
+	# demos
+	$(< "$script_dir/demos/runtime-pre-8.11.3.sh")
+	$(< "$script_dir/demos/runtime-4.0.0.sh")
+	$(< "$script_dir/demos/invoked_missing_json.sh")
+	$(< "$script_dir/demos/invoked_bad_json.sh")
+	$(< "$script_dir/demos/invoked_no_version.sh")
+	$(< "$script_dir/demos/invoked_no_node_engine.sh")
+	$(< "$script_dir/demos/invoked_bad_node_engine.sh")
+	$(< "$script_dir/demos/invoked_missing_dep.sh")
+	trap "exit 0" SIGINT && while true; do sleep 1; done
+	SCRIPT
+    )
+    # do not alter indentation, tabs in lines above
+    cd "$td_dapp"
+    local -a run_opts_demo=()
+    if [[ $EMBARK_SHIM_DEMO_DEV = true ]]; then
+        run_opts_demo=(
+            "${run_opts_demo[@]}"
+            "-v"
+            "${embark_dir}:/home/embark/repos/embark"
+        )
+    fi
+    EMBARK_DOCKER_RUN=<(echo "$demo") \
+                     EMBARK_DOCKER_TAG="$shim_demo_tag" \
+                     run_embark \
+                     "${run_opts_demo[@]}" \
+                     -- \
+                     $EMBARK_SHIM_DEMO_DEV \
+        || cleanup || return
+    cd "$work_dir"
+}
+export -f run_shim_demo
+
+if [[ "$0" = "$BASH_SOURCE" ]]; then
+    run_shim_demo
+fi

--- a/test/cli_shim/demos/invoked_bad_json.sh
+++ b/test/cli_shim/demos/invoked_bad_json.sh
@@ -1,0 +1,20 @@
+say "$(cat << 'MSG'
+
+If invoked embark's package.json cannot be parsed then report error and exit
+
+MSG
+)"
+
+cd ~/working/embark
+echo '}' >> package.json
+cd ~/embark_demo
+nac lts
+
+bash -i << 'DEMO'
+embark version
+DEMO
+
+nac default
+cd ~/working/embark
+git stash &> /dev/null
+cd ~

--- a/test/cli_shim/demos/invoked_bad_node_engine.sh
+++ b/test/cli_shim/demos/invoked_bad_node_engine.sh
@@ -1,0 +1,38 @@
+say "$(cat << 'MSG'
+
+If invoked embark's package.json does not specify a valid node engine and
+node < default minimum version, include a message about the fallback in the
+"Unsupported runtime" error messages
+
+MSG
+)"
+
+cd ~/working/embark
+nac lts
+json -I -f package.json -e 'this.engines.node=">-8.11.3"' &> /dev/null
+
+cd ~/embark_demo
+nac pre-8.11.3
+
+bash -i << 'DEMO'
+node ~/working/embark/bin/embark version
+DEMO
+
+say "$(cat << 'MSG'
+
+No message about the fallback to testing with the default minimum version is
+displayed if the node version is supported
+
+MSG
+)"
+
+nac lts
+
+bash -i << 'DEMO'
+node ~/working/embark/bin/embark version
+DEMO
+
+nac default
+cd ~/working/embark
+git stash &> /dev/null
+cd ~

--- a/test/cli_shim/demos/invoked_missing_dep.sh
+++ b/test/cli_shim/demos/invoked_missing_dep.sh
@@ -1,0 +1,102 @@
+say "$(cat << 'MSG'
+
+If invoked embark is missing a dependency then report error and exit
+
+MSG
+)"
+
+cd ~/working/embark/node_modules
+mv opn opn-RENAMED
+
+cd ~
+nac lts
+
+bash -i << 'DEMO'
+embark version
+DEMO
+
+nac default
+cd ~/working/embark/node_modules
+mv opn-RENAMED opn
+cd ~
+
+say "$(cat << 'MSG'
+
+If invoked embark is missing a dev dependency then report error and exit
+
+MSG
+)"
+
+cd ~/working/embark/node_modules
+mv sinon sinon-RENAMED
+
+cd ~
+nac lts
+
+bash -i << 'DEMO'
+embark version
+DEMO
+
+nac default
+cd ~/working/embark/node_modules
+mv sinon-RENAMED sinon
+cd ~
+
+say "$(cat << 'MSG'
+
+If invoked embark is within a node_modules tree then dependencies are not checked
+
+MSG
+)"
+
+cd ~/working/embark/node_modules
+mv opn opn-RENAMED
+cd ~/working
+mkdir node_modules
+mv embark node_modules/
+
+cd ~
+nac lts
+
+bash -i << 'DEMO'
+node ~/working/node_modules/embark/bin/embark version
+DEMO
+
+nac default
+cd ~/working/node_modules
+mv embark ../
+cd ../
+rmdir node_modules
+cd ~/working/embark/node_modules
+mv opn-RENAMED opn
+cd ~
+
+say "$(cat << 'MSG'
+
+If invoked embark is within a node_modules tree then dev dependencies are not
+checked
+
+MSG
+)"
+
+cd ~/working/embark/node_modules
+mv sinon sinon-RENAMED
+cd ~/working
+mkdir node_modules
+mv embark node_modules/
+
+cd ~
+nac lts
+
+bash -i << 'DEMO'
+node ~/working/node_modules/embark/bin/embark version
+DEMO
+
+nac default
+cd ~/working/node_modules
+mv embark ../
+cd ../
+rmdir node_modules
+cd ~/working/embark/node_modules
+mv sinon-RENAMED sinon
+cd ~

--- a/test/cli_shim/demos/invoked_missing_json.sh
+++ b/test/cli_shim/demos/invoked_missing_json.sh
@@ -1,0 +1,20 @@
+say "$(cat << 'MSG'
+
+If invoked embark's package.json is missing then report error and exit
+
+MSG
+)"
+
+cd ~/working/embark
+rm package.json
+cd ~/embark_demo
+nac lts
+
+bash -i << 'DEMO'
+embark version
+DEMO
+
+nac default
+cd ~/working/embark
+git stash &> /dev/null
+cd ~

--- a/test/cli_shim/demos/invoked_no_node_engine.sh
+++ b/test/cli_shim/demos/invoked_no_node_engine.sh
@@ -1,0 +1,38 @@
+say "$(cat << 'MSG'
+
+If invoked embark's package.json does not specify a node engine and
+node < default minimum version, include a message about the fallback in the
+"Unsupported runtime" error messages
+
+MSG
+)"
+
+cd ~/working/embark
+nac lts
+json -I -f package.json -e 'delete this.engines.node' &> /dev/null
+
+cd ~/embark_demo
+nac pre-8.11.3
+
+bash -i << 'DEMO'
+node ~/working/embark/bin/embark version
+DEMO
+
+say "$(cat << 'MSG'
+
+No message about the fallback to testing with the default minimum version is
+displayed if the node version is supported
+
+MSG
+)"
+
+nac lts
+
+bash -i << 'DEMO'
+node ~/working/embark/bin/embark version
+DEMO
+
+nac default
+cd ~/working/embark
+git stash &> /dev/null
+cd ~

--- a/test/cli_shim/demos/invoked_no_version.sh
+++ b/test/cli_shim/demos/invoked_no_version.sh
@@ -1,0 +1,21 @@
+say "$(cat << 'MSG'
+
+If invoked embark's package.json does not specify a version then report warning
+and continue
+
+MSG
+)"
+
+cd ~/working/embark
+nac lts
+json -I -f package.json -e 'delete this.version' &> /dev/null
+cd ~/embark_demo
+
+bash -i << 'DEMO'
+embark version
+DEMO
+
+nac default
+cd ~/working/embark
+git stash &> /dev/null
+cd ~

--- a/test/cli_shim/demos/runtime-4.0.0.sh
+++ b/test/cli_shim/demos/runtime-4.0.0.sh
@@ -1,0 +1,16 @@
+say "$(cat << 'MSG'
+
+Intended "Unsupported runtime" error messages are displayed for node >= 4.0.0
+
+MSG
+)"
+
+cd ~/embark_demo
+nac 4.0.0
+
+bash -i << 'DEMO'
+node ~/working/embark/bin/embark version
+DEMO
+
+nac default
+cd ~

--- a/test/cli_shim/demos/runtime-pre-8.11.3.sh
+++ b/test/cli_shim/demos/runtime-pre-8.11.3.sh
@@ -1,0 +1,17 @@
+say "$(cat << 'MSG'
+
+If a node < version specified in invoked embark's `{engines:{node:[semver]}}`
+is used to run embark then report error and exit
+
+MSG
+)"
+
+cd ~/embark_demo
+nac pre-8.11.3
+
+bash -i << 'DEMO'
+node ~/working/embark/bin/embark version
+DEMO
+
+nac default
+cd ~


### PR DESCRIPTION
**TL;DR**

When `bin/embark` is invoked (one way or another), it will look for a "local" `bin/embark` relative to a DApp's top-level directory, or the working directory if it wasn't invoked inside a DApp. Command execution is passed to local `bin/embark`, if one is found, else it proceeds with invoked `bin/embark`.

### Would You Like to Know More?

The shim collects a variety of info as it figures out what files are where relative to the starting directory. Depending on the invocation context, this involves checking whether `package.json` and `embark.json` files exist and are parsable, if specified dependencies of embark/s and/or the DApp are installed, etc. Lots and lots of things get checked. 🔎 🚀 

The [npmlog](https://github.com/npm/npmlog) logging style was chosen since there is strong conceptual cross-over between the shim's and npm's checks, warnings, and errors. In a sense, the shim's checks are a superset of the checks npm performs (or can perform) on packages and projects. Also, if `embark` is invoked via `npm run`, it allows embark and npm errors and warnings (if any) to visually fit together.

### Limitations

When a "local installed" `bin/embark` is introduced by linking/folder (instead of a regular install), the behavior of `check-dependencies` can be inflexible. A workaround is being considered, and may involve a stripped down implementation of the `check-dependencies` functionality that's better suited to Embark's needs.

### Remaining work

This implementation is robust but quite complex, and has resulted from several long rounds of experimentation, head-scratching, and a major effort in recent days to clean up the code so that it's easier to understand.

It's ready for the Embark team to begin giving it a close look and taking it for a spin.

However, tests are still being written, to exhaustively poke at all facets of the shim's behavior. At present, those are taking the form of Bash "demo" scripts that run inside a Docker container. I've found it easier to "see the results" by taking that route, and the approach fits naturally with the ad hoc command-line testing I've conducted during the shim's development.

Longer term, it should be straightforward to lift out all the `bin/embark` pieces not inside `function main() {...}`, place them in modules within `<embark>/cmd/lib/` and build a cross-platform test suite in the usual manner with mocha and sinon. If review and QA for this PR turn up a lot of problems, this PR may need to be closed and another one submitted after that test suite is written.

### Cool Spaceship Picture

![](https://vignette.wikia.nocookie.net/voltron/images/f/fd/My-vehicle-voltron-flat.jpg/revision/latest?cb=20090926155337)