### PR TITLE
feat: update to solc 0.5.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -147,7 +147,7 @@
     "serve-static": "1.13.2",
     "shelljs": "0.5.3",
     "simples": "0.8.8",
-    "solc": "0.4.25",
+    "solc": "0.5.0",
     "source-map-support": "0.5.9",
     "string-replace-async": "1.2.1",
     "style-loader": "0.23.1",

--- a/src/lib/core/config.js
+++ b/src/lib/core/config.js
@@ -262,7 +262,7 @@ Config.prototype.loadBlockchainConfigFile = function() {
 Config.prototype.loadContractsConfigFile = function() {
   var defaultVersions = {
     "web3": "1.0.0-beta",
-    "solc": "0.4.25"
+    "solc": "0.5.0"
   };
   var versions = utils.recursiveMerge(defaultVersions, this.embarkConfig.versions || {});
 

--- a/src/lib/modules/scaffolding-solidity/templates/contract.sol.hbs
+++ b/src/lib/modules/scaffolding-solidity/templates/contract.sol.hbs
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.24;
+pragma solidity ^0.5.0;
 
 contract {{contractName}} {
 

--- a/src/lib/modules/solidity/solcP.js
+++ b/src/lib/modules/solidity/solcP.js
@@ -1,11 +1,11 @@
 const fs = require('fs-extra');
 const path = require('path');
+const semver = require('semver');
 const constants = require('../../constants');
 const Utils = require('../../utils/utils');
 const ProcessWrapper = require('../../core/processes/processWrapper');
 const PluginManager = require('live-plugin-manager-git-fix').PluginManager;
 const NpmTimer = require('../library_manager/npmTimer');
-
 
 class SolcProcess extends ProcessWrapper {
 
@@ -55,7 +55,11 @@ class SolcProcess extends ProcessWrapper {
   compile(jsonObj, cb) {
     // TODO: only available in 0.4.11; need to make versions warn about this
     try {
-      let output = this.solc.compileStandardWrapper(JSON.stringify(jsonObj), this.findImports);
+      let func = this.solc.compileStandardWrapper;
+      if (semver.gte(this.solc.version(), '0.5.0')) {
+        func = this.solc.compile;
+      } 
+      let output = func(JSON.stringify(jsonObj), this.findImports);
       cb(null, output);
     } catch (err) {
       cb(err.message);

--- a/src/test/compiler.js
+++ b/src/test/compiler.js
@@ -14,7 +14,7 @@ let ipcObject = new Ipc({
 });
 
 let generateApiObject = function() {
-  var solcVersion = "0.4.25";
+  var solcVersion = "0.5.0";
 
   var TestEvents = {
     request: (cmd, cb) => {

--- a/src/test/config.js
+++ b/src/test/config.js
@@ -111,7 +111,7 @@ describe('embark.Config', function () {
     it('should load contract config correctly', function () {
       config.loadContractsConfigFile();
       let expectedConfig = {
-        versions: {'web3': '1.0.0-beta', solc: '0.4.25'},
+        versions: {'web3': '1.0.0-beta', solc: '0.5.0'},
         deployment: {host: 'localhost', port: 8545, type: 'rpc', "accounts": [{"mnemonic": "12 word mnemonic", "balance": "5000000000"}]},
         dappConnection: ['$WEB3', 'localhost:8545'],
         "gas": "400000",
@@ -133,7 +133,7 @@ describe('embark.Config', function () {
 
     it('should replace occourences of `0x0` with full zero addresses', () => {
       let expectedConfig = {
-        versions: {'web3': '1.0.0-beta', solc: '0.4.25'},
+        versions: {'web3': '1.0.0-beta', solc: '0.5.0'},
         deployment: {host: 'localhost', port: 8545, type: 'rpc'},
         dappConnection: ['$WEB3', 'localhost:8545'],
         "gas": "auto",

--- a/src/test/contracts/contract_with_http_import.sol
+++ b/src/test/contracts/contract_with_http_import.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.7;
+pragma solidity ^0.5.0;
 import "https://github.com/embark-framework/embark/blob/master/test_apps/contracts_app/contracts/contract_args.sol";
 contract SimpleStorage {
   uint public storedData;

--- a/src/test/contracts/contract_with_import.sol
+++ b/src/test/contracts/contract_with_import.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.7;
+pragma solidity ^0.5.0;
 import "./ownable.sol";
 contract SimpleStorage {
   uint public storedData;

--- a/src/test/contracts/simple_storage.sol
+++ b/src/test/contracts/simple_storage.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.7;
+pragma solidity ^0.5.0;
 
 contract SimpleStorage {
   uint public storedData;

--- a/src/test/contracts/token.sol
+++ b/src/test/contracts/token.sol
@@ -1,6 +1,6 @@
 // https://github.com/nexusdev/erc20/blob/master/contracts/base.sol
 
-pragma solidity ^0.4.7;
+pragma solidity ^0.5.0;
 
 contract Token {
 

--- a/src/test/contracts/token_storage.sol
+++ b/src/test/contracts/token_storage.sol
@@ -1,6 +1,6 @@
 // https://github.com/nexusdev/erc20/blob/master/contracts/base.sol
 
-pragma solidity ^0.4.7;
+pragma solidity ^0.5.0;
 
 contract TokenStorage {
 

--- a/src/test/fixtures/cont.sol
+++ b/src/test/fixtures/cont.sol
@@ -1,5 +1,4 @@
-pragma solidity ^0.4.24;
-
+pragma solidity ^0.5.0;
 contract x {
   int number;
   string name;

--- a/templates/boilerplate/embark.json
+++ b/templates/boilerplate/embark.json
@@ -10,7 +10,7 @@
   "config": "config/",
   "versions": {
     "web3": "1.0.0-beta",
-    "solc": "0.4.25",
+    "solc": "0.5.0",
     "ipfs-api": "17.2.4"
   },
   "plugins": {

--- a/templates/demo/contracts/simple_storage.sol
+++ b/templates/demo/contracts/simple_storage.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.25;
+pragma solidity ^0.5.0;
 
 contract SimpleStorage {
   uint public storedData;

--- a/templates/demo/embark.json
+++ b/templates/demo/embark.json
@@ -9,7 +9,7 @@
   "config": "config/",
   "versions": {
     "web3": "1.0.0-beta",
-    "solc": "0.4.25",
+    "solc": "0.5.0",
     "ipfs-api": "17.2.4"
   },
   "plugins": {

--- a/templates/simple/embark.json
+++ b/templates/simple/embark.json
@@ -10,7 +10,7 @@
     "webserver": false
   },
   "versions": {
-    "solc": "0.4.25"
+    "solc": "0.5.0"
   },
   "plugins": {
   },

--- a/test_apps/coverage_app/contracts/branches.sol
+++ b/test_apps/coverage_app/contracts/branches.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.23;
+pragma solidity ^0.5.0;
 
 contract Branches {
   uint public lastComparison;

--- a/test_apps/coverage_app/contracts/events.sol
+++ b/test_apps/coverage_app/contracts/events.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.23;
+pragma solidity ^0.5.0;
 
 contract Events {
   uint public balance;

--- a/test_apps/coverage_app/contracts/loops.sol
+++ b/test_apps/coverage_app/contracts/loops.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.23;
+pragma solidity ^0.5.0;
 
 contract Loops {
   uint public storedData;

--- a/test_apps/coverage_app/contracts/modifiers.sol
+++ b/test_apps/coverage_app/contracts/modifiers.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.23;
+pragma solidity ^0.5.0;
 
 contract Modifiers {
   uint public storedData;

--- a/test_apps/coverage_app/contracts/simple_storage.sol
+++ b/test_apps/coverage_app/contracts/simple_storage.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.23;
+pragma solidity ^0.5.0;
 
 contract SimpleStorage {
   uint public storedData;

--- a/test_apps/coverage_app/embark.json
+++ b/test_apps/coverage_app/embark.json
@@ -9,7 +9,7 @@
   "config": "config/",
   "versions": {
     "web3": "1.0.0-beta",
-    "solc": "0.4.24",
+    "solc": "0.5.0",
     "ipfs-api": "17.2.4"
   },
   "plugins": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -12137,6 +12137,11 @@ require-from-string@^1.1.0:
   resolved "https://registry.yarnpkg.com/require-from-string/-/require-from-string-1.2.1.tgz#529c9ccef27380adfec9a2f965b649bbee636418"
   integrity sha1-UpyczvJzgK3+yaL5ZbZJu+5jZBg=
 
+require-from-string@^2.0.0:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/require-from-string/-/require-from-string-2.0.2.tgz#89a7fdd938261267318eafe14f9c32e598c36909"
+  integrity sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==
+
 require-main-filename@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/require-main-filename/-/require-main-filename-1.0.1.tgz#97f717b69d48784f5f526a6c5aa8ffdda055a4d1"
@@ -12885,7 +12890,19 @@ sockjs@0.3.19:
     faye-websocket "^0.10.0"
     uuid "^3.0.1"
 
-solc@0.4.25, solc@^0.4.13, solc@^0.4.24, solc@^0.4.25:
+solc@0.5.0:
+  version "0.5.0"
+  resolved "https://registry.yarnpkg.com/solc/-/solc-0.5.0.tgz#2deb2ae992acac3afb909f85c38d00f01dcb335e"
+  integrity sha512-mdLHDl9WeYrN+FIKcMc9PlPfnA9DG9ur5QpCDKcv6VC4RINAsTF4EMuXMZMKoQTvZhtLyJIVH/BZ+KU830Z8Xg==
+  dependencies:
+    fs-extra "^0.30.0"
+    keccak "^1.0.2"
+    memorystream "^0.3.1"
+    require-from-string "^2.0.0"
+    semver "^5.5.0"
+    yargs "^11.0.0"
+
+solc@^0.4.13, solc@^0.4.24, solc@^0.4.25:
   version "0.4.25"
   resolved "https://registry.yarnpkg.com/solc/-/solc-0.4.25.tgz#06b8321f7112d95b4b903639b1138a4d292f5faa"
   integrity sha512-jU1YygRVy6zatgXrLY2rRm7HW1d7a8CkkEgNJwvH2VLpWhMFsMdWcJn6kUqZwcSz/Vm+w89dy7Z/aB5p6AFTrg==
@@ -15384,6 +15401,13 @@ yargs-parser@^7.0.0:
   dependencies:
     camelcase "^4.1.0"
 
+yargs-parser@^9.0.2:
+  version "9.0.2"
+  resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-9.0.2.tgz#9ccf6a43460fe4ed40a9bb68f48d43b8a68cc077"
+  integrity sha1-nM9qQ0YP5O1Aqbto9I1DuKaMwHc=
+  dependencies:
+    camelcase "^4.1.0"
+
 yargs@6.6.0:
   version "6.6.0"
   resolved "https://registry.yarnpkg.com/yargs/-/yargs-6.6.0.tgz#782ec21ef403345f830a808ca3d513af56065208"
@@ -15402,6 +15426,24 @@ yargs@6.6.0:
     which-module "^1.0.0"
     y18n "^3.2.1"
     yargs-parser "^4.2.0"
+
+yargs@^11.0.0:
+  version "11.1.0"
+  resolved "https://registry.yarnpkg.com/yargs/-/yargs-11.1.0.tgz#90b869934ed6e871115ea2ff58b03f4724ed2d77"
+  integrity sha512-NwW69J42EsCSanF8kyn5upxvjp5ds+t3+udGBeTbFnERA+lF541DDpMawzo4z6W/QrzNM18D+BPMiOBibnFV5A==
+  dependencies:
+    cliui "^4.0.0"
+    decamelize "^1.1.1"
+    find-up "^2.1.0"
+    get-caller-file "^1.0.1"
+    os-locale "^2.0.0"
+    require-directory "^2.1.1"
+    require-main-filename "^1.0.1"
+    set-blocking "^2.0.0"
+    string-width "^2.0.0"
+    which-module "^2.0.0"
+    y18n "^3.2.1"
+    yargs-parser "^9.0.2"
 
 yargs@^12.0.0:
   version "12.0.2"


### PR DESCRIPTION
What's in:
- Accept 0.5.0 solc compiler
- Update demo to use 0.5.0
- Update test_apps/coverage_app to use 0.5.0
- Update templates

What's *not* in:
* Update test_apps/test_app to use 0.5.0:
2 reasons:
** we depends of open zeppelin and they haven't updated yet, as it is a minor version with zero major, the caret range don't allow it
** we depends of embark contracts in master => It seems like a bad idea to do that in general plus the caret range don't work again

fixes https://github.com/embark-framework/embark/issues/1081