### PR TITLE
Accept standard Ether units and update/add tests

### DIFF
--- a/lib/core/config.js
+++ b/lib/core/config.js
@@ -4,10 +4,12 @@ const Plugins = require('./plugins.js');
 const utils = require('../utils/utils.js');
 const path = require('path');
 const deepEqual = require('deep-equal');
+const web3 = require('web3');
 const constants = require('../constants');
 const {canonicalHost, defaultHost} = require('../utils/host');
 
 const DEFAULT_CONFIG_PATH = 'config/';
+const unitRegex = /([0-9]+) ([a-zA-Z]+)/;
 
 var Config = function(options) {
   const self = this;
@@ -188,15 +190,28 @@ Config.prototype.loadBlockchainConfigFile = function() {
   if (!configFilePath) {
     this.blockchainConfig.default = true;
   }
+
+  if (this.blockchainConfig.targetGasLimit && this.blockchainConfig.targetGasLimit.match(unitRegex)) {
+    this.blockchainConfig.targetGasLimit = utils.getWeiBalanceFromString(this.blockchainConfig.targetGasLimit, web3);
+  }
+
+  if (this.blockchainConfig.gasPrice && this.blockchainConfig.gasPrice.match(unitRegex)) {
+    this.blockchainConfig.gasPrice = utils.getWeiBalanceFromString(this.blockchainConfig.gasPrice, web3);
+  }
+
+  if (this.blockchainConfig.account && this.blockchainConfig.account.balance && this.blockchainConfig.account.balance.match(unitRegex)) {
+      this.blockchainConfig.account.balance = utils.getWeiBalanceFromString(this.blockchainConfig.account.balance, web3);
+  }
+
   if (
     !this.shownNoAccountConfigMsg &&
-    (/rinkeby|testnet|livenet/).test(this.blockchainConfig.networkType) && 
-    !(this.blockchainConfig.account && this.blockchainConfig.account.address && this.blockchainConfig.account.password) && 
+    (/rinkeby|testnet|livenet/).test(this.blockchainConfig.networkType) &&
+    !(this.blockchainConfig.account && this.blockchainConfig.account.address && this.blockchainConfig.account.password) &&
     !this.blockchainConfig.isDev &&
     this.env !== 'development' && this.env !== 'test') {
       this.logger.warn((
         '\n=== ' + __('Cannot unlock account - account config missing').bold + ' ===\n' +
-        __('Geth is configured to sync to a testnet/livenet and needs to unlock an account ' + 
+        __('Geth is configured to sync to a testnet/livenet and needs to unlock an account ' +
         'to allow your dApp to interact with geth, however, the address and password must ' +
         'be specified in your blockchain config. Please update your blockchain config with ' +
         'a valid address and password: \n') +
@@ -206,7 +221,7 @@ Config.prototype.loadBlockchainConfigFile = function() {
         '\n - Linux: ' + `~/.ethereum/${this.env}/keystore`.italic +
         '\n - Windows: ' + `%APPDATA%\\Ethereum\\${this.env}\\keystore`.italic) +
         __('\n\nAlternatively, you could change ' +
-        `config/blockchain.js > ${this.env} > networkType`.italic + 
+        `config/blockchain.js > ${this.env} > networkType`.italic +
         __(' to ') +
         '"custom"\n'.italic).yellow
       );
@@ -243,9 +258,27 @@ Config.prototype.loadContractsConfigFile = function() {
   });
 
   let configFilePath = this._getFileOrOject(this.configDir, 'contracts', 'contracts');
-
-  const newContractsConfig = this._mergeConfig(configFilePath, configObject, this.env);
-
+  let newContractsConfig = this._mergeConfig(configFilePath, configObject, this.env);
+  if (newContractsConfig.gas.match(unitRegex)) {
+    newContractsConfig.gas = utils.getWeiBalanceFromString(newContractsConfig.gas, web3);
+  }
+  if (newContractsConfig.deployment && 'accounts' in newContractsConfig.deployment) {
+    newContractsConfig.deployment.accounts.forEach((account) => {
+      if (account.balance.match(unitRegex)) {
+        account.balance = utils.getWeiBalanceFromString(account.balance, web3);
+      }
+    });
+  }
+  Object.keys(newContractsConfig.contracts).forEach(contractName => {
+      let gas = newContractsConfig.contracts[contractName].gas;
+      let gasPrice = newContractsConfig.contracts[contractName].gasPrice;
+      if (gas && gas.match(unitRegex)) {
+        newContractsConfig.contracts[contractName].gas = utils.getWeiBalanceFromString(gas, web3);
+      }
+      if (gasPrice && gasPrice.match(unitRegex)) {
+        newContractsConfig.contracts[contractName].gasPrice = utils.getWeiBalanceFromString(gasPrice, web3);
+      }
+  });
   if (!deepEqual(newContractsConfig, this.contractsConfig)) {
     this.contractsConfig = newContractsConfig;
   }

--- a/lib/modules/blockchain_process/dev_funds.js
+++ b/lib/modules/blockchain_process/dev_funds.js
@@ -1,6 +1,6 @@
 const async = require('async');
 const Web3 = require('web3');
-const {getWeiBalanceFromString, buildUrl} = require('../../utils/utils.js');
+const {buildUrl} = require('../../utils/utils.js');
 const {readFileSync, dappPath} = require('../../core/fs');
 
 class DevFunds {
@@ -14,7 +14,7 @@ class DevFunds {
     this.provider = options.provider || new Web3.providers.WebsocketProvider(buildUrl('ws', this.blockchainConfig.wsHost, this.blockchainConfig.wsPort), {headers: {Origin: "http://embark"}});
     this.web3 = new Web3(this.provider);
     if (this.blockchainConfig.account.balance) {
-      this.balance = getWeiBalanceFromString(this.blockchainConfig.account.balance, this.web3);
+      this.balance = this.blockchainConfig.account.balance;
     }
     this.logger = options.logger || console;
   }

--- a/test/config.js
+++ b/test/config.js
@@ -36,6 +36,72 @@ describe('embark.Config', function () {
 
       assert.deepEqual(config.blockchainConfig, expectedConfig);
     });
+
+    it('should convert Ether units', function () {
+      let expectedConfig = {
+        "enabled": true,
+        "networkType": "custom",
+        "genesisBlock": "config/development/genesis.json",
+        "datadir": ".embark/development/datadir",
+        "isDev": false,
+        "targetGasLimit": "300000",
+        "gasPrice": "8000000",
+        "mineWhenNeeded": true,
+        "nodiscover": true,
+        "rpcHost": "localhost",
+        "rpcPort": 8545,
+        "rpcCorsDomain": "http://localhost:8000",
+        "wsOrigins": "auto",
+        "account": {
+          "password": "config/development/password",
+          "balance": "3000000000000000000"
+        }
+      };
+
+      let config = new Config({
+        env: 'unitenv',
+        configDir: './test/test1/config/',
+        events: new Events()
+      });
+      config.plugins = new Plugins({plugins: {}});
+      config.logger = new TestLogger({});
+      config.loadBlockchainConfigFile();
+
+      assert.deepEqual(config.blockchainConfig, expectedConfig);
+    });
+
+    it('should accept unitless gas values', function () {
+      let expectedConfig = {
+        "enabled": true,
+        "networkType": "custom",
+        "genesisBlock": "config/development/genesis.json",
+        "datadir": ".embark/development/datadir",
+        "isDev": false,
+        "targetGasLimit": "20000000",
+        "gasPrice": "8000000",
+        "mineWhenNeeded": true,
+        "nodiscover": true,
+        "rpcHost": "localhost",
+        "rpcPort": 8545,
+        "rpcCorsDomain": "http://localhost:8000",
+        "wsOrigins": "auto",
+        "account": {
+          "password": "config/development/password",
+          "balance": "3000000000000000000"
+        }
+      };
+
+      let config = new Config({
+        env: 'unitlessenv',
+        configDir: './test/test1/config/',
+        events: new Events()
+      });
+      config.plugins = new Plugins({plugins: {}});
+      config.logger = new TestLogger({});
+      config.loadBlockchainConfigFile();
+
+      assert.deepEqual(config.blockchainConfig, expectedConfig);
+    });
   });
 
   describe('#loadContractsConfigFile', function () {
@@ -43,13 +109,14 @@ describe('embark.Config', function () {
       config.loadContractsConfigFile();
       let expectedConfig = {
         versions: {'web3': '1.0.0-beta', solc: '0.4.17'},
-        deployment: {host: 'localhost', port: 8545, type: 'rpc'},
+        deployment: {host: 'localhost', port: 8545, type: 'rpc', "accounts": [{"mnemonic": "12 word mnemonic", "balance": "5000000000"}]},
         dappConnection: ['$WEB3', 'localhost:8545'],
-        "gas": "auto",
+        "gas": "400000",
         "contracts": {
           "SimpleStorage": {
             "args": [100],
-            "gas": 123456
+            "gas": "123000",
+            "gasPrice": "1000"
           },
           "Token": {
             "args": [200]

--- a/test/devFunds.js
+++ b/test/devFunds.js
@@ -31,7 +31,8 @@ describe('embark.DevFunds', function() {
     account: {
       password: './test/test1/password',
       numAccounts: 3,
-      balance: "5 ether"
+      // this conversion is normally done when constructing a Config object
+      balance: utils.getWeiBalanceFromString("5 ether", Web3)
     },
     bootnodes: "",
     wsApi: ["eth", "web3", "net", "shh", "debug"],
@@ -109,8 +110,7 @@ describe('embark.DevFunds', function() {
         // provider.injectResult('0x11f4d0A3c12e86B4b5F39B213F7E19D048276DAe'); // send tx response
       });
 
-      devFunds.fundAccounts(false, (errFundAccounts) => {
-
+      devFunds.fundAccounts(devFunds.balance, (errFundAccounts) => {
         assert.equal(errFundAccounts, null);
 
         // inject response for web3.eth.getAccounts
@@ -119,7 +119,7 @@ describe('embark.DevFunds', function() {
 
         web3.eth.getAccounts().then((accts) => {
 
-          const weiFromConfig = utils.getWeiBalanceFromString(config.account.balance, web3);
+          const weiFromConfig = config.account.balance;
 
           async.each(accts, (acct, cb) => {
 

--- a/test/test1/config/blockchain.json
+++ b/test/test1/config/blockchain.json
@@ -13,6 +13,40 @@
       "password": "config/development/password"
     }
   },
+  "unitenv": {
+    "networkType": "custom",
+    "genesisBlock": "config/development/genesis.json",
+    "datadir": ".embark/development/datadir",
+    "isDev": false,
+    "gasPrice": "8 Mwei",
+    "mineWhenNeeded": true,
+    "nodiscover": true,
+    "rpcHost": "localhost",
+    "rpcPort": 8545,
+    "rpcCorsDomain": "http://localhost:8000",
+    "targetGasLimit": "300 Kwei",
+    "account": {
+      "password": "config/development/password",
+      "balance": "3 ether"
+    }
+  },
+  "unitlessenv": {
+      "networkType": "custom",
+      "genesisBlock": "config/development/genesis.json",
+      "datadir": ".embark/development/datadir",
+      "isDev": false,
+      "gasPrice": "8000000",
+      "mineWhenNeeded": true,
+      "nodiscover": true,
+      "rpcHost": "localhost",
+      "rpcPort": 8545,
+      "rpcCorsDomain": "http://localhost:8000",
+      "targetGasLimit": "20000000",
+      "account": {
+        "password": "config/development/password",
+        "balance": "3000000000000000000"
+    }
+  },
   "testnet": {
     "networkType": "testnet",
     "rpcHost": "localhost",

--- a/test/test1/config/contracts.json
+++ b/test/test1/config/contracts.json
@@ -10,16 +10,25 @@
     }
   },
   "myenv": {
-    "gas": "auto",
+    "gas": "400 Kwei",
     "contracts": {
       "SimpleStorage": {
-        "gas": 123456
+        "gas": "123 Kwei",
+        "gasPrice": "1 Kwei"
       },
       "Token": {
         "args": [
           200
         ]
       }
+    },
+    "deployment": {
+      "accounts": [
+        {
+          "mnemonic": "12 word mnemonic",
+          "balance": "5000 Mwei"
+        }
+      ]
     }
   }
 }


### PR DESCRIPTION
## Overview
**TL;DR**
Allows the use of standard Ether units in configuration files rather than being limited to just wei.

Supersedes https://github.com/embark-framework/embark/pull/910

### Questions

### Review
@iurimatias @PascalPrecht @jrainville This new branch is rebased on latest develop and includes all previous changes as well as some linting fixes from the new linter in the tests.

### Cool Spaceship Picture
![spaceship](https://user-images.githubusercontent.com/869266/46663669-ac21ed80-cbf9-11e8-923c-7a0d5db20b09.gif)
