### PR TITLE
feat: enable ethereum manually

### DIFF
--- a/src/lib/core/config.js
+++ b/src/lib/core/config.js
@@ -276,6 +276,7 @@ Config.prototype.loadContractsConfigFile = function() {
         "$WEB3",
         "localhost:8545"
       ],
+      "dappAutoEnable": true,
       "strategy": constants.deploymentStrategy.implicit,
       "gas": "auto",
       "contracts": {

--- a/src/lib/modules/code_generator/code_templates/web3-connector.js.ejs
+++ b/src/lib/modules/code_generator/code_templates/web3-connector.js.ejs
@@ -1,3 +1,4 @@
+EmbarkJS.Blockchain.autoEnable = <%= autoEnable %>;
 EmbarkJS.Blockchain.connect(<%- connectionList %>, {warnAboutMetamask: <%= warnAboutMetamask %>}, function(err) {
   <%- done  %>
 });

--- a/src/lib/modules/code_generator/index.js
+++ b/src/lib/modules/code_generator/index.js
@@ -133,7 +133,12 @@ class CodeGenerator {
       } else {
         let connectionList = "[" + this.contractsConfig.dappConnection.map((x) => '"' + x + '"').join(',') + "]";
         let isDev = (self.env === 'development');
-        web3Load = Templates.web3_connector({connectionList: connectionList, done: 'done(err);', warnAboutMetamask: isDev});
+        web3Load = Templates.web3_connector({
+          autoEnable: this.contractsConfig.dappAutoEnable,
+          connectionList: connectionList,
+          done: 'done(err);',
+          warnAboutMetamask: isDev
+        });
       }
 
       result += Templates.do_when_loaded({block: web3Load, environment: this.env});

--- a/src/test/config.js
+++ b/src/test/config.js
@@ -114,6 +114,7 @@ describe('embark.Config', function () {
         versions: {'web3': '1.0.0-beta', solc: '0.4.25'},
         deployment: {host: 'localhost', port: 8545, type: 'rpc', "accounts": [{"mnemonic": "12 word mnemonic", "balance": "5000000000"}]},
         dappConnection: ['$WEB3', 'localhost:8545'],
+        dappAutoEnable: true,
         "gas": "400000",
         "strategy": "implicit",
         "contracts": {
@@ -136,6 +137,7 @@ describe('embark.Config', function () {
         versions: {'web3': '1.0.0-beta', solc: '0.4.25'},
         deployment: {host: 'localhost', port: 8545, type: 'rpc'},
         dappConnection: ['$WEB3', 'localhost:8545'],
+        dappAutoEnable: true,
         "gas": "auto",
         "strategy": "implicit",
         "contracts": {

--- a/templates/boilerplate/config/contracts.js
+++ b/templates/boilerplate/config/contracts.js
@@ -32,6 +32,11 @@ module.exports = {
       "http://localhost:8545"
     ],
 
+    // Automatically call `ethereum.enable` if true.
+    // If false, the following code must run before sending any transaction: `await EmbarkJS.enableEthereum();`
+    // Default value is true.
+    // dappAutoEnable: true,
+
     gas: "auto",
 
     // Strategy for the deployment of the contracts:

--- a/templates/demo/app/components/blockchain.js
+++ b/templates/demo/app/components/blockchain.js
@@ -12,7 +12,7 @@ class Blockchain extends React.Component {
       valueSet: 10,
       valueGet: "",
       logs: []
-    }
+    };
   }
 
   handleChange(e) {
@@ -27,9 +27,9 @@ class Blockchain extends React.Component {
     func.apply(this, [e]);
   }
 
-  setValue(e) {
+  async setValue(e) {
     e.preventDefault();
-
+    await EmbarkJS.enableEthereum();
     var value = parseInt(this.state.valueSet, 10);
 
     SimpleStorage.methods.set(value).send();

--- a/templates/demo/config/contracts.js
+++ b/templates/demo/config/contracts.js
@@ -32,6 +32,11 @@ module.exports = {
       "http://localhost:8545"
     ],
 
+    // Automatically call `ethereum.enable` if true.
+    // If false, the following code must run before sending any transaction: `await EmbarkJS.enableEthereum();`
+    // Default value is true.
+    // dappAutoEnable: true,
+
     gas: "auto",
 
     // Strategy for the deployment of the contracts:

--- a/templates/simple/contracts.js
+++ b/templates/simple/contracts.js
@@ -32,6 +32,11 @@ module.exports = {
       "http://localhost:8545"
     ],
 
+    // Automatically call `ethereum.enable` if true.
+    // If false, the following code must run before sending any transaction: `await EmbarkJS.enableEthereum();`
+    // Default value is true.
+    // dappAutoEnable: true,
+
     gas: "auto",
 
     // Strategy for the deployment of the contracts:


### PR DESCRIPTION
Update demo to work with `EmbarkJS.enableEthereum`

DO NOT MERGE until a new version of EmbarkJS has been published