### PR TITLE
feat(@embark/cli): add --template option to embark demo cli command

### DIFF
--- a/src/cmd/cmd.js
+++ b/src/cmd/cmd.js
@@ -88,10 +88,19 @@ class Cmd {
     program
       .command('demo')
       .option('--locale [locale]', __('language to use (default: en)'))
+      .option('--template <name/url>', __('download a demo template using a known name or a git host URL'))
       .description(__('create a working dapp with a SimpleStorage contract'))
       .action(function(options) {
         i18n.setOrDetectLocale(options.locale);
-        embark.generateTemplate('demo', './', 'embark_demo');
+        if(options.template) {
+          const hostedGitInfo = require('hosted-git-info');
+          const hgi = hostedGitInfo.fromUrl(options.template);
+          const url = !hgi ? `embark-framework/embark-${options.template}-template#demo`:options.template;
+          const folderName = !hgi ? `embark_${options.template}_demo`:'template_demo';
+          embark.generateTemplate('demo', './', folderName, url);
+        } else {
+          embark.generateTemplate('demo', './', 'embark_demo');
+        }
       });
   }
 


### PR DESCRIPTION
## Overview

This PR aims to solve issue #937 and supersedes PR #999 to match new contributing criteria. 

It Adds a --template option to the embark demo CLI command so it is now possible to generate a demo project using an existing embark's template repository on Github with an existing demo branch (e.g. `embark demo --template vue` will use `embark-framework/embark-vue-template#demo`) or any other git URL repository. If no `--template` option is specified, the command  will generate a demo from default template in `templates/demo`.

This new feature will allow users to create a dapp demo using, for example Vue.js framework. A corresponding template will be sent to demo branch in [https://github.com/embark-framework/embark-vue-template](https://github.com/embark-framework/embark-vue-template)

### Review

The `demo` branch in [https://github.com/embark-framework/embark-vue-template](https://github.com/embark-framework/embark-vue-template) repository has not been created yet (see https://github.com/embark-framework/embark-vue-template/pull/3#issuecomment-438110894), but it is possible to test the corresponding Vue.js demo tamplate by running the command `embark demo --template https://github.com/santteegt/embark-vue-template#demo`, which points to my current fork repository.