### PR TITLE
feat: run coverage for bytecode and deployedBytecode

### DIFF
--- a/src/lib/modules/coverage/contractSource.js
+++ b/src/lib/modules/coverage/contractSource.js
@@ -1,4 +1,4 @@
-const SourceMap = require('./source_map');
+const SourceMap = require('./sourceMap');
 
 class ContractSource {
   constructor(file, path, body) {
@@ -18,11 +18,11 @@ class ContractSource {
   }
 
   sourceMapToLocations(sourceMap) {
-    var [offset, length, ..._] = sourceMap.split(":").map((val) => {
+    const [offset, length, ..._] = sourceMap.split(":").map((val) => {
       return parseInt(val, 10);
     });
 
-    var locations = {};
+    const locations = {};
 
     for(let i = 0; i < this.lineCount; i++) {
       if(this.lineOffsets[i+1] <= offset) continue;
@@ -31,7 +31,7 @@ class ContractSource {
       break;
     }
 
-    for(var i = locations.start.line; i < this.lineCount; i++) {
+    for(let i = locations.start.line; i < this.lineCount; i++) {
       if(this.lineOffsets[i+1] <= offset + length) continue;
 
       locations.end = {line: i, column: ((offset + length) - this.lineOffsets[i])};
@@ -41,7 +41,7 @@ class ContractSource {
     // Ensure we return an "end" as a safeguard if the marker ends up to be
     // or surpass the offset for last character.
     if(!locations.end) {
-      var lastLine = this.lineCount - 1;
+      const lastLine = this.lineCount - 1;
       locations.end = {line: lastLine, column: this.lineLengths[lastLine]};
     }
 
@@ -57,7 +57,7 @@ class ContractSource {
     this.contractBytecode = {};
     this.contractDeployedBytecode = {};
 
-    for(var contractName in contracts) {
+    for(const contractName in contracts) {
       this.contractBytecode[contractName] = {};
       this.contractDeployedBytecode[contractName] = {};
 
@@ -81,7 +81,7 @@ class ContractSource {
   generateCodeCoverage(trace) {
     if(!this.ast || !this.contractBytecode) throw new Error('Error generating coverage: solc output was not assigned');
 
-    let coverage = {
+    const coverage = {
       code: this.body.trim().split("\n"),
       l: {},
       path: this.path,
@@ -93,11 +93,11 @@ class ContractSource {
       branchMap: {}
     };
 
-    var nodesRequiringVisiting = [this.ast];
-    var sourceMapToNodeType = {};
+    let nodesRequiringVisiting = [this.ast];
+    const sourceMapToNodeType = {};
 
     do {
-      let node = nodesRequiringVisiting.pop();
+      const node = nodesRequiringVisiting.pop();
       if(!node) continue;
 
       let children = [];
@@ -117,12 +117,12 @@ class ContractSource {
 
         case 'IfStatement': {
           location = this.sourceMapToLocations(node.src);
-          let trueBranchLocation = this.sourceMapToLocations(node.trueBody.src);
+          const trueBranchLocation = this.sourceMapToLocations(node.trueBody.src);
 
-          let declarationSourceMap = new SourceMap(node.src).subtract(new SourceMap(node.trueBody.src));
-          let declarationLocation = this.sourceMapToLocations(declarationSourceMap.toString());
+          const declarationSourceMap = new SourceMap(node.src).subtract(new SourceMap(node.trueBody.src));
+          const declarationLocation = this.sourceMapToLocations(declarationSourceMap.toString());
 
-          var falseBranchLocation;
+          let falseBranchLocation;
           if(node.falseBody) {
             falseBranchLocation = this.sourceMapToLocations(node.falseBody.src);
           } else {
@@ -139,13 +139,13 @@ class ContractSource {
           markLocations = [declarationLocation];
           children = [node.condition];
 
-          let trueExpression = (node.trueBody && node.trueBody.statements && node.trueBody.statements[0]) || node.trueBody;
+          const trueExpression = (node.trueBody && node.trueBody.statements && node.trueBody.statements[0]) || node.trueBody;
           if(trueExpression) {
             children = children.concat(trueExpression);
             trueExpression._parent = {type: 'b', id: node.id, idx: 0};
           }
 
-          let falseExpression = (node.falseBody && node.falseBody.statements && node.falseBody.statements[0]) || node.falseBody;
+          const falseExpression = (node.falseBody && node.falseBody.statements && node.falseBody.statements[0]) || node.falseBody;
           if(falseExpression) {
             children = children.concat(falseExpression);
             falseExpression._parent = {type: 'b', id: node.id, idx: 1};
@@ -188,18 +188,18 @@ class ContractSource {
           break;
 
         case 'ModifierDefinition':
-        case 'FunctionDefinition':
+        case 'FunctionDefinition': {
           // Istanbul only wants the function definition, not the body, so we're
           // going to do some fun math here.
-          var functionSourceMap = new SourceMap(node.src);
-          var functionParametersSourceMap = new SourceMap(node.parameters.src);
+          const functionSourceMap = new SourceMap(node.src);
+          const functionParametersSourceMap = new SourceMap(node.parameters.src);
 
-          var functionDefinitionSourceMap = new SourceMap(
+          const functionDefinitionSourceMap = new SourceMap(
             functionSourceMap.offset,
             (functionParametersSourceMap.offset + functionParametersSourceMap.length) - functionSourceMap.offset
           ).toString();
 
-          var fnName = node.isConstructor ? "(constructor)" : node.name;
+          const fnName = node.isConstructor ? "(constructor)" : node.name;
           location = this.sourceMapToLocations(functionDefinitionSourceMap);
 
           coverage.f[node.id] = 0;
@@ -215,19 +215,19 @@ class ContractSource {
           if(node.body) children = node.body.statements;
           markLocations = [location];
           break;
-
+        }
         case 'ForStatement': {
           // For statements will be a bit of a special case. We want to count the body
           // iterations but we only want to count the for loop being hit once. Because
           // of this, we cover the initialization on the node.
-          let sourceMap = new SourceMap(node.src);
-          let bodySourceMap = new SourceMap(node.body.src);
-          let forLoopDeclaration = sourceMap.subtract(bodySourceMap).toString();
+          const sourceMap = new SourceMap(node.src);
+          const bodySourceMap = new SourceMap(node.body.src);
+          const forLoopDeclaration = sourceMap.subtract(bodySourceMap).toString();
 
           location = this.sourceMapToLocations(forLoopDeclaration);
 
-          let markExpression = node.initializationExpression || node.loopExpression;
-          let expressionLocation = this.sourceMapToLocations(markExpression.src);
+          const markExpression = node.initializationExpression || node.loopExpression;
+          const expressionLocation = this.sourceMapToLocations(markExpression.src);
 
           if(!sourceMapToNodeType[markExpression.src]) sourceMapToNodeType[markExpression.src] = [];
           sourceMapToNodeType[markExpression.src].push({type: 's', id: node.id, body: {loc: location}});
@@ -274,9 +274,9 @@ class ContractSource {
   }
 
   _generateCodeCoverageForBytecode(trace, coverage, sourceMapToNodeType, contractBytecode) {
-    var contractMatches = true;
-    for(var contractName in contractBytecode) {
-      var bytecode = contractBytecode[contractName];
+    let contractMatches = true;
+    for(const contractName in contractBytecode) {
+      const bytecode = contractBytecode[contractName];
 
       // Try to match the contract to the bytecode. If it doesn't,
       // then we bail.
@@ -287,8 +287,8 @@ class ContractSource {
       trace.structLogs.forEach((step) => {
         step = bytecode[step.pc];
         if(!step.sourceMap || step.sourceMap === '' || step.sourceMap === SourceMap.empty()) return;
-        let sourceMapString = step.sourceMap.toString(this.id);
-        var nodes = sourceMapToNodeType[sourceMapString];
+        const sourceMapString = step.sourceMap.toString(this.id);
+        const nodes = sourceMapToNodeType[sourceMapString];
 
         if(!nodes) return;
 
@@ -297,7 +297,7 @@ class ContractSource {
           if(node.type === 'f' && step.jump) return;
 
           if(node.type !== 'b' && node.body && node.body.loc) {
-            for(var line = node.body.loc.start.line; line <= node.body.loc.end.line; line++) {
+            for(let line = node.body.loc.start.line; line <= node.body.loc.end.line; line++) {
               coverage.l[line]++;
             }
           }
@@ -320,11 +320,11 @@ class ContractSource {
   }
 
   _buildContractBytecode(contractName, contractBytecode, opcodes, sourceMaps) {
-    var bytecodeMapping = contractBytecode[contractName];
-    var bytecodeIdx = 0;
-    var pc = 0;
-    var instructions = 0;
-    var previousSourceMap = null;
+    const bytecodeMapping = contractBytecode[contractName];
+    let bytecodeIdx = 0;
+    let pc = 0;
+    let instructions = 0;
+    let previousSourceMap = null;
 
     do {
       let sourceMap;
@@ -335,8 +335,8 @@ class ContractSource {
         sourceMap = previousSourceMap.createRelativeTo(sourceMapArgs);
       }
 
-      var instruction = opcodes[bytecodeIdx];
-      var length = this._instructionLength(instruction);
+      const instruction = opcodes[bytecodeIdx];
+      const length = this._instructionLength(instruction);
       bytecodeMapping[pc] = {
         instruction: instruction,
         sourceMap: sourceMap,

--- a/src/lib/modules/coverage/contractSources.js
+++ b/src/lib/modules/coverage/contractSources.js
@@ -1,7 +1,7 @@
 const fs = require('fs');
 const path = require('path');
 
-const ContractSource = require('./contract_source');
+const ContractSource = require('./contractSource');
 
 class ContractSources {
   constructor(files) {
@@ -20,7 +20,7 @@ class ContractSources {
 
       case '[object Array]':
         files.forEach((file) => {
-          var content = fs.readFileSync(file).toString();
+          const content = fs.readFileSync(file).toString();
           this.addFile(file, content);
         });
         break;
@@ -31,37 +31,37 @@ class ContractSources {
   }
 
   addFile(fullPath, contents) {
-    let basename = path.basename(fullPath);
+    const basename = path.basename(fullPath);
     if(this.files[basename]) return;
 
     this.files[basename] = new ContractSource(basename, fullPath, contents);
   }
 
   toSolcInputs() {
-    var inputs = {};
+    const inputs = {};
 
-    for(var file in this.files) {
-      inputs[file] = {content: this.files[file].body};
+    for(const filename in this.files) {
+      inputs[filename] = {content: this.files[filename].body};
     }
 
     return inputs;
   }
 
   parseSolcOutput(output) {
-    for(var file in output.contracts) {
-      var contractSource = this.files[path.basename(file)];
+    for(const filename in output.contracts) {
+      const contractSource = this.files[path.basename(filename)];
       if(!contractSource) continue;
 
-      contractSource.parseSolcOutput(output.sources[file], output.contracts[file]);
+      contractSource.parseSolcOutput(output.sources[filename], output.contracts[filename]);
     }
   }
 
   generateCodeCoverage(trace) {
-    var coverageReport = {};
+    const coverageReport = {};
 
-    for(var file in this.files) {
-      if(this.files[file].isInterface()) continue;
-      coverageReport[file] = this.files[file].generateCodeCoverage(trace);
+    for(const filename in this.files) {
+      if(this.files[filename].isInterface()) continue;
+      coverageReport[filename] = this.files[filename].generateCodeCoverage(trace);
     }
 
     if(!this.coverageReport) {

--- a/src/lib/modules/coverage/index.js
+++ b/src/lib/modules/coverage/index.js
@@ -1,7 +1,6 @@
 /*global web3*/
 const fs = require('../../core/fs');
-const ContractSources = require('./contract_sources');
-
+const ContractSources = require('./contractSources');
 
 class CodeCoverage {
   constructor(embark, _options) {
@@ -54,21 +53,19 @@ class CodeCoverage {
     let block = await web3.eth.getBlock(receipt.number);
     if(block.transactions.length === 0) return;
 
-    let requests = [];
-    for(let i in block.transactions) {
-      var txHash = block.transactions[i];
-
+    let requests = block.transactions.reduce((acc, txHash) => {
       if(this.seenTransactions[txHash]) return;
 
       this.seenTransactions[txHash] = true;
-      requests.push(web3.debug.traceTransaction(txHash, {}));
-    }
+      acc.push(web3.debug.traceTransaction(txHash, {}));
+      return acc;
+    }, []);
 
     let traces = await Promise.all(requests);
 
-    for(let i in traces) {
-      this.coverageReport = this.contractSources.generateCodeCoverage(traces[i]);
-    }
+    traces.forEach(trace => {
+      this.coverageReport = this.contractSources.generateCodeCoverage(trace);
+    });
   }
 }
 

--- a/src/lib/modules/coverage/sourceMap.js
+++ b/src/lib/modules/coverage/sourceMap.js
@@ -12,7 +12,7 @@ const EmptySourceMap = {
 class SourceMap {
   constructor(sourceMapStringOrOffset, length, id, jump) {
     if(typeof sourceMapStringOrOffset === 'string') {
-      let [offset, length, id, jump] = sourceMapStringOrOffset.split(":");
+      const [offset, length, id, jump] = sourceMapStringOrOffset.split(":");
 
       this.offset = parseInt(offset, 10);
       this.length = parseInt(length, 10);
@@ -44,7 +44,7 @@ class SourceMap {
   }
 
   toString(defaultId) {
-    let parts = [this.offset, this.length];
+    const parts = [this.offset, this.length];
 
     if(this.id !== undefined && this.id !== '') {
       parts.push(this.id);

--- a/src/test/coverage.js
+++ b/src/test/coverage.js
@@ -4,9 +4,9 @@ const fs = require('fs');
 const path = require('path');
 const sinon = require('sinon');
 
-const ContractSources = require('../lib/modules/coverage/contract_sources');
-const ContractSource = require('../lib/modules/coverage/contract_source');
-const SourceMap = require('../lib/modules/coverage/source_map');
+const ContractSources = require('../lib/modules/coverage/contractSources');
+const ContractSource = require('../lib/modules/coverage/contractSource');
+const SourceMap = require('../lib/modules/coverage/sourceMap');
 
 function fixturePath(fixture) {
   return path.join(__dirname, 'fixtures', fixture);

--- a/src/test/coverage.js
+++ b/src/test/coverage.js
@@ -16,10 +16,6 @@ function loadFixture(fixture) {
   return fs.readFileSync(fixturePath(fixture)).toString();
 }
 
-function dumpToFile(obj, path) {
-  return fs.writeFileSync(path, JSON.stringify(obj));
-}
-
 describe('ContractSources', () => {
   describe('constructor', () => {
     it('should read files and create instances of ContractSource', (done) => {
@@ -149,6 +145,29 @@ contract x {
   });
 
   describe('#parseSolcOutput', () => {
+    it('should parse the deployed bytecode output correctly', (done) => {
+      var solcOutput = JSON.parse(loadFixture('solc-output.json'));
+      const contractPath = fixturePath('cont.sol');
+      var cs = new ContractSources(contractPath);
+      cs.parseSolcOutput(solcOutput);
+
+      var contractSource = cs.files['cont.sol'];
+
+      assert.isNotEmpty(contractSource.contractDeployedBytecode);
+      assert.isNotEmpty(contractSource.contractDeployedBytecode['x']);
+
+      var bytecode = contractSource.contractDeployedBytecode['x'];
+
+      assert.deepEqual({instruction: 'PUSH1', sourceMap: {offset: 26, length: 487, id: 0, jump: '-'}, jump: '-', seen: false}, bytecode[0]);
+      assert.deepEqual({instruction: 'PUSH1', sourceMap: SourceMap.empty(), seen: false, jump: undefined}, bytecode[2]);
+      assert.deepEqual({instruction: 'MSTORE', sourceMap: SourceMap.empty(), seen: false, jump: undefined}, bytecode[4]);
+      assert.deepEqual({instruction: 'PUSH1', sourceMap: SourceMap.empty(), seen: false, jump: undefined}, bytecode[5]);
+
+      done();
+    });
+  });
+
+  describe('#parseSolcOutput', () => {
     it('should parse the bytecode output correctly', (done) => {
       var solcOutput = JSON.parse(loadFixture('solc-output.json'));
       const contractPath = fixturePath('cont.sol');
@@ -165,7 +184,7 @@ contract x {
       assert.deepEqual({instruction: 'PUSH1', sourceMap: {offset: 26, length: 487, id: 0, jump: '-'}, jump: '-', seen: false}, bytecode[0]);
       assert.deepEqual({instruction: 'PUSH1', sourceMap: SourceMap.empty(), seen: false, jump: undefined}, bytecode[2]);
       assert.deepEqual({instruction: 'MSTORE', sourceMap: SourceMap.empty(), seen: false, jump: undefined}, bytecode[4]);
-      assert.deepEqual({instruction: 'PUSH1', sourceMap: SourceMap.empty(), seen: false, jump: undefined}, bytecode[5]);
+      assert.deepEqual({instruction: 'CALLVALUE', sourceMap: {offset: 71, length: 60, jump: undefined}, seen: false, jump: undefined}, bytecode[5]);
 
       done();
     });


### PR DESCRIPTION
In order to get result for the constructor we also need to run code coverage on the bytecode, not only the deployedBytecode.

See below: code coverage is now 100%

![screenshot at nov 15 09-12-06](https://user-images.githubusercontent.com/491074/48542999-70dda300-e8b8-11e8-8797-8edaa21a00c2.png)

![1200px-ariane_5es_with_atv_4_on_its_way_to_ela-3](https://user-images.githubusercontent.com/491074/48543062-98347000-e8b8-11e8-82b3-90858c1e7af6.jpg)
