### PR TITLE
chore(CONTRIBUTING): update guide to use `master` instead of `develop…

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -63,7 +63,7 @@ Before you submit your Pull Request (PR) consider the following guidelines:
 1. Make your changes in a new git branch:
 
      ```shell
-     git checkout -b my-fix-branch develop
+     git checkout -b my-fix-branch master
      ```
 
 1. Create your patch, **including appropriate test cases**.
@@ -83,14 +83,14 @@ Before you submit your Pull Request (PR) consider the following guidelines:
     git push origin my-fix-branch
     ```
 
-1. In GitHub, send a pull request to `embark:develop`.
+1. In GitHub, send a pull request to `embark:master`.
 * If we suggest changes then:
   * Make the required updates.
   * Re-run the test suites to ensure tests are still passing.
   * Rebase your branch and force push to your GitHub repository (this will update your Pull Request):
 
     ```shell
-    git rebase develop -i
+    git rebase master -i
     git push -f
     ```
 
@@ -107,10 +107,10 @@ from the main (upstream) repository:
     git push origin --delete my-fix-branch
     ```
 
-* Check out the develop branch:
+* Check out the master branch:
 
     ```shell
-    git checkout develop -f
+    git checkout master -f
     ```
 
 * Delete the local branch:
@@ -119,10 +119,10 @@ from the main (upstream) repository:
     git branch -D my-fix-branch
     ```
 
-* Update your develop with the latest upstream version:
+* Update your master with the latest upstream version:
 
     ```shell
-    git pull --ff upstream develop
+    git pull --ff upstream master
     ```
 
 ## <a name="rules"></a> Coding Rules


### PR DESCRIPTION
…` branch

We've decided to have a single branch that is now `master`, no longer `develop`