### PR TITLE
Add webserver message at the end of file build

### DIFF
--- a/lib/modules/webserver/index.js
+++ b/lib/modules/webserver/index.js
@@ -26,6 +26,7 @@ class WebServer {
     this.events.emit("status", __("Starting Server"));
 
     this.server = new Server({
+      logger: this.logger,
       buildDir: this.buildDir,
       events: this.events,
       host: this.host,

--- a/lib/modules/webserver/server.js
+++ b/lib/modules/webserver/server.js
@@ -8,6 +8,7 @@ require('http-shutdown').extend();
 
 class Server {
   constructor(options) {
+    this.logger = options.logger;
     this.buildDir = options.buildDir;
     this.events = options.events;
     this.port = options.port || 8000;
@@ -15,6 +16,11 @@ class Server {
     this.isFirstStart = true;
     this.opened = false;
     this.openBrowser = options.openBrowser;
+
+
+    this.events.once('outputDone', () => {
+      this.logger.info(this._getMessage());
+    });
   }
 
   start(callback) {
@@ -77,12 +83,14 @@ class Server {
       if (err) {
         return callback(err);
       }
-      const msg = (
-        __('webserver available at') + ' ' +
-          ('http://' + canonicalHost(self.hostname) + ':' + self.port).bold.underline.green
-      );
-      callback(null, msg, self.port);
+
+      callback(null, self._getMessage(), self.port);
     });
+  }
+
+  _getMessage() {
+    return __('webserver available at') + ' ' +
+    ('http://' + canonicalHost(this.hostname) + ':' + this.port).bold.underline.green;
   }
 
   stop(callback) {

--- a/locales/en.json
+++ b/locales/en.json
@@ -61,7 +61,7 @@
   "error running afterDeploy: ": "error running afterDeploy: ",
   "ready to watch file changes": "ready to watch file changes",
   "Starting Server": "Starting Server",
-  "webserver available at": "webserver available at",
+  "webserver available at": "Webserver available at",
   "Webserver": "Webserver",
   "versions": "versions",
   "possible commands are:": "possible commands are:",

--- a/locales/es.json
+++ b/locales/es.json
@@ -66,7 +66,7 @@
    "error running afterDeploy: ": "error al ejecutar afterDeploy: ",
    "ready to watch file changes": "listo para monitorear cambios en archivos",
    "Starting Server": "Iniciando el Servidor",
-   "webserver available at": "servidor web disponible en",
+   "webserver available at": "Servidor web disponible en",
    "Webserver": "Servidor web",
    " already deployed at ": " ya desplegado en ",
    "Deployed": "Desplegado",

--- a/locales/fr.json
+++ b/locales/fr.json
@@ -66,7 +66,7 @@
   "error running afterDeploy: ": "erreur d'exécution AfterDeploy: ",
   "ready to watch file changes": "Prêt à monitorer les changements de fichiers",
   "Starting Server": "Démarrage du serveur",
-  "webserver available at": "serveur Web disponible à",
+  "webserver available at": "Serveur Web disponible à",
   "Webserver": "Serveur Web",
   " already deployed at ": " déjà déployé à ",
   "Deployed": "Déployé",

--- a/locales/pt.json
+++ b/locales/pt.json
@@ -66,7 +66,7 @@
   "error running afterDeploy: ": "erro ao executar afterDeploy: ",
   "ready to watch file changes": "pronto para monitorar alterações em ficheiros/arquivos",
   "Starting Server": "iniciando o servidor",
-  "webserver available at": "servidor web disponivel em",
+  "webserver available at": "Servidor web disponivel em",
   "Webserver": "servidor web",
   " already deployed at ": " já publicado em ",
   "Deployed": "Publicado",


### PR DESCRIPTION
## Overview
**TL;DR**
Put the webserver message at the end too, as it can be lost at the top

### Questions
I didn't remove the one at the top, because it comes from the start, and if we stop and restart the server using `websever start`, we want to have the message pop up. I could deactivate it on first run, but I don't feel it's useful. What do you think?



### Cool Spaceship Picture
![chozo_memories](https://user-images.githubusercontent.com/11926403/46684679-90025a00-cbc1-11e8-835f-c82db86c73b4.png)