### PR TITLE
Remove personal API from websockets by default

### DIFF
--- a/lib/modules/blockchain_process/gethClient.js
+++ b/lib/modules/blockchain_process/gethClient.js
@@ -8,7 +8,7 @@ const DEFAULTS = {
   "NETWORK_ID": 1337,
   "RPC_API": ['eth', 'web3', 'net', 'debug'],
   "WS_API": ['eth', 'web3', 'net', 'shh', 'debug', 'pubsub'],
-  "DEV_WS_API": ['eth', 'web3', 'net', 'shh', 'debug', 'pubsub', 'personal'],
+  "DEV_WS_API": ['eth', 'web3', 'net', 'shh', 'debug', 'pubsub'],
   "TARGET_GAS_LIMIT": 8000000
 };
 
@@ -47,7 +47,7 @@ class GethClient {
   needKeepAlive() {
     // TODO: check version also (geth version < 1.8.15)
     if (this.isDev) {
-      // Trigger regular txs due to a bug in geth (< 1.8.15) and stuck transactions in --dev mode.   
+      // Trigger regular txs due to a bug in geth (< 1.8.15) and stuck transactions in --dev mode.
       return true;
     }
     return false;

--- a/lib/modules/blockchain_process/parityClient.js
+++ b/lib/modules/blockchain_process/parityClient.js
@@ -8,7 +8,7 @@ const DEFAULTS = {
   "NETWORK_ID": 17,
   "RPC_API": ["web3", "eth", "pubsub", "net", "parity", "private", "parity_pubsub", "traces", "rpc", "shh", "shh_pubsub"],
   "WS_API": ["web3", "eth", "pubsub", "net", "parity", "private", "parity_pubsub", "traces", "rpc", "shh", "shh_pubsub"],
-  "DEV_WS_API": ["web3", "eth", "pubsub", "net", "parity", "private", "parity_pubsub", "traces", "rpc", "shh", "shh_pubsub", "personal"],
+  "DEV_WS_API": ["web3", "eth", "pubsub", "net", "parity", "private", "parity_pubsub", "traces", "rpc", "shh", "shh_pubsub"],
   "TARGET_GAS_LIMIT": 8000000,
   "DEV_ACCOUNT": "0x00a329c0648769a73afac7f9381e08fb43dbea72",
   "DEV_WALLET": {"id": "d9460e00-6895-8f58-f40c-bb57aebe6c00", "version": 3, "crypto": {"cipher": "aes-128-ctr", "cipherparams": {"iv": "74245f453143f9d06a095c6e6e309d5d"}, "ciphertext": "2fa611c4aa66452ef81bd1bd288f9d1ed14edf61aa68fc518093f97c791cf719", "kdf": "pbkdf2", "kdfparams": {"c": 10240, "dklen": 32, "prf": "hmac-sha256", "salt": "73b74e437a1144eb9a775e196f450a23ab415ce2c17083c225ddbb725f279b98"}, "mac": "f5882ae121e4597bd133136bf15dcbcc1bb2417a25ad205041a50c59def812a8"}, "address": "00a329c0648769a73afac7f9381e08fb43dbea72", "name": "Development Account", "meta": "{\"description\":\"Never use this account outside of development chain!\",\"passwordHint\":\"Password is empty string\"}"}


### PR DESCRIPTION
## Overview
**TL;DR**
Removes personal APIs by default from Geth and Parity.

**DO NOT MERGE YET**

### Cool Spaceship Picture
![](https://odditymall.com/includes/content/spaceship-camping-tent-for-kids-0.jpg)
