### PR TITLE
fix(@embark/core): Restart IPFS after CORS Update

### DIFF
--- a/src/lib/constants.json
+++ b/src/lib/constants.json
@@ -47,7 +47,8 @@
   },
   "storage": {
     "init": "init",
-    "initiated": "initiated"
+    "initiated": "initiated",
+    "restart": "restart"
   },
   "tests": {
     "gasLimit": 6000000

--- a/src/lib/utils/utils.js
+++ b/src/lib/utils/utils.js
@@ -62,7 +62,7 @@ function httpsGet(url, callback) {
 function httpGetJson(url, callback) {
   httpGetRequest(http, url, function (err, body) {
     try {
-      let parsed = JSON.parse(body);
+      let parsed = body && JSON.parse(body);
       return callback(err, parsed);
     } catch (e) {
       return callback(e);


### PR DESCRIPTION
When adding URLs to IPFS CORS that are not localhost, the IPFS daemon needed to be restarted after non-localhost CORS updates were added to the IPFS config. Without the restart, any non-localhost URLs added to the CORS were not being sent in the CORS header.

After this change, when the IPFS process is run, the following happens:
1. IPFS config is checked if the correct CORS settings are present in the config.
2. If not present, they are updated and IPFS is restarted.
3. If they are present, continue without restarting IPFS.