### PR TITLE
Add message warning user a password is needed to unlock

### DIFF
--- a/lib/modules/blockchain_process/gethClient.js
+++ b/lib/modules/blockchain_process/gethClient.js
@@ -282,6 +282,9 @@ class GethClient {
           accountAddress = address;
         }
         if (accountAddress) {
+          if(!(self.config && self.config.account && self.config.account.password)){
+            console.warn(__("\n===== Password needed =====\nPassword for account {{account}} not found. Unlocking this account may fail. Please ensure a password is specified in config/blockchain.js > {{env}} > account > password.\n", {account: address, env: self.env}));
+          }
           args.push("--unlock=" + accountAddress);
           return callback(null, "--unlock=" + accountAddress);
         }


### PR DESCRIPTION
## Overview
**TL;DR**
When `mineWhenNeeded` is true (occurs in zero-config) and an account on the node exists, a password is required to be specified `config/blockchain.js > account > password` so that the existing account can be unlocked by geth (the `—unlock` cli option).

### Cool Spaceship Picture
![MIB](https://vfxblog.com/wp-content/uploads/2017/07/men_in_black_bg-7.jpg)