### PR TITLE
Fix using an object as arguments

### DIFF
--- a/src/lib/constants.json
+++ b/src/lib/constants.json
@@ -41,7 +41,9 @@
       "testnet": 3,
       "ropsten": 3,
       "rinkeby": 4
-    }
+    },
+    "gasAllowanceError": "Returned error: gas required exceeds allowance or always failing transaction",
+    "gasAllowanceErrorMessage": "Failing call, this could be because of invalid inputs or function guards that may have been triggered, or an unknown error."
   },
   "storage": {
     "init": "init",

--- a/src/lib/modules/contracts_manager/index.js
+++ b/src/lib/modules/contracts_manager/index.js
@@ -124,8 +124,8 @@ class ContractsManager {
                 res.send({result});
               });
             } catch (e) {
-              if (funcCall === 'call' && e.message === 'Returned error: gas required exceeds allowance or always failing transaction') {
-                return res.send({result: 'Failing call, this could be because of invalid inputs or function guards that may have been triggered, or an unknown error.'});
+              if (funcCall === 'call' && e.message === constants.blockchain.gasAllowanceError) {
+                return res.send({result: constants.blockchain.gasAllowanceErrorMessage});
               }
               res.send({result: e.message});
             }

--- a/src/lib/modules/contracts_manager/index.js
+++ b/src/lib/modules/contracts_manager/index.js
@@ -421,8 +421,7 @@ class ContractsManager {
           if (Array.isArray(contract.args)) {
             ref = contract.args;
           } else {
-            let keys = Object.keys(contract.args);
-            ref = keys.map((k) => contract.args[k]).filter((x) => !x);
+            ref = Object.values(contract.args);
           }
 
           for (let j = 0; j < ref.length; j++) {

--- a/src/lib/modules/deployment/index.js
+++ b/src/lib/modules/deployment/index.js
@@ -2,6 +2,7 @@ let async = require('async');
 
 const ContractDeployer = require('./contract_deployer.js');
 const cloneDeep = require('clone-deep');
+const constants = require('../../constants');
 
 class DeployManager {
   constructor(embark, options) {
@@ -66,6 +67,9 @@ class DeployManager {
                   if (err) {
                     contract.error = err.message || err;
                     self.logger.error(`[${contract.className}]: ${err.message || err}`);
+                    if (contract.error === constants.blockchain.gasAllowanceError) {
+                      self.logger.error(constants.blockchain.gasAllowanceErrorMessage);
+                    }
                     errors.push(err);
                   }
                   callback();


### PR DESCRIPTION
Fixes part of https://github.com/embark-framework/embark/issues/1028
It at least now enables to deploy completely using RPC.
Problem was that somehow, we didn't parse contract args correctly if it was an object. So `_lpBase: '$LiquidPledgingMock'` returned a void address.

I also added a better message for bad inputs, just in case.