### PR TITLE
feat(@embark/cli): introduce `eject-build-config` alias

### DIFF
--- a/src/cmd/cmd.js
+++ b/src/cmd/cmd.js
@@ -382,8 +382,9 @@ class Cmd {
 
   ejectWebpack() {
     program
-      .command('eject-webpack')
-      .description(__('copy the default webpack config into your dapp for customization'))
+      .command('eject-build-config')
+      .alias('eject-webpack')
+      .description(__('copy the default build config into your dapp for customization'))
       .action(function() {
         embark.initConfig('development', {
           embarkConfig: 'embark.json',


### PR DESCRIPTION
As discussed in #1121, the `eject-webpack` command in Embark's CLI
exposes implementation details of the CLI's build process, namely webpack.

If we ever change our internal build tooling, commands like this
will become obsolete immediately. That's why this commit introduces
a new command `eject-build-config`, with `eject-webpack` being an alias for it.

So the following commands are the same:

```
$ embark eject-build-config
```
and
```
$ embark eject-webpack
```

The `eject-webpack` command can now be marked as deprecated and removed in future
versions of Embark.

Closes #1121