### PR TITLE
bug: empty response

### DIFF
--- a/embark-ui/src/actions/index.js
+++ b/embark-ui/src/actions/index.js
@@ -124,7 +124,7 @@ export const commands = {
         {
           timestamp: new Date().getTime(),
           name: EMBARK_PROCESS_NAME,
-          msg: `${ansiToHtml(command.result)}`,
+          msg: `${ansiToHtml(command.result || '')}`,
           command: `console> ${payload.command}<br>`,
 			    result: command.result
         }


### PR DESCRIPTION
## Overview
**TL;DR**
If the command return an empty result, don't break the client