### PR TITLE
fix(@embark/core): don't expect `balance` on `accounts`

### DIFF
--- a/src/lib/core/config.js
+++ b/src/lib/core/config.js
@@ -294,7 +294,7 @@ Config.prototype.loadContractsConfigFile = function() {
   }
   if (newContractsConfig.deployment && 'accounts' in newContractsConfig.deployment) {
     newContractsConfig.deployment.accounts.forEach((account) => {
-      if (account.balance.match(unitRegex)) {
+      if (account.balance && account.balance.match(unitRegex)) {
         account.balance = utils.getWeiBalanceFromString(account.balance, web3);
       }
     });


### PR DESCRIPTION
In https://github.com/embark-framework/embark/pull/975/commits/594d1323faa272ef305e9870b8dd6f8db63f4d10 we've introduced the ability
to configure balance-related options with human readable ether units.

There are cases where there's account configurations that don't come
with a `balance` property, which breaks Embark when running an Embark app.

Fixes #1067