### PR TITLE
Auto set swarm account to account controlled by the node

### DIFF
--- a/lib/modules/blockchain_connector/index.js
+++ b/lib/modules/blockchain_connector/index.js
@@ -350,8 +350,9 @@ class BlockchainConnector {
       }
       let accountConfig = self.config.blockchainConfig.account;
       let selectedAccount = accountConfig && accountConfig.address;
-      self.setDefaultAccount(selectedAccount || accounts[0]);
-      cb();
+      const defaultAccount = selectedAccount || accounts[0];
+      self.setDefaultAccount(defaultAccount);
+      cb(null, defaultAccount);
     });
   }
 

--- a/lib/modules/storage/storageProcessesLauncher.js
+++ b/lib/modules/storage/storageProcessesLauncher.js
@@ -109,13 +109,21 @@ class StorageProcessesLauncher {
         silent: self.logger.logLevel !== 'trace',
         exitCallback: self.processExited.bind(this, storageName)
       });
-      self.processes[storageName].send({
-        action: constants.blockchain.init, options: {
-          storageConfig: self.storageConfig,
-          blockchainConfig: self.blockchainConfig,
-          cors: self.buildCors()
-        }
+      this.events.once("web3Ready", () => {
+        this.events.request("blockchain:object", (blockchain) => {
+          blockchain.determineDefaultAccount((err, defaultAccount) => {
+            self.processes[storageName].send({
+              action: constants.storage.init, options: {
+                storageConfig: self.storageConfig,
+                blockchainConfig: self.blockchainConfig,
+                cors: self.buildCors(),
+                defaultAccount: defaultAccount
+              }
+            });
+          });
+        });
       });
+      
 
       self.processes[storageName].on('result', constants.storage.initiated, (msg) => {
         if (msg.error) {

--- a/lib/modules/storage/storageProcessesLauncher.js
+++ b/lib/modules/storage/storageProcessesLauncher.js
@@ -112,6 +112,9 @@ class StorageProcessesLauncher {
       this.events.once("web3Ready", () => {
         this.events.request("blockchain:object", (blockchain) => {
           blockchain.determineDefaultAccount((err, defaultAccount) => {
+            if (err) {
+              return callback(err);
+            }
             self.processes[storageName].send({
               action: constants.storage.init, options: {
                 storageConfig: self.storageConfig,

--- a/lib/modules/swarm/process.js
+++ b/lib/modules/swarm/process.js
@@ -12,21 +12,43 @@ class SwarmProcess extends ProcessWrapper {
     this.blockchainConfig = options.blockchainConfig;
     this.cors = options.cors;
     this.command = this.storageConfig.swarmPath || 'swarm';
+    this.defaultAccount = options.defaultAccount;
   }
 
   startSwarmDaemon() {
     const self = this;
-    if (!this.storageConfig.account || !this.storageConfig.account.address || !this.storageConfig.account.password) {
+    let bzzaccount;
+    let password;
+    // use our storage config address/password if we have it
+    if (this.storageConfig.account && this.storageConfig.account.address && this.storageConfig.account.password) {
+      bzzaccount = this.storageConfig.account.address;
+      password = fs.dappPath(this.storageConfig.account.password);
+    }
+    // default to our blockchain config account, or our default account
+    else if (!this.blockchainConfig.isDev &&
+      this.blockchainConfig.mineWhenNeeded &&
+      this.blockchainConfig.account &&
+      (this.blockchainConfig.account.address || this.defaultAccount) &&
+      this.blockchainConfig.account.password
+    ) {
+      // defaultAccount is populated from blockchain_connector.determineDefaultAccount which is either
+      // config/blockchain.js > account > address or the first address returned from web3.eth.getAccounts
+      // (usually the default account)
+      bzzaccount = this.defaultAccount;
+      password = fs.dappPath(this.blockchainConfig.account.password);
+      console.trace(`Swarm account/password falling back to the blockchain account ${this.defaultAccount}. The account is either specified in config/blockchain.js > account > address or is the first address returned from web3.eth.getAccounts. The password is specified in config/blockchain.js > account > address.`);
+    }
+    else {
       return 'Account address and password are needed in the storage config to start the Swarm process';
     }
 
     const datadir = this.blockchainConfig.datadir || fs.dappPath(`.embark/development/datadir`);
     const args = [
       '--datadir', datadir,
-      '--bzzaccount', this.storageConfig.account.address,
-      '--password', fs.dappPath(this.storageConfig.account.password),
+      '--bzzaccount', bzzaccount,
       '--corsdomain', self.cors.join(',')
     ];
+    if (password) args.push('--password', password);
 
     console.trace('Starting swarm process with arguments: ' + args.join(' '));
     this.child = child_process.spawn(this.command, args);

--- a/lib/modules/swarm/process.js
+++ b/lib/modules/swarm/process.js
@@ -25,18 +25,16 @@ class SwarmProcess extends ProcessWrapper {
       password = fs.dappPath(this.storageConfig.account.password);
     }
     // default to our blockchain config account, or our default account
-    else if (!this.blockchainConfig.isDev &&
-      this.blockchainConfig.mineWhenNeeded &&
-      this.blockchainConfig.account &&
+    else if (this.blockchainConfig.account &&
       (this.blockchainConfig.account.address || this.defaultAccount) &&
       this.blockchainConfig.account.password
     ) {
       // defaultAccount is populated from blockchain_connector.determineDefaultAccount which is either
       // config/blockchain.js > account > address or the first address returned from web3.eth.getAccounts
       // (usually the default account)
-      bzzaccount = this.defaultAccount;
+      bzzaccount = this.blockchainConfig.account.address || this.defaultAccount;
       password = fs.dappPath(this.blockchainConfig.account.password);
-      console.trace(`Swarm account/password falling back to the blockchain account ${this.defaultAccount}. The account is either specified in config/blockchain.js > account > address or is the first address returned from web3.eth.getAccounts. The password is specified in config/blockchain.js > account > address.`);
+      console.trace(`Swarm account/password falling back to the blockchain account ${this.blockchainConfig.account.address || this.defaultAccount}. The account is either specified in config/blockchain.js > account > address or is the first address returned from web3.eth.getAccounts. The password is specified in config/blockchain.js > account > address.`);
     }
     else {
       return 'Account address and password are needed in the storage config to start the Swarm process';


### PR DESCRIPTION
## Overview
**TL;DR**
When there is no account/password specified for swarm, there was an error shown in the logs (asking for address/password), and the swarm process would quit.

This PR changes the behaviour so that if a swarm address/password are not specified in the config, it attempts to use the blockchain address/password specified in `config/blockchain > account`. If `config/blockchain > account > address` doesn’t exist, the first account controlled by the node is used (provided by `web3.eth.getAccounts`, along with the password from `config/blockchain > account > password`.

### Cool Spaceship Picture
![x-files](https://upload.wikimedia.org/wikipedia/en/9/90/BiogenesisXFiles.jpg)