### PR TITLE
Improve error messages when contract deployment fails

### DIFF
--- a/lib/modules/deployment/index.js
+++ b/lib/modules/deployment/index.js
@@ -81,25 +81,20 @@ class DeployManager {
               contractDeploys[className].push(deploy);
             });
 
-            try {
-              async.auto(contractDeploys, 1, function(_err, _results) {
-                if (errors.length) {
-                  _err = __("Error deploying contracts. Please fix errors to continue.");
-                  self.logger.error(_err);
-                  self.events.emit("outputError", __("Error deploying contracts, please check console"));
-                  return done(_err);
-                }
-                if (contracts.length === 0) {
-                  self.logger.info(__("no contracts found"));
-                  return done();
-                }
-                self.logger.info(__("finished deploying contracts"));
-                done(err);
-              });
-            } catch (e) {
-              self.logger.error(e.message || e);
-              done(__('Error deploying'));
-            }
+            async.auto(contractDeploys, 1, function(_err, _results) {
+              if (errors.length) {
+                _err = __("Error deploying contracts. Please fix errors to continue.");
+                self.logger.error(_err);
+                self.events.emit("outputError", __("Error deploying contracts, please check console"));
+                return done(_err);
+              }
+              if (contracts.length === 0) {
+                self.logger.info(__("no contracts found"));
+                return done();
+              }
+              self.logger.info(__("finished deploying contracts"));
+              done(err);
+            });
           }
         ]);
       });

--- a/lib/modules/deployment/index.js
+++ b/lib/modules/deployment/index.js
@@ -65,7 +65,7 @@ class DeployManager {
                 self.events.request('deploy:contract', contract, (err) => {
                   if (err) {
                     contract.error = err.message || err;
-                    self.logger.error(err.message || err);
+                    self.logger.error(`[${contract.className}]: ${err.message || err}`);
                     errors.push(err);
                   }
                   callback();


### PR DESCRIPTION
As mentioned in #1038, when contract deployment fails, Embark doesn't give any information about which contract caused the error.