### PR TITLE
fix(@embark/ens): use local ZERO_ADDRESS in ENSFunctions

### DIFF
--- a/src/lib/modules/ens/ENSFunctions.js
+++ b/src/lib/modules/ens/ENSFunctions.js
@@ -1,9 +1,9 @@
-import { ZERO_ADDRESS } from '../../utils/addressUtils';
 /*global web3*/
 const namehash = require('eth-ens-namehash');
 // Price of ENS registration contract functions
 const ENS_GAS_PRICE = 700000;
 
+const ZERO_ADDRESS = '0x0000000000000000000000000000000000000000';
 const reverseAddressSuffix = '.addr.reverse';
 const NoDecodeAddrErr = 'Error: Couldn\'t decode address from ABI: 0x';
 const NoDecodeStringErr = 'ERROR: The returned value is not a convertible string: 0x0';


### PR DESCRIPTION
We've introduced a regression in https://github.com/embark-framework/embark/commit/2dfaaa8201c664efb99e54bc7a0b3b3ea07028bd where zero addresses
have been replaced with a constant, including the ones within ENSFunctions.

The problem is that this code is as well added to the EmbarkJS client, where importing
`../../utils/addressUtils` won't work as it isn't available.

This commit reverts back to have ENSFunctions having its own ZERO_ADDRESS constant.