### PR TITLE
fix(@embark/core): expect `afterDeploy` hook on contracts config environment

### DIFF
--- a/src/lib/core/config.js
+++ b/src/lib/core/config.js
@@ -341,10 +341,10 @@ Config.prototype.loadContractsConfigFile = function() {
     }
   });
 
-  const afterDeploy = newContractsConfig.contracts.afterDeploy;
+  const afterDeploy = newContractsConfig.afterDeploy;
 
   if (Array.isArray(afterDeploy)) {
-    newContractsConfig.contracts.afterDeploy = afterDeploy.map(replaceZeroAddressShorthand);
+    newContractsConfig.afterDeploy = afterDeploy.map(replaceZeroAddressShorthand);
   }
 
   if (!deepEqual(newContractsConfig, this.contractsConfig)) {

--- a/src/test/config.js
+++ b/src/test/config.js
@@ -145,12 +145,12 @@ describe('embark.Config', function () {
             "onDeploy": [
               "SimpleStorage.methods.changeAddress('0x0000000000000000000000000000000000000000')"
             ]
-          },
-          "afterDeploy": [
-            "SimpleStorage.methods.changeAddress('0x0000000000000000000000000000000000000000')",
-            "SimpleStorage.methods.changeAddress('$SomeToken')"
-          ]
-        }
+          }
+        },
+        "afterDeploy": [
+          "SimpleStorage.methods.changeAddress('0x0000000000000000000000000000000000000000')",
+          "SimpleStorage.methods.changeAddress('$SomeToken')"
+        ]
       };
       let zeroAddressconfig = new Config({
         env: 'zeroaddress',

--- a/src/test/test1/config/contracts.json
+++ b/src/test/test1/config/contracts.json
@@ -21,12 +21,12 @@
         "onDeploy": [
           "SimpleStorage.methods.changeAddress('0x0')"
         ]
-      },
-      "afterDeploy": [
-        "SimpleStorage.methods.changeAddress('0x0')",
-        "SimpleStorage.methods.changeAddress('$SomeToken')"
-      ]
-    }
+      }
+    },
+    "afterDeploy": [
+      "SimpleStorage.methods.changeAddress('0x0')",
+      "SimpleStorage.methods.changeAddress('$SomeToken')"
+    ]
   },
   "myenv": {
     "gas": "400 Kwei",


### PR DESCRIPTION


In https://github.com/embark-framework/embark/commit/d3f6b4398620e643f16634d30fdc9cb56d9e9bee we ensured that Embark automatically
expands `0x0` address to full zero addresses in order to stay backward compatible
with existing projects that made use of `0x0`, even after we've upgraded web3,
which doesn't allow that syntax anymore.

Turns out however, that the address expansion for `afterDeploy` hook was
done in the wrong place. This was due to a bug in our documentation that has been
fixed in https://github.com/embark-framework/embark-site/commit/66a5bec46d05d6ed8ec1d21e6f5ca3615a813277