### PR TITLE
fix(ci): make CI happy again by updating http paths to master branch

### DIFF
--- a/test/contracts/contract_with_http_import.sol
+++ b/test/contracts/contract_with_http_import.sol
@@ -1,5 +1,5 @@
 pragma solidity ^0.4.7;
-import "https://github.com/embark-framework/embark/blob/develop/test_apps/contracts_app/contracts/contract_args.sol";
+import "https://github.com/embark-framework/embark/blob/master/test_apps/contracts_app/contracts/contract_args.sol";
 contract SimpleStorage {
   uint public storedData;
 

--- a/test/file.js
+++ b/test/file.js
@@ -10,7 +10,7 @@ describe('embark.File', function () {
     it('should find all the imports', function (done) {
       const contract = fs.readFileSync('./test/contracts/contract_with_import.sol').toString();
       const file = new File({filename: '.embark/contracts/embark-framework/embark/master/test_app/app/contracts/simple_storage.sol',
-        path: 'https://raw.githubusercontent.com/embark-framework/embark/develop/test_apps/test_app/app/contracts/simple_storage.sol'});
+        path: 'https://raw.githubusercontent.com/embark-framework/embark/master/test_apps/test_app/app/contracts/simple_storage.sol'});
       const downloadFileStub = sinon.stub(file, 'downloadFile')
         .callsFake((path, url, cb) => {
           cb();
@@ -21,7 +21,7 @@ describe('embark.File', function () {
         assert.strictEqual(downloadFileStub.firstCall.args[0],
           path.normalize('.embark/contracts/embark-framework/embark/master/test_app/app/contracts/ownable.sol'));
         assert.strictEqual(downloadFileStub.firstCall.args[1],
-          'https://raw.githubusercontent.com/embark-framework/embark/develop/test_apps/test_app/app/contracts/./ownable.sol');
+          'https://raw.githubusercontent.com/embark-framework/embark/master/test_apps/test_app/app/contracts/./ownable.sol');
         done();
       });
     });
@@ -29,7 +29,7 @@ describe('embark.File', function () {
     it('should find all the imports but not call download because not a http contract', function (done) {
       const contract = fs.readFileSync('./test/contracts/contract_with_import.sol').toString();
       const file = new File({filename: '.embark/contracts/embark-framework/embark/master/test_app/app/contracts/simple_storage.sol',
-        path: 'https://raw.githubusercontent.com/embark-framework/embark/develop/test_apps/test_app/app/contracts/simple_storage.sol'});
+        path: 'https://raw.githubusercontent.com/embark-framework/embark/master/test_apps/test_app/app/contracts/simple_storage.sol'});
       const downloadFileStub = sinon.stub(file, 'downloadFile')
         .callsFake((path, url, cb) => {
           cb();
@@ -44,7 +44,7 @@ describe('embark.File', function () {
     it('should find all the imports and call downlaod because it is an http import', function (done) {
       const contract = fs.readFileSync('./test/contracts/contract_with_http_import.sol').toString();
       const file = new File({filename: '.embark/contracts/embark-framework/embark/master/test_app/app/contracts/simple_storage.sol',
-        path: 'https://raw.githubusercontent.com/embark-framework/embark/develop/test_apps/test_app/app/contracts/simple_storage.sol'});
+        path: 'https://raw.githubusercontent.com/embark-framework/embark/master/test_apps/test_app/app/contracts/simple_storage.sol'});
       const downloadFileStub = sinon.stub(file, 'downloadFile')
         .callsFake((path, url, cb) => {
           cb();
@@ -53,9 +53,9 @@ describe('embark.File', function () {
       file.parseFileForImport(contract, () => {
         assert.strictEqual(downloadFileStub.callCount, 1);
         assert.strictEqual(downloadFileStub.firstCall.args[0],
-          '.embark/contracts/embark-framework/embark/develop/test_apps/contracts_app/contracts/contract_args.sol');
+          '.embark/contracts/embark-framework/embark/master/test_apps/contracts_app/contracts/contract_args.sol');
         assert.strictEqual(downloadFileStub.firstCall.args[1],
-          'https://raw.githubusercontent.com/embark-framework/embark/develop/test_apps/contracts_app/contracts/contract_args.sol');
+          'https://raw.githubusercontent.com/embark-framework/embark/master/test_apps/contracts_app/contracts/contract_args.sol');
         done();
       });
     });
@@ -63,7 +63,7 @@ describe('embark.File', function () {
     it('should find all the imports but only once if called twice', function (done) {
       const contract = fs.readFileSync('./test/contracts/contract_with_http_import.sol').toString();
       const file = new File({filename: '.embark/contracts/embark-framework/embark/master/test_app/app/contracts/simple_storage.sol',
-        path: 'https://raw.githubusercontent.com/embark-framework/embark/develop/test_apps/test_app/app/contracts/simple_storage.sol'});
+        path: 'https://raw.githubusercontent.com/embark-framework/embark/master/test_apps/test_app/app/contracts/simple_storage.sol'});
       const downloadFileStub = sinon.stub(file, 'downloadFile')
         .callsFake((path, url, cb) => {
           cb();
@@ -74,9 +74,9 @@ describe('embark.File', function () {
         file.parseFileForImport(contract, () => {
           assert.strictEqual(downloadFileStub.callCount, 1);
           assert.strictEqual(downloadFileStub.firstCall.args[0],
-            '.embark/contracts/embark-framework/embark/develop/test_apps/contracts_app/contracts/contract_args.sol');
+            '.embark/contracts/embark-framework/embark/master/test_apps/contracts_app/contracts/contract_args.sol');
           assert.strictEqual(downloadFileStub.firstCall.args[1],
-            'https://raw.githubusercontent.com/embark-framework/embark/develop/test_apps/contracts_app/contracts/contract_args.sol');
+            'https://raw.githubusercontent.com/embark-framework/embark/master/test_apps/contracts_app/contracts/contract_args.sol');
           done();
         });
       });

--- a/test_apps/test_app/app/contracts/SimpleStorageWithHttpImport.sol
+++ b/test_apps/test_app/app/contracts/SimpleStorageWithHttpImport.sol
@@ -1,7 +1,7 @@
 pragma solidity ^0.4.17;
 
-import "https://github.com/embark-framework/embark/blob/develop/test_apps/contracts_app/contracts/ownable.sol";
-import "https://github.com/embark-framework/embark/blob/develop/test_apps/contracts_app/contracts/contract_args.sol";
+import "https://github.com/embark-framework/embark/blob/master/test_apps/contracts_app/contracts/ownable.sol";
+import "https://github.com/embark-framework/embark/blob/master/test_apps/contracts_app/contracts/contract_args.sol";
 
 
 contract SimpleStorageWithHttpImport is Ownable {

--- a/test_apps/test_app/test/http_contract_test.js
+++ b/test_apps/test_app/test/http_contract_test.js
@@ -25,7 +25,7 @@ describe('http contracts', () => {
   });
 
   it('should have downloaded the http import in SimpleStorageWithHttpImport', (done) => {
-    const contractImportPath = '.embark/contracts/embark-framework/embark/develop/test_apps/contracts_app/contracts/ownable.sol';
+    const contractImportPath = '.embark/contracts/embark-framework/embark/master/test_apps/contracts_app/contracts/ownable.sol';
     fs.access(contractImportPath, (err) => {
       if (err) {
         assert.fail(contractImportPath + ' was not downloaded');


### PR DESCRIPTION
Some test endpoints have still pointed to `develop` branch on GitHub,
which made our tests fail as we're now on `master` branch