### PR TITLE
Change RPC to WS in contract configs

### DIFF
--- a/templates/boilerplate/config/contracts.js
+++ b/templates/boilerplate/config/contracts.js
@@ -4,8 +4,8 @@ module.exports = {
     // Blockchain node to deploy the contracts
     deployment: {
       host: "localhost", // Host of the blockchain node
-      port: 8545, // Port of the blockchain node
-      type: "rpc" // Type of connection (ws or rpc),
+      port: 8546, // Port of the blockchain node
+      type: "ws" // Type of connection (ws or rpc),
       // Accounts to use instead of the default account to populate your wallet
       /*,accounts: [
         {

--- a/templates/simple/contracts.js
+++ b/templates/simple/contracts.js
@@ -4,8 +4,8 @@ module.exports = {
     // Blockchain node to deploy the contracts
     deployment: {
       host: "localhost", // Host of the blockchain node
-      port: 8545, // Port of the blockchain node
-      type: "rpc" // Type of connection (ws or rpc),
+      port: 8546, // Port of the blockchain node
+      type: "ws" // Type of connection (ws or rpc),
       // Accounts to use instead of the default account to populate your wallet
       /*,accounts: [
         {

--- a/test_apps/coverage_app/config/contracts.js
+++ b/test_apps/coverage_app/config/contracts.js
@@ -4,8 +4,8 @@ module.exports = {
     // Blockchain node to deploy the contracts
     deployment: {
       host: "localhost", // Host of the blockchain node
-      port: 8545, // Port of the blockchain node
-      type: "rpc" // Type of connection (ws or rpc),
+      port: 8546, // Port of the blockchain node
+      type: "ws" // Type of connection (ws or rpc),
       // Accounts to use instead of the default account to populate your wallet
       /*,accounts: [
         {

--- a/test_apps/embark_demo/config/contracts.js
+++ b/test_apps/embark_demo/config/contracts.js
@@ -4,8 +4,8 @@ module.exports = {
     // Blockchain node to deploy the contracts
     deployment: {
       host: "localhost", // Host of the blockchain node
-      port: 8545, // Port of the blockchain node
-      type: "rpc" // Type of connection (ws or rpc),
+      port: 8546, // Port of the blockchain node
+      type: "ws" // Type of connection (ws or rpc),
       // Accounts to use instead of the default account to populate your wallet
       /*,accounts: [
         {


### PR DESCRIPTION
Since RPC is deprecated and the cockpit requires WS to have all the features activated