### PR TITLE
fix(@embark/contracts_manager): set contract `deployedAddress` if address is set

### DIFF
--- a/src/lib/modules/contracts_manager/index.js
+++ b/src/lib/modules/contracts_manager/index.js
@@ -295,6 +295,10 @@ class ContractsManager {
           contract.type = 'file';
           contract.className = className;
 
+          if (contract.address) {
+            contract.deployedAddress = contract.address;
+          }
+
           self.contracts[className] = contract;
         }
         callback();


### PR DESCRIPTION
This commit fixes a bug in a scenario where dapp developers choose to refer
to an already deployed Smart Contract (they don't own) and want to use its web3 instance
on the client-side, or in deployment hooks.

For example, Dapp developers might want to do something like this:

```
// config/contract.js
...
contracts: {
  SimpleStorage: {
    address: '0x1234...' // SimpleStorage is already deployed
  }
},
afterDeploy: async (deps) => {
  const simpleStorage = deps.contracts.SimpleStorage; // this is the web3 instance created from an ABI
  const value = await simpleStorage.methods.get().call();
  console.log(value);
}
...
```

In order for Embark to create ready-to-use web3 Smart Contract instances,
it needs the contract's ABI. At the moment there are two possible ways to
achieve this for contracts we don't own:

1. Set the `address` of the already deployed contract and create a Solidity
   interface with the same name of the existing Contract that matches that
   Contract's interface. Embark is then going to compile that interface
   which will output an ABI whic can be used for web3 instance creation.

2. If the source of the 3rd party Smart Contract is available, use the
   `file` option to specify the path to the source, which Embark then picks
   up for compilation. Again, this results in ABI code which is then used
   for web3 instance creation.

As of now option 1) doesn't actually work, at least web3 is going to throw
an error when trying to access Smart Contract instances that have been created
that way. The reason for that is that the instance doesn't have a `deployedAddress`.

This commit ensures that the `deployedAddress` is set when the Smart Contract
config comes with a preconfigured `address`.