### PR TITLE
Fix slow tests by deactivating coverage without --coverage

### DIFF
--- a/src/cmd/cmd_controller.js
+++ b/src/cmd/cmd_controller.js
@@ -642,7 +642,9 @@ class EmbarkController {
         });
         engine.startService("codeGenerator");
         engine.startService("codeRunner");
-        engine.startService("codeCoverage");
+        if (options.coverage) {
+          engine.startService("codeCoverage");
+        }
         engine.startService("testRunner");
         callback();
       },


### PR DESCRIPTION
Fixes #1091
Speeds up tests because coverage triggers big loops on each new block headers.