### PR TITLE
enable self-referencing contracts in onDeploy

### DIFF
--- a/lib/modules/contracts_manager/index.js
+++ b/lib/modules/contracts_manager/index.js
@@ -276,6 +276,10 @@ class ContractsManager {
                 return;
               }
               cmd.replace(regex, (match) => {
+                if (match.substring(1) === contract.className) {
+                  // Contract self-referencing. In onDeploy, it should be available
+                  return;
+                }
                 self.contractDependencies[className] = self.contractDependencies[className] || [];
                 self.contractDependencies[className].push(match.substr(1));
               });

--- a/test_apps/test_app/test/simple_storage_spec.js
+++ b/test_apps/test_app/test/simple_storage_spec.js
@@ -7,22 +7,22 @@ config({
   contracts: {
     "SimpleStorage": {
       args: [100],
-      onDeploy: ["SimpleStorage.methods.setRegistar(web3.eth.defaultAccount).send()"]
+      onDeploy: ["SimpleStorage.methods.setRegistar('$SimpleStorage').send()"]
     }
   }
 }, (err, theAccounts) => {
   accounts = theAccounts;
 });
 
-contract("SimpleStorage", function () {
+contract("SimpleStorage", function() {
   this.timeout(0);
 
-  it("should set constructor value", async function () {
+  it("should set constructor value", async function() {
     let result = await SimpleStorage.methods.storedData().call();
     assert.strictEqual(parseInt(result, 10), 100);
   });
 
-  it("set storage value", function (done) {
+  it("set storage value", function(done) {
     Utils.secureSend(web3, SimpleStorage.methods.set(150), {}, false, async function(err) {
       if (err) {
         return done(err);
@@ -33,18 +33,21 @@ contract("SimpleStorage", function () {
     });
   });
 
-  it("should set defaultAccount", async function () {
+  it("should set to self address", async function() {
     let result = await SimpleStorage.methods.registar().call();
-    assert.strictEqual(result, web3.eth.defaultAccount);
+    assert.strictEqual(result, SimpleStorage.options.address);
+  });
+
+  it('should have the right defaultAccount', function() {
     assert.strictEqual(accounts[0], web3.eth.defaultAccount);
   });
 
-  it("should alias contract address", function () {
+  it("should alias contract address", function() {
     assert.strictEqual(SimpleStorage.options.address, SimpleStorage.address);
   });
 
-  it('listens to events', function (done) {
-    SimpleStorage.once('EventOnSet2', async function (error, _result) {
+  it('listens to events', function(done) {
+    SimpleStorage.once('EventOnSet2', async function(error, _result) {
       assert.strictEqual(error, null);
       let result = await SimpleStorage.methods.get().call();
       assert.strictEqual(parseInt(result, 10), 150);

--- a/test_apps/test_app/test/token_spec.js
+++ b/test_apps/test_app/test/token_spec.js
@@ -82,7 +82,7 @@ describe("Token", function () {
     assert.strictEqual(result, MyToken.options.address);
   });
 
-  it("should not deploy if deployIf returns false", async function() {
+  it("should not deploy if deployIf returns false", function() {
     assert.ok(!SomeContract.options.address);
   });
 });


### PR DESCRIPTION
Fixes the bug @tabcat had on Gitter where he had a circular dependency, but it can work, since the address is available in `onDeploy`