### PR TITLE
IPC: send requests and events only when connected

### DIFF
--- a/src/lib/core/ipc.js
+++ b/src/lib/core/ipc.js
@@ -65,7 +65,10 @@ class IPC {
     ipc.server.emit(client, 'message', message);
   }
 
-  listenTo(action, callback) {
+  listenTo(action, callback = () => {}) {
+    if (!this.connected) {
+      return callback();
+    }
     ipc.of['embark'].on(action, (messageString) => {
       callback(parse(messageString));
     });
@@ -75,7 +78,10 @@ class IPC {
     ipc.server.broadcast(action, stringify(data));
   }
 
-  once(action, cb) {
+  once(action, cb = () => {}) {
+    if (!this.connected) {
+      return cb();
+    }
     ipc.of['embark'].once('message', function(messageString) {
       const message = parse(messageString);
       if (message.action !== action) {
@@ -86,6 +92,10 @@ class IPC {
   }
 
   request(action, data, cb) {
+    if (!this.connected) {
+      cb = cb || (() => {});
+      return cb();
+    }
     if (cb) {
       this.once(action, cb);
     }


### PR DESCRIPTION
Fixes #1063 
Happened when you used the console standalone, which still launches a blockchain process.
However, the console uses IPC as a Client, whereas the `run` is a server (for the console and others to connect to. 
The blockchain acts as a client too and is trying to send it's logs to the server, but there is none with a console, so it crashed.

Now, it looks for the IPC to be connected first.