### PR TITLE
fix: handle contracts being removed

### DIFF
--- a/src/lib/core/config.js
+++ b/src/lib/core/config.js
@@ -59,6 +59,11 @@ var Config = function(options) {
     };
     self.contractsFiles.push(new File({filename, type: File.types.custom, path: filename, resolver}));
   });
+
+  self.events.on('file-remove', (fileType, path) => {
+    if(fileType !== 'contract') return;
+    self.contractsFiles = self.contractsFiles.filter(file => file.filename !== path);
+  });
 };
 
 Config.prototype.loadConfigFiles = function(options) {

--- a/src/lib/core/config.js
+++ b/src/lib/core/config.js
@@ -60,9 +60,10 @@ var Config = function(options) {
     self.contractsFiles.push(new File({filename, type: File.types.custom, path: filename, resolver}));
   });
 
-  self.events.on('file-remove', (fileType, path) => {
+  self.events.on('file-remove', (fileType, removedPath) => {
     if(fileType !== 'contract') return;
-    self.contractsFiles = self.contractsFiles.filter(file => file.filename !== path);
+    const normalizedPath = path.normalize(removedPath);
+    self.contractsFiles = self.contractsFiles.filter(file => path.normalize(file.filename) !== normalizedPath);
   });
 };
 


### PR DESCRIPTION
This PR handles contracts being removed from the contract directory. Instead of Embark blowing up, it will now stop tracking them, and, as a result, stop reading/trying to build.