### PR TITLE
Fix local install problems

### DIFF
--- a/embark-ui/package-lock.json
+++ b/embark-ui/package-lock.json
@@ -47,9 +47,9 @@
       }
     },
     "@types/node": {
-      "version": "10.12.0",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-10.12.0.tgz",
-      "integrity": "sha512-3TUHC3jsBAB7qVRGxT6lWyYo2v96BMmD2PTcl47H25Lu7UXtFH/2qqmKiVrnel6Ne//0TFYf6uvNX+HW2FRkLQ=="
+      "version": "10.12.5",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-10.12.5.tgz",
+      "integrity": "sha512-GzdHjq3t3eGLMv92Al90Iq+EoLL+86mPfQhuglbBFO7HiLdC/rkt+zrzJJumAiBF6nsrBWhou22rPW663AAyFw=="
     },
     "abab": {
       "version": "1.0.4",
@@ -2390,9 +2390,9 @@
       "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
     },
     "cors": {
-      "version": "2.8.4",
-      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.4.tgz",
-      "integrity": "sha1-K9OB8usgECAQXNUOpZ2mMJBpRoY=",
+      "version": "2.8.5",
+      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.5.tgz",
+      "integrity": "sha512-KIHbLJqu73RGr/hnbrO9uBeixNGuvSQjul/jdFvS/KFSIH1hWVd1ng7zOHx+YrEfInLG7q4n6GHQ9cDtxv/P6g==",
       "requires": {
         "object-assign": "^4",
         "vary": "^1"

--- a/src/cmd/cmd.js
+++ b/src/cmd/cmd.js
@@ -1,32 +1,10 @@
 const program = require('commander');
 const EmbarkController = require('./cmd_controller.js');
 const i18n = require('../lib/core/i18n/i18n.js');
+const fs = require('../lib/core/fs.js');
 const utils = require('../lib/utils/utils.js');
 
 let embark = new EmbarkController();
-
-// set PWD to process.cwd() since Windows doesn't have a value for PWD
-if (!process.env.PWD) {
-  process.env.PWD = process.cwd();
-}
-
-// set the anchor for embark's fs.dappPath()
-if (!process.env.DAPP_PATH) {
-  process.env.DAPP_PATH = process.env.PWD;
-}
-
-// set the anchor for embark's fs.embarkPath()
-if (!process.env.EMBARK_PATH) {
-  process.env.EMBARK_PATH = utils.joinPath(__dirname, '../..');
-}
-
-// set the anchor for embark's fs.pkgPath()
-if (!process.env.PKG_PATH) {
-  process.env.PKG_PATH = process.env.PWD;
-}
-
-process.env.DEFAULT_DIAGRAM_PATH = utils.joinPath(process.env.DAPP_PATH, 'diagram.svg');
-process.env.DEFAULT_CMD_HISTORY_SIZE = 20;
 
 class Cmd {
   constructor() {
@@ -308,7 +286,7 @@ class Cmd {
       .option('--skip-functions', __('Graph will not include functions'))
       .option('--skip-events', __('Graph will not include events'))
       .option('--locale [locale]', __('language to use (default: en)'))
-      .option('--output [svgfile]', __('filepath to output SVG graph to (default: %s)', process.env['DEFAULT_DIAGRAM_PATH']))
+      .option('--output [svgfile]', __('filepath to output SVG graph to (default: %s)', fs.diagramPath()))
       .description(__('generates documentation based on the smart contracts configured'))
       .action(function(env, options) {
         i18n.setOrDetectLocale(options.locale);
@@ -318,7 +296,7 @@ class Cmd {
           skipUndeployed: options.skipUndeployed,
           skipFunctions: options.skipFunctions,
           skipEvents: options.skipEvents,
-          output: options.output || process.env['DEFAULT_DIAGRAM_PATH']
+          output: options.output || fs.diagramPath()
         });
       });
   }

--- a/src/lib/core/env.js
+++ b/src/lib/core/env.js
@@ -1,0 +1,67 @@
+/* global __dirname module process require */
+
+const {delimiter} = require('path');
+const {joinPath} = require('../utils/utils.js');
+
+function anchoredValue(anchor, value) {
+  if (!arguments.length) {
+    throw new TypeError('anchor name was not specified');
+  }
+  if (arguments.length > 2) {
+    throw new TypeError('accepts at most 2 arguments');
+  }
+  if (typeof anchor !== 'string') {
+    throw new TypeError('anchor name was not a string');
+  }
+  let _anchor = process.env[anchor];
+  if (arguments.length < 2 && !_anchor) {
+    throw new Error(`process.env.${anchor} was not set`);
+  }
+  // don't override an existing value, e.g. if already set by bin/embark
+  if (!_anchor) {
+    _anchor = value;
+    process.env[anchor] = _anchor;
+  }
+  return _anchor;
+}
+
+const PWD = 'PWD';
+const DEFAULT_PWD = process.cwd();
+anchoredValue(PWD, DEFAULT_PWD);
+
+const DAPP_PATH = 'DAPP_PATH';
+const DEFAULT_DAPP_PATH = anchoredValue(PWD);
+anchoredValue(DAPP_PATH, DEFAULT_DAPP_PATH);
+
+const CMD_HISTORY_SIZE = 'CMD_HISTORY_SIZE';
+const DEFAULT_CMD_HISTORY_SIZE = 20;
+anchoredValue(CMD_HISTORY_SIZE, DEFAULT_CMD_HISTORY_SIZE);
+
+const DIAGRAM_PATH = 'DIAGRAM_PATH';
+const DEFAULT_DIAGRAM_PATH = joinPath(anchoredValue(DAPP_PATH), 'diagram.svg');
+anchoredValue(DIAGRAM_PATH, DEFAULT_DIAGRAM_PATH);
+
+const EMBARK_PATH = 'EMBARK_PATH';
+const DEFAULT_EMBARK_PATH = joinPath(__dirname, '../../..');
+anchoredValue(EMBARK_PATH, DEFAULT_EMBARK_PATH);
+
+const PKG_PATH = 'PKG_PATH';
+const DEFAULT_PKG_PATH = anchoredValue(PWD);
+anchoredValue(PKG_PATH, DEFAULT_PKG_PATH);
+
+const NODE_PATH = 'NODE_PATH';
+// NOTE: setting NODE_PATH at runtime won't effect lookup behavior in the
+// current process, but will take effect in child processes
+process.env[NODE_PATH] = joinPath(anchoredValue(EMBARK_PATH), 'node_modules') +
+  (process.env[NODE_PATH] ? delimiter : '') +
+  (process.env[NODE_PATH] || '');
+
+module.exports = {
+  anchoredValue,
+  PWD,
+  DAPP_PATH,
+  CMD_HISTORY_SIZE,
+  DIAGRAM_PATH,
+  EMBARK_PATH,
+  PKG_PATH
+};

--- a/src/lib/core/fs.js
+++ b/src/lib/core/fs.js
@@ -3,33 +3,8 @@ const os = require('os');
 let path = require('path');
 let fs = require('fs-extra');
 let utils = require('../utils/utils.js');
+let env = require('./env.js');
 require('colors');
-
-// set PWD to process.cwd() since Windows doesn't have a value for PWD
-if (!process.env.PWD) {
-  process.env.PWD = process.cwd();
-}
-
-// set the anchor for embark's fs.dappPath()
-if (!process.env.DAPP_PATH) {
-  process.env.DAPP_PATH = process.env.PWD;
-}
-
-// set the anchor for embark's fs.embarkPath()
-if (!process.env.EMBARK_PATH) {
-  process.env.EMBARK_PATH = utils.joinPath(__dirname, '../../..');
-}
-
-// set the anchor for embark's fs.pkgPath()
-if (!process.env.PKG_PATH) {
-  process.env.PKG_PATH = process.env.PWD;
-}
-
-const pathConfigs = {
-  DAPP_PATH: process.env.DAPP_PATH,
-  EMBARK_PATH: process.env.EMBARK_PATH,
-  PKG_PATH: process.env.PKG_PATH
-};
 
 function restrictPath(receiver, binding, count, args) {
   const dapp = dappPath();
@@ -149,25 +124,24 @@ function removeSync() {
   return restrictPath(fs.removeSync, fs.removeSync, 1, arguments);
 }
 
-function anchoredPath(envAnchor, ...args) {
-  let anchor = pathConfigs[envAnchor];
-  if (!pathConfigs[envAnchor]) {
-    console.error(`process.env.${envAnchor} was not set`.bold.red);
-    process.exit(1);
-  }
-  return utils.joinPath(anchor, ...args);
+function anchoredPath(anchor, ...args) {
+  return utils.joinPath(env.anchoredValue(anchor), ...args);
 }
 
 function embarkPath() {
-  return anchoredPath('EMBARK_PATH', ...arguments);
+  return anchoredPath(env.EMBARK_PATH, ...arguments);
 }
 
 function dappPath() {
-  return anchoredPath('DAPP_PATH', ...arguments);
+  return anchoredPath(env.DAPP_PATH, ...arguments);
+}
+
+function diagramPath() {
+  return anchoredPath(env.DIAGRAM_PATH, ...arguments);
 }
 
 function pkgPath() {
-  return anchoredPath('PKG_PATH', ...arguments);
+  return anchoredPath(env.PKG_PATH, ...arguments);
 }
 
 function createWriteStream() {
@@ -209,8 +183,11 @@ module.exports = {
   access,
   appendFileSync,
   copy,
+  copyPreserve,
   copySync,
   createWriteStream,
+  dappPath,
+  diagramPath,
   embarkPath,
   existsSync,
   mkdirp,
@@ -218,6 +195,7 @@ module.exports = {
   move,
   moveSync,
   outputFileSync,
+  pkgPath,
   readFile,
   readFileSync,
   readJSONSync,
@@ -231,8 +209,5 @@ module.exports = {
   writeFile,
   writeFileSync,
   writeJSONSync,
-  copyPreserve,
-  dappPath,
-  pkgPath,
   writeJson
 };

--- a/src/lib/modules/console/index.js
+++ b/src/lib/modules/console/index.js
@@ -1,3 +1,4 @@
+let env = require('../../core/env');
 let fs = require('../../core/fs');
 let utils = require('../../utils/utils');
 const EmbarkJS = require('embarkjs');
@@ -23,12 +24,16 @@ class Console {
       this.ipc.on('console:executeCmd', this.executeCmd.bind(this));
     }
     this.events.setCommandHandler("console:executeCmd", this.executeCmd.bind(this));
-    this.events.setCommandHandler("console:history", (cb) => this.getHistory(process.env.DEFAULT_CMD_HISTORY_SIZE, cb));
+    this.events.setCommandHandler("console:history", (cb) => this.getHistory(this.cmdHistorySize(), cb));
     this.registerEmbarkJs();
     this.registerConsoleCommands();
     this.registerApi();
 
     this.suggestions = new Suggestions(embark, options);
+  }
+
+  cmdHistorySize() {
+    return env.anchoredValue(env.CMD_HISTORY_SIZE);
   }
 
   registerApi() {
@@ -170,7 +175,7 @@ class Console {
         _length = parseInt(_length, 10);
         if (isNaN(_length)) return callback("Invalid argument. Please provide an integer.");
       }
-      let length = _length || process.env.DEFAULT_CMD_HISTORY_SIZE;
+      let length = _length || this.cmdHistorySize();
       return callback(null, this.history
                               .slice(Math.max(0, this.history.length - length))
                               .filter(line => line.trim())
@@ -182,7 +187,7 @@ class Console {
     if (fs.existsSync(utils.dirname(this.cmdHistoryFile))) {
       fs.writeFileSync(this.cmdHistoryFile,
                        this.history
-                        .slice(Math.max(0, this.history.length - process.env.DEFAULT_CMD_HISTORY_SIZE))
+                        .slice(Math.max(0, this.history.length - this.cmdHistorySize()))
                         .reverse()
                         .filter(line => line.trim())
                         .join('\n'));

--- a/src/test/fs.js
+++ b/src/test/fs.js
@@ -29,6 +29,7 @@ describe('fs', () => {
 
   const helperFunctions = [
     'dappPath',
+    'diagramPath',
     'embarkPath',
     'pkgPath',
     'tmpDir'


### PR DESCRIPTION
## Overview
**TL;DR**

DApps with embark installed locally were suffering from lingering module resolution problems, but not always... it depended on their dependencies. This PR tries to improve the situation in lieu of more extensive revisions (which may ultimately be necessary).

Among the changes included here, I've introduced a `lib/core/env.js` script, which groups together all of the `process.env.X` defaults and anchors. Also, due to sensitivity around plugin ordering, the default webpack config now includes @babel/plugin-proposal-decorators in the correct order relative to other plugins.

### More info

Several problems were noticed with [dreddit-devcon](https://github.com/status-im/dreddit-devcon), which was originally supposed to feature a local install of the latest embark 4 alpha version; similar problems could be reproduced with other DApps:

* @babel/core had to be included in the DApp's own dependencies even though embark should have been able to supply it to the DApp.
* The hard-source-webpack-plugin was mysteriously working with global but not local embark; then sometimes with neither... very confusing.

It turns out both problems were related to how the webpack.config.js script was looking up its dependencies. There were problems regardless of whether the config was ejected or not, with slight variations in behavior.

The immediate solution is to:

1. re-introduce the customization of NODE_PATH to include embark's own node_modules —  important for both global and local installs, owing to embark being shrinkwrapped. This fixes the lookup problem for @babel/core. I'm not too happy about putting NODE_PATH back in the equation, but I don't see a better quick fix at present.

2. Change the "custom require" logic in webpack.config.js to always lookup the modules it expects *starting* within embark's own node_modules. This fixes the problem with hard-source-webpack-plugin. We still need the NODE_PATH hack *and* the "custom require" because the latter is critical when the config script is being evaluated in the main embark process vs. a child process.

An explanation of the problem fixed by (2) may be helpful: depending on what changes I made to a DApp's deps while exploring the problem, an older version of lodash.clonedeep could be installed in the DApp's node_modules. The previous "custom require" logic would find that one first, but it behaved differently than the lodash.clonedeep version specified in embark's package.json; the end result was that the plugin instance (`new HardSourceWebpackPlugin()`) wasn't being properly cloned from the `base` config to the `development` or `production` configs. The problem was quite subtle, very hard to debug!

~I'm working on a write-up that will outline a more robust solution to these kinds of problems, which may crop up again in slightly different and equally difficult to debug forms.~

I've completed a write-up in https://github.com/embark-framework/embark/issues/1048 that outlines a more robust solution to these kinds of problems, to avoid their cropping up again in slightly different and equally difficult to debug forms.

### Cool Spaceship Picture

![Silver Surfer](https://static.comicvine.com/uploads/scale_small/3/31666/3627093-tumblr_mwhlifyyfk1spk5yeo1_1280.jpg)
