### PR TITLE
Fix disabling whisper crashing the proxy

### DIFF
--- a/lib/constants.json
+++ b/lib/constants.json
@@ -56,5 +56,6 @@
   "logs": {
     "logPath": ".embark/logs/",
     "maxLogLength": 1500
-  }
+  },
+  "embarkResourceOrigin": "http://embark"
 }

--- a/lib/core/config.js
+++ b/lib/core/config.js
@@ -133,10 +133,8 @@ Config.prototype._updateBlockchainCors = function(){
       corsParts.push(utils.buildUrlFromConfig(storageConfig.upload));
     }
   }
-  // add whisper cors
-  if(this.communicationConfig && this.communicationConfig.enabled && this.communicationConfig.provider === 'whisper'){
-    corsParts.push('http://embark');
-  }
+  // Add cors for the proxy and whisper
+  corsParts.push(constants.embarkResourceOrigin);
 
   let cors = corsParts.join(',');
   if(blockchainConfig.rpcCorsDomain === 'auto'){

--- a/lib/modules/blockchain_connector/provider.js
+++ b/lib/modules/blockchain_connector/provider.js
@@ -1,6 +1,7 @@
 const async = require('async');
 const AccountParser = require('../../utils/accountParser');
 const fundAccount = require('./fundAccount');
+const constants = require('../../constants');
 
 class Provider {
   constructor(options) {
@@ -21,10 +22,10 @@ class Provider {
     } else if (this.type === 'ws') {
     // Note: don't pass to the provider things like {headers: {Origin: "embark"}}. Origin header is for browser to fill
     // to protect user, it has no meaning if it is used server-side. See here for more details: https://github.com/ethereum/go-ethereum/issues/16608
-    // Moreover, Parity reject origins that are not urls so if you try to connect with Origin: "embark" it gives the followin error:
+    // Moreover, Parity reject origins that are not urls so if you try to connect with Origin: "embark" it gives the following error:
     // << Blocked connection to WebSockets server from untrusted origin: Some("embark") >>
     // The best choice is to use void origin, BUT Geth rejects void origin, so to keep both clients happy we can use http://embark
-      self.provider = new this.web3.providers.WebsocketProvider(self.web3Endpoint, {headers: {Origin: "http://embark"}});
+      self.provider = new this.web3.providers.WebsocketProvider(self.web3Endpoint, {headers: {Origin: constants.embarkResourceOrigin}});
 
       self.provider.on('error', () => self.logger.error('Websocket Error'));
       self.provider.on('end', () => self.logger.error('Websocket connection ended'));

--- a/lib/modules/blockchain_process/dev_funds.js
+++ b/lib/modules/blockchain_process/dev_funds.js
@@ -2,6 +2,7 @@ const async = require('async');
 const Web3 = require('web3');
 const {buildUrl} = require('../../utils/utils.js');
 const {readFileSync, dappPath} = require('../../core/fs');
+const constants = require('../../constants');
 
 class DevFunds {
   constructor(options) {
@@ -11,7 +12,7 @@ class DevFunds {
     this.password = this.blockchainConfig.account.password ? readFileSync(dappPath(this.blockchainConfig.account.password), 'utf8').replace('\n', '') : 'dev_password';
     this.networkId = null;
     this.balance = Web3.utils.toWei("1", "ether");
-    this.provider = options.provider || new Web3.providers.WebsocketProvider(buildUrl('ws', this.blockchainConfig.wsHost, this.blockchainConfig.wsPort), {headers: {Origin: "http://embark"}});
+    this.provider = options.provider || new Web3.providers.WebsocketProvider(buildUrl('ws', this.blockchainConfig.wsHost, this.blockchainConfig.wsPort), {headers: {Origin: constants.embarkResourceOrigin}});
     this.web3 = new Web3(this.provider);
     if (this.blockchainConfig.account.balance) {
       this.balance = this.blockchainConfig.account.balance;

--- a/lib/modules/whisper/index.js
+++ b/lib/modules/whisper/index.js
@@ -4,6 +4,7 @@ let Web3 = require('web3');
 const {parallel} = require('async');
 const {sendMessage, listenTo} = require('./js/communicationFunctions');
 const messageEvents = require('./js/message_events');
+const constants = require('../../constants');
 
 const {canonicalHost, defaultHost} = require('../../utils/host');
 
@@ -44,7 +45,7 @@ class Whisper {
     // Moreover, Parity reject origins that are not urls so if you try to connect with Origin: "embark" it gives the followin error:
     // << Blocked connection to WebSockets server from untrusted origin: Some("embark") >>
     // The best choice is to use void origin, BUT Geth rejects void origin, so to keep both clients happy we can use http://embark
-    this.web3.setProvider(new Web3.providers.WebsocketProvider(web3Endpoint, {headers: {Origin: "http://embark"}}));
+    this.web3.setProvider(new Web3.providers.WebsocketProvider(web3Endpoint, {headers: {Origin: constants.embarkResourceOrigin}}));
   }
 
   waitForWeb3Ready(cb) {
@@ -133,7 +134,7 @@ class Whisper {
     const code = `\nEmbarkJS.Messages.setProvider('whisper', ${JSON.stringify(config)});`;
     this.embark.addProviderInit('communication', code, shouldInit);
 
-    const consoleConfig = Object.assign({}, config, {providerOptions: {headers: {Origin: "http://embark"}}});
+    const consoleConfig = Object.assign({}, config, {providerOptions: {headers: {Origin: constants.embarkResourceOrigin}}});
     const consoleCode = `\nEmbarkJS.Messages.setProvider('whisper', ${JSON.stringify(consoleConfig)});`;
     this.embark.addConsoleProviderInit('communication', consoleCode, shouldInit);
   }


### PR DESCRIPTION
Fixes https://github.com/embark-framework/embark/issues/1027
Was caused by a missing cors. We used to set `http://embark` as cors only for whisper, but it is needed for the proxy too.