### PR TITLE
Adding signature and recipient's public key to whisper envelope

### DIFF
--- a/src/lib/modules/whisper/js/communicationFunctions.js
+++ b/src/lib/modules/whisper/js/communicationFunctions.js
@@ -83,6 +83,8 @@ function listenTo(options, callback) {
       data = {
         topic: toAscii(result.topic),
         data: payload,
+        sig: result.sig,
+        recipientPublicKey: result.recipientPublicKey,
         //from: result.from,
         time: result.timestamp
       };


### PR DESCRIPTION
These two options are useful for identifying to whom was the whisper message directed, and what's the pubKey that signed the message.

https://web3js.readthedocs.io/en/1.0/web3-shh.html#notification-returns
