### PR TITLE
feat(@embark/contracts_manager): allow ABI definition non-owned contr…

### DIFF
--- a/src/lib/modules/contracts_manager/index.js
+++ b/src/lib/modules/contracts_manager/index.js
@@ -391,7 +391,7 @@ class ContractsManager {
         for (className in self.contracts) {
           contract = self.contracts[className];
 
-          if (contract.code === undefined) {
+          if (contract.code === undefined && !contract.abiDefinition) {
             self.logger.error(__("%s has no code associated", className));
             let suggestion = utils.proposeAlternative(className, dictionary, [className]);
             if (suggestion) {
@@ -418,9 +418,11 @@ class ContractsManager {
           }
 
           // look in code for dependencies
-          let libMatches = (contract.code.match(/:(.*?)(?=_)/g) || []);
-          for (let match of libMatches) {
-            self.contractDependencies[className].push(match.substr(1));
+          if (contract.code) {
+            let libMatches = (contract.code.match(/:(.*?)(?=_)/g) || []);
+            for (let match of libMatches) {
+              self.contractDependencies[className].push(match.substr(1));
+            }
           }
 
           // look in arguments for dependencies


### PR DESCRIPTION
…acts

This commit allows dapp developers to specify an ABI for contracts that are
already deployed and which source they don't own.

Prior to this commit there were two options to use web3 contract instances of 3rd
party contracts in Embark:

1. Define an interface for the 3rd party contract and have Embark compile that
2. Define path to source file of 3rd party contract and have Embark compile that

Both options result in Embark getting hold of the contracts ABI so it can be used
by web3 to create instances.

Now there's a third option that doesn't require creating an interface, nor the
source of the 3rd party contract.

Example:

```
// config/contracts.js

...
contracts: {
  SimpleStorage: {
    address: '0x0bFb07f9144729EEF54A9057Af0Fcf87aC7Cbba9',
    abiDefinition: [...] // full ABI
  }
},
afterDeploy: async(deps) => {
  const simpleStorage = deps.contracts.SimpleStorage;
  const value = await simpleStorage.methods.get().call();
  console.log('value', value);
}
```