### PR TITLE
Fix ENS register + Make EmbarkJS functions work with await

### DIFF
--- a/src/lib/modules/ens/embarkjs.js
+++ b/src/lib/modules/ens/embarkjs.js
@@ -2,7 +2,6 @@
 
 let __embarkENS = {};
 
-const NOT_REGISTERED_ERROR = 'Name not yet registered';
 // resolver interface
 __embarkENS.resolverInterface = [
   {
@@ -193,7 +192,7 @@ __embarkENS.resolve = function (name, callback) {
   return this.ens.methods.resolver(node).call()
     .then(resolverAddress => {
       if (resolverAddress === voidAddress) {
-        return cb(NOT_REGISTERED_ERROR);
+        return cb('Name not yet registered');
       }
       let resolverContract = new EmbarkJS.Blockchain.Contract({
         abi: this.resolverInterface,
@@ -202,9 +201,7 @@ __embarkENS.resolve = function (name, callback) {
       });
       return resolverContract.methods.addr(node).call(cb);
     })
-    .catch(err => {
-      cb(err);
-    });
+    .catch(cb);
 };
 
 __embarkENS.lookup = function (address, callback) {
@@ -239,9 +236,7 @@ __embarkENS.lookup = function (address, callback) {
       });
       return resolverContract.methods.name(node).call(cb);
     })
-    .catch(err => {
-      cb(err);
-    });
+    .catch(cb);
 };
 
 __embarkENS.registerSubDomain = function (name, address, callback) {


### PR DESCRIPTION
We introduced a bug when fixing the hangs by returning on error when resolving sub domains, but the real trick is to look at the error and if it's the right error ('Not registered yet'), then we register,

Also, while playing with it, I found that doing `await EmbarkJS.Names.resolve('eth')` gives the resolver address instead of the name's address. This was fixed so `await` works correctly now.