### PR TITLE
fix(core/cmd_controller): ensure webserver host and port aren't set to undefined

### DIFF
--- a/cmd/cmd_controller.js
+++ b/cmd/cmd_controller.js
@@ -59,19 +59,19 @@ class EmbarkController {
 
     const webServerConfig = {};
 
-    if (options.runWebserver !== null) {
+    if (options.runWebserver !== null && options.runWebserver !== undefined) {
       webServerConfig.enabled = options.runWebserver;
     }
 
-    if (options.serverHost !== null) {
+    if (options.serverHost !== null && options.serverHost !== undefined) {
       webServerConfig.host = options.serverHost;
     }
 
-    if (options.serverPort !== null) {
+    if (options.serverPort !== null && options.serverPort !== undefined) {
       webServerConfig.port = options.serverPort;
     }
 
-    if (options.openBrowser !== null) {
+    if (options.openBrowser !== null && options.openBrowser !== undefined) {
       webServerConfig.openBrowser = options.openBrowser;
     }
 


### PR DESCRIPTION

We've introduced a regression in https://github.com/embark-framework/embark/commit/6d75a4c6c4b993d39be91bae14baa3f1f5695f0c where running
`embark run` breaks due to webserver options not being defined.

The reason this happened is because in the mentioned commit, we're checking given
webserver options with an identity check against `null` and only set dedicated
options, if that condition is true.

E.g.:

```
if (options.runWebserver !== null) {
  webServerConfig.enabled = options.runWebserver;
}
```

Unfortunately, due to one of JavaScript design flaws, this condition behaves totally
different when no identity check is done, which causes Embark to break.

Meaning that in JavaScript:

```
undefined != null // false
undefined !== null // true
```

In other words, after the mentioned commit, the condition is true, resulting
in several webserver configurations to be set to `undefined`.

This conflicts at runtime when we compose webserver configurations out of user input
and Embark's defaults here: https://github.com/embark-framework/embark/blob/dc5de7c1b4f537c3137d207dc7258473e47d6a6c/lib/core/config.js#L392

In other words, since webserver config options are already set to `undefined`,
they don't get overridden by our config algorithm.

This commit ensures that webserver config values are not set when their values
are either `null` or `undefined`.
