### PR TITLE
Warn re: unsupported blockchain client

### DIFF
--- a/lib/modules/blockchain_process/blockchain.js
+++ b/lib/modules/blockchain_process/blockchain.js
@@ -461,6 +461,7 @@ var BlockchainClient = function(userConfig, clientName, env, onReadyCallback, on
   userConfig.env = env;
   userConfig.onReadyCallback = onReadyCallback;
   userConfig.onExitCallback = onExitCallback;
+  userConfig.logger = logger;
   return new Blockchain(userConfig, clientClass);
 };
 

--- a/lib/modules/blockchain_process/blockchain.js
+++ b/lib/modules/blockchain_process/blockchain.js
@@ -305,6 +305,13 @@ Blockchain.prototype.isClientInstalled = function (callback) {
     if (err || !stdout || stderr.indexOf("not found") >= 0 || stdout.indexOf("not found") >= 0) {
       return callback(__('Ethereum client bin not found:') + ' ' + this.client.getBinaryPath());
     }
+    const parsedVersion = this.client.parseVersion(stdout);
+    const supported = this.client.isSupportedVersion(parsedVersion);
+    if (supported === undefined) {
+      this.logger.error((__('WARNING! Ethereum client version could not be determined or compared with version range') + ' ' + this.client.versSupported + __(', for best results please use a supported version')).yellow);
+    } else if (!supported) {
+      this.logger.error((__('WARNING! Ethereum client version unsupported, for best results please use a version in range') + ' ' + this.client.versSupported).yellow);
+    }
     callback();
   });
 };

--- a/lib/modules/blockchain_process/blockchainProcess.js
+++ b/lib/modules/blockchain_process/blockchainProcess.js
@@ -21,7 +21,8 @@ class BlockchainProcess extends ProcessWrapper {
       this.client,
       this.env,
       this.blockchainReady.bind(this),
-      this.blockchainExit.bind(this)
+      this.blockchainExit.bind(this),
+      console
     );
 
     this.blockchain.run();

--- a/lib/modules/blockchain_process/gethClient.js
+++ b/lib/modules/blockchain_process/gethClient.js
@@ -1,9 +1,11 @@
 const async = require('async');
 const GethMiner = require('./miner');
 const os = require('os');
+const semver = require('semver');
 
 const DEFAULTS = {
   "BIN": "geth",
+  "VERSIONS_SUPPORTED": ">=1.8.14",
   "NETWORK_TYPE": "custom",
   "NETWORK_ID": 1337,
   "RPC_API": ['eth', 'web3', 'net', 'debug', 'personal'],
@@ -26,6 +28,7 @@ class GethClient {
     this.name = "geth";
     this.prettyName = "Go-Ethereum (https://github.com/ethereum/go-ethereum)";
     this.bin = this.config.ethereumClientBin || DEFAULTS.BIN;
+    this.versSupported = DEFAULTS.VERSIONS_SUPPORTED;
     this.httpReady = false;
     this.wsReady = !this.config.wsRPC;
   }
@@ -90,6 +93,30 @@ class GethClient {
 
   determineVersionCommand() {
     return this.bin + " version";
+  }
+
+  parseVersion(rawVersionOutput) {
+    let parsed;
+    const match = rawVersionOutput.match(/Version: (.*)/);
+    if (match) {
+      parsed = match[1].trim();
+    }
+    return parsed;
+  }
+
+  isSupportedVersion(parsedVersion) {
+    let test;
+    try {
+      let v = semver(parsedVersion);
+      v = `${v.major}.${v.minor}.${v.patch}`;
+      test = semver.Range(this.versSupported).test(semver(v));
+      if (typeof test !== 'boolean') {
+        test = undefined;
+      }
+    } finally {
+      // eslint-disable-next-line no-unsafe-finally
+      return test;
+    }
   }
 
   determineNetworkType(config) {

--- a/lib/modules/blockchain_process/parityClient.js
+++ b/lib/modules/blockchain_process/parityClient.js
@@ -1,9 +1,11 @@
 const async = require('async');
 const fs = require('../../core/fs.js');
 const os = require('os');
+const semver = require('semver');
 
 const DEFAULTS = {
   "BIN": "parity",
+  "VERSIONS_SUPPORTED": ">=2.0.0",
   "NETWORK_TYPE": "dev",
   "NETWORK_ID": 17,
   "RPC_API": ["web3", "eth", "pubsub", "net", "parity", "private", "parity_pubsub", "traces", "rpc", "shh", "shh_pubsub"],
@@ -33,6 +35,7 @@ class ParityClient {
     this.name = "parity";
     this.prettyName = "Parity-Ethereum (https://github.com/paritytech/parity-ethereum)";
     this.bin = this.config.ethereumClientBin || DEFAULTS.BIN;
+    this.versSupported = DEFAULTS.VERSIONS_SUPPORTED;
   }
 
   isReady(data) {
@@ -111,6 +114,30 @@ class ParityClient {
 
   determineVersionCommand() {
     return this.bin + " --version";
+  }
+
+  parseVersion(rawVersionOutput) {
+    let parsed;
+    const match = rawVersionOutput.match(/version Parity-Ethereum\/(.*?)\//);
+    if (match) {
+      parsed = match[1].trim();
+    }
+    return parsed;
+  }
+
+  isSupportedVersion(parsedVersion) {
+    let test;
+    try {
+      let v = semver(parsedVersion);
+      v = `${v.major}.${v.minor}.${v.patch}`;
+      test = semver.Range(this.versSupported).test(semver(v));
+      if (typeof test !== 'boolean') {
+        test = undefined;
+      }
+    } finally {
+      // eslint-disable-next-line no-unsafe-finally
+      return test;
+    }
   }
 
   determineNetworkType(config) {


### PR DESCRIPTION
## Overview
**TL;DR**

If geth or parity (or others, in the future) is not within a client-specific supported-version range (or that version-test could not be performed), then a warning is printed.

There is some code-repeat across the client classes, but that can be addressed in a future PR that refactors them to specialize from a base class.

### Cool Spaceship Picture

![Thunderbirds](https://i.ytimg.com/vi/xnYG7R0nCmg/maxresdefault.jpg)