### PR TITLE
feat(@embark/plugins): introduce API to register test contract factories

### DIFF
--- a/src/lib/core/plugin.js
+++ b/src/lib/core/plugin.js
@@ -13,6 +13,8 @@ var Plugin = function(options) {
   this.clientWeb3Providers = [];
   this.beforeDeploy = [];
   this.contractsGenerators = [];
+  this.generateCustomContractCode = null;
+  this.testContractFactory = null;
   this.pipeline = [];
   this.pipelineFiles = [];
   this.console = [];
@@ -118,6 +120,16 @@ Plugin.prototype.registerClientWeb3Provider = function(cb) {
 Plugin.prototype.registerContractsGeneration = function(cb) {
   this.contractsGenerators.push(cb);
   this.addPluginType('contractGeneration');
+};
+
+Plugin.prototype.registerCustomContractGenerator = function (cb) {
+  this.generateCustomContractCode = cb;
+  this.addPluginType('customContractGeneration');
+};
+
+Plugin.prototype.registerTestContractFactory = function(cb) {
+  this.testContractFactory = cb;
+  this.addPluginType('testContractFactory');
 };
 
 Plugin.prototype.registerPipeline = function(matcthingFiles, cb) {

--- a/src/lib/modules/code_generator/index.js
+++ b/src/lib/modules/code_generator/index.js
@@ -47,36 +47,11 @@ class CodeGenerator {
       cb(providerCode);
     });
 
-    // new events
-    this.events.setCommandHandler('code-vanila', function(cb) {
-      self.events.request("contracts:list", (_err, contractsList) => {
-        let vanillaABI = self.generateABI(contractsList, {useEmbarkJS: false});
-        let contractsJSON = self.generateContractsJSON(contractsList);
-        cb(vanillaABI, contractsJSON);
-      });
-    });
-
     this.events.setCommandHandler('code', function(cb) {
       self.events.request("contracts:list", (_err, contractsList) => {
         let embarkJSABI = self.generateABI(contractsList, {useEmbarkJS: true});
         let contractsJSON = self.generateContractsJSON(contractsList);
         cb(embarkJSABI, contractsJSON);
-      });
-    });
-
-    this.events.setCommandHandler('code-contracts-vanila', function(cb) {
-      self.events.request("contracts:list", (_err, contractsList) => {
-        let vanillaContractsABI = self.generateContracts(contractsList, false, true, false);
-        let contractsJSON = self.generateContractsJSON(contractsList);
-        cb(vanillaContractsABI, contractsJSON);
-      });
-    });
-
-    this.events.setCommandHandler('code-vanila-deployment', function(cb) {
-      self.events.request("contracts:list", (_err, contractsList) => {
-        let vanillaABI = self.generateABI(contractsList, {useEmbarkJS: false, deployment: true});
-        let contractsJSON = self.generateContractsJSON(contractsList);
-        cb(vanillaABI, contractsJSON);
       });
     });
 

--- a/src/lib/modules/deployment/contract_deployer.js
+++ b/src/lib/modules/deployment/contract_deployer.js
@@ -193,9 +193,7 @@ class ContractDeployer {
     contract.deployedAddress = trackedContract.address;
     self.events.emit("deploy:contract:deployed", contract);
 
-    // TODO: can be moved into a afterDeploy event
-    // just need to figure out the gasLimit coupling issue
-    self.events.request('code-generator:contract:vanilla', contract, contract._gasLimit || false, (contractCode) => {
+    self.events.request('code-generator:contract:custom', contract, (contractCode) => {
       self.events.request('runcode:eval', contractCode, () => {}, true);
       return callback();
     });
@@ -306,9 +304,8 @@ class ContractDeployer {
           self.events.emit("deploy:contract:receipt", receipt);
           self.events.emit("deploy:contract:deployed", contract);
 
-          // TODO: can be moved into a afterDeploy event
-          // just need to figure out the gasLimit coupling issue
-          self.events.request('code-generator:contract:vanilla', contract, contract._gasLimit || false, (contractCode) => {
+
+          self.events.request('code-generator:contract:custom', contract, (contractCode) => {
             self.events.request('runcode:eval', contractCode, () => {}, true);
             self.plugins.runActionsForEvent('deploy:contract:deployed', {contract: contract}, () => {
               return next(null, receipt);

--- a/src/lib/modules/tests/test.js
+++ b/src/lib/modules/tests/test.js
@@ -11,6 +11,7 @@ class Test {
     this.options = options || {};
     this.simOptions = {};
     this.events = options.events;
+    this.plugins = options.config.plugins;
     this.logger = options.logger;
     this.ipc = options.ipc;
     this.configObj = options.config;
@@ -268,7 +269,9 @@ class Test {
               self.contracts[contract.className] = {};
             }
 
-            const newContract = Test.getWeb3Contract(contract, web3);
+            const testContractFactoryPlugin = self.plugins.getPluginsFor('testContractFactory').slice(-1)[0];
+
+            const newContract = testContractFactoryPlugin ? testContractFactoryPlugin.testContractFactory(contract, web3) : Test.getWeb3Contract(contract, web3);
             Object.setPrototypeOf(self.contracts[contract.className], newContract);
 
             eachCb();


### PR DESCRIPTION
This commit introduces a new API `registerTestContractFactory()` which can be
used to register a factory function for the creation of web3 contract instances
in the testing environment.

Example:

```
// some.plugin.js

module.exports = function (embark) {
  embark.registerTestContractFactory((contractRecipe, web3) => {
    // do something with web3 and contractRecipe and return contract instance here
  });
};
```

Closes #1066