### PR TITLE
Don't spin up blockchain node in graph and build command with --contracts option

### DIFF
--- a/cmd/cmd_controller.js
+++ b/cmd/cmd_controller.js
@@ -387,13 +387,10 @@ class EmbarkController {
         engine.startService("processManager");
         engine.startService("serviceMonitor");
         engine.startService("libraryManager");
-        engine.startService("pipeline");
-        engine.startService("deployment", {onlyCompile: true});
-        engine.startService("web3");
+        engine.startService("compiler");
         engine.startService("codeGenerator");
         engine.startService("graph");
-
-        engine.events.request('deploy:contracts', callback);
+        engine.events.request('contracts:build', {}, callback);
       }
     ], (err) => {
       if (err) {

--- a/lib/core/engine.js
+++ b/lib/core/engine.js
@@ -63,6 +63,7 @@ class Engine {
       "pipeline": this.pipelineService,
       "codeRunner": this.codeRunnerService,
       "codeGenerator": this.codeGeneratorService,
+      "compiler": this.setupCompilerAndContractsManagerService,
       "deployment": this.deploymentService,
       "fileWatcher": this.fileWatchService,
       "webServer": this.webServerService,
@@ -178,17 +179,21 @@ class Engine {
     this.events.on('asset-changed', addToCargo);
   }
 
+  setupCompilerAndContractsManagerService(options) {
+    this.registerModule('compiler', {plugins: this.plugins, disableOptimizations: options.disableOptimizations});
+    this.registerModule('solidity', {ipc: this.ipc, useDashboard: this.useDashboard});
+    this.registerModule('vyper');
+    this.registerModule('contracts_manager', {compileOnceOnly: options.compileOnceOnly});
+  }
+
   deploymentService(options) {
     let self = this;
 
-    this.registerModule('compiler', {plugins: self.plugins, disableOptimizations: options.disableOptimizations});
-    this.registerModule('solidity', {ipc: self.ipc, useDashboard: this.useDashboard});
-    this.registerModule('vyper');
+    this.setupCompilerAndContractsManagerService(options);
     this.registerModule('profiler');
     this.registerModule('deploytracker', {trackContracts: options.trackContracts});
     this.registerModule('specialconfigs');
     this.registerModule('console_listener', {ipc: self.ipc});
-    this.registerModule('contracts_manager', {compileOnceOnly: options.compileOnceOnly});
     this.registerModule('deployment', {plugins: this.plugins, onlyCompile: options.onlyCompile});
 
     this.events.on('file-event', function (fileType) {


### PR DESCRIPTION
## Overview
Both commands, `$ embark graph` and `$ embark build --contracts` spin up all web3 related services, including starting a blockchain node which is not necessary in those cases.


### Cool Spaceship Picture
