### PR TITLE
fix(@embark/core): fix to allow large ether values

### DIFF
--- a/src/lib/modules/blockchain_connector/fundAccount.js
+++ b/src/lib/modules/blockchain_connector/fundAccount.js
@@ -6,7 +6,7 @@ function fundAccount(web3, accountAddress, hexBalance, callback) {
   if (!hexBalance) {
     hexBalance = TARGET;
   }
-  const targetBalance = (typeof hexBalance === 'string') ? parseInt(hexBalance, 16) : hexBalance;
+  const targetBalance = web3.utils.toBN(hexBalance);
   let accountBalance;
   let coinbaseAddress;
   let lastNonce;
@@ -18,7 +18,8 @@ function fundAccount(web3, accountAddress, hexBalance, callback) {
         if (err) {
           return next(err);
         }
-        if (balance >= targetBalance) {
+        balance = web3.utils.toBN(balance);
+        if (balance.gte(targetBalance)) {
           return next(ALREADY_FUNDED);
         }
         accountBalance = balance;
@@ -60,7 +61,7 @@ function fundAccount(web3, accountAddress, hexBalance, callback) {
       web3.eth.sendTransaction({
         from: coinbaseAddress,
         to: accountAddress,
-        value: targetBalance - accountBalance,
+        value: targetBalance.sub(accountBalance),
         gasPrice: gasPrice,
         nonce: lastNonce
       }, next);

--- a/src/lib/modules/tests/test.js
+++ b/src/lib/modules/tests/test.js
@@ -5,6 +5,7 @@ const AccountParser = require('../../utils/accountParser');
 const EmbarkJS = require('embarkjs');
 const utils = require('../../utils/utils');
 const constants = require('../../constants');
+const web3Utils = require('web3-utils');
 
 const BALANCE_10_ETHER_IN_HEX = '0x8AC7230489E80000';
 
@@ -217,6 +218,13 @@ class Test {
       function changeGlobalWeb3(accounts, next) {
         self.events.request('blockchain:get', (web3) => {
           global.web3 = web3;
+          EmbarkJS.Blockchain.setProvider('web3');
+          next(null, accounts);
+        });
+      },
+      function reconfigEns(accounts, next) {
+        self.events.request("ens:config", (config) => {
+          EmbarkJS.Names.setProvider('ens', config);
           next(null, accounts);
         });
       }
@@ -259,7 +267,7 @@ class Test {
           if (err) {
             return next(err);
           }
-          if (parseInt(balance, 10) === 0) {
+          if (web3Utils.toBN(balance).eq(web3Utils.toBN(0))) {
             self.logger.warn("Warning: default account has no funds");
           }
           next(null, accounts);

--- a/src/lib/utils/logHandler.js
+++ b/src/lib/utils/logHandler.js
@@ -1,3 +1,4 @@
+
 const utils = require('./utils');
 
 // define max number of logs to keep in memory for this process
@@ -8,15 +9,15 @@ const MAX_LOGS = require('../constants').logs.maxLogLength;
  * Serves as a central point of log handling.
  */
 class LogHandler {
-  
+
   /**
    * @param {Object} options Options object containing:
    * - {EventEmitter} events Embark events
    * - {Logger} logger Embark logger
-   * - {String} processName Name of the process for which it's logs 
+   * - {String} processName Name of the process for which it's logs
    *            are being handled.
    * - {Boolean} silent If true, does not log the message, unless
-   *             it has a logLevel of 'error'. 
+   *             it has a logLevel of 'error'.
    */
   constructor({events, logger, processName, silent}) {
     this.events = events;
@@ -30,18 +31,18 @@ class LogHandler {
 
   /**
    * Servers as an interception of logs, normalises the message output, adds
-   * metadata (timestamp, id), stores the log in memory, then sends it to the 
+   * metadata (timestamp, id), stores the log in memory, then sends it to the
    * logger for output. Max number of logs stored in memory is capped by MAX_LOGS.
-   * 
+   *
    * @param {Object} msg Object containing the log message (msg.message)
-   * @param {Boolean} alreadyLogged (optional, default = false) If true, prevents 
-   * the logger from logging the event. Generally used when the log has already 
-   * been logged using the Logger (which emits a "log" event), and is then sent 
-   * to `handleLog` for normalization. If allowed to log again, another event 
-   * would be emitted, and an infinite loop would occur. Setting to true will 
+   * @param {Boolean} alreadyLogged (optional, default = false) If true, prevents
+   * the logger from logging the event. Generally used when the log has already
+   * been logged using the Logger (which emits a "log" event), and is then sent
+   * to `handleLog` for normalization. If allowed to log again, another event
+   * would be emitted, and an infinite loop would occur. Setting to true will
    * prevent infinite looping.
-   * 
-   * @returns {void} 
+   *
+   * @returns {void}
    */
   handleLog(msg, alreadyLogged = false) {
     if (!msg) return;
@@ -55,6 +56,9 @@ class LogHandler {
       processedMessages = [msg.message];
     } else if (Array.isArray(msg.message)) {
       msg.message.forEach(message => {
+        if (message === Object(message)) {
+          message = JSON.stringify(message); // test for objects - don't know how to handle these
+        }
         if (Array.isArray(message)) {
           return message.forEach(line => processedMessages.push(line));
         }

--- a/src/lib/utils/utils.js
+++ b/src/lib/utils/utils.js
@@ -490,7 +490,7 @@ function getWeiBalanceFromString(balanceString, web3){
     throw new Error(__('Unrecognized balance string "%s"', balanceString));
   }
   if (!match[2]) {
-    return web3.utils.toHex(parseInt(match[1], 10));
+    return web3.utils.toHex(match[1]);
   }
 
   return web3.utils.toWei(match[1], match[2]);
@@ -511,7 +511,7 @@ function getHexBalanceFromString(balanceString, web3) {
     throw new Error(__('Unrecognized balance string "%s"', balanceString));
   }
   if (!match[2]) {
-    return web3.utils.toHex(parseInt(match[1], 10));
+    return web3.utils.toHex(match[1]);
   }
 
   return web3.utils.toHex(web3.utils.toWei(match[1], match[2]));

--- a/src/test/accountParser.js
+++ b/src/test/accountParser.js
@@ -140,10 +140,32 @@ describe('embark.AccountParser', function () {
       assert.strictEqual(hexBalance, '0x9cb1ed0a00');
     });
 
+    it('should convert to hex with large ether values', () => {
+      const hexBalance = utils.getHexBalanceFromString('100000 ether', Web3);
+
+      assert.strictEqual(hexBalance, '0x152d02c7e14af6800000');
+    });
+
     it('should fail when string is not good', () => {
       try {
         utils.getHexBalanceFromString('nogood', Web3);
         assert.fail('Should have failed at getHexBalance');
+      } catch (e) {
+        // Ok
+      }
+    });
+  });
+  describe('getWeiBalance', () => {
+    it('should convert to hex with large ether values', () => {
+      const weiBalance = utils.getWeiBalanceFromString('100000 ether', Web3);
+
+      assert.strictEqual(weiBalance, '100000000000000000000000');
+    });
+
+    it('should fail when string is not good', () => {
+      try {
+        utils.getWeiBalanceFromString('nogood', Web3);
+        assert.fail('Should have failed at getWeiBalance');
       } catch (e) {
         // Ok
       }

--- a/test_apps/test_app/test/config_spec.js
+++ b/test_apps/test_app/test/config_spec.js
@@ -1,0 +1,67 @@
+/*global embark, config, it, web3*/
+const assert = require('assert');
+
+let gasUsedForDeploy = 0;
+let gasPrice = 1;
+let accounts;
+
+config({
+  deployment: {
+    accounts: [
+      // you can configure custom accounts with a custom balance
+      // see https://embark.status.im/docs/contracts_testing.html#Configuring-accounts
+      {
+        privateKey: "random",
+        balance: "100000 ether"
+      }
+    ]
+  },
+  contracts: {
+    "Token": {
+      deploy: false,
+      args: [1000]
+    },
+    "MyToken2": {
+      instanceOf: "Token",
+      args: [2000]
+    },
+    "SomeContract": {
+      "args": [
+        ["$MyToken2", "$accounts[0]"],
+        100
+      ]
+    },
+    "SimpleStorage": {
+      args: [100]
+    }
+  }
+}, (_err, web3_accounts) => {
+  accounts = web3_accounts;
+});
+
+// must be declared outside of the 'before' block, otherwise
+// the 'block:header' event does not fire
+embark.events.on("block:header", (blockHeader) => {
+  gasUsedForDeploy += blockHeader.gasUsed;
+});
+
+describe("Account balance", function () {
+  before(function (done) {
+    embark.events.request("blockchain:gasPrice", (err, blkGasPrice) => {
+      if (err) {
+        return next(new Error(__("could not get the gas price")));
+      }
+      gasPrice = parseInt(blkGasPrice, 10);
+      done();
+    });
+  });
+  it('should create an account balance from a large ether value in config', async function () {
+    const shouldBeWeiBN = web3.utils.toBN('100000000000000000000000');
+    const actualBalanceWei = await web3.eth.getBalance(accounts[0]);
+    const actualBalanceWeiBN = web3.utils.toBN(actualBalanceWei);
+    const gasUsedWeiBN = web3.utils.toBN((gasUsedForDeploy * gasPrice).toString());
+    const totalBalanceWeiBN = actualBalanceWeiBN.add(gasUsedWeiBN);
+    assert.ok(totalBalanceWeiBN.gte(shouldBeWeiBN), "Total balance (account balance + deployment costs) should be greater than or equal to 100K ether");
+  });
+});
+


### PR DESCRIPTION
Specifying large ether values in the configs was causing embark to crash as javascript could not handle the large integer after the value was converted to wei.

The fix involves converting all values to BigNumbers and then comparing and adding/subtracting BigNumbers from that point forward.

There are two specific components that this affected: `config/contracts > accounts > balance` and `config/blockchain > account > balance`. The contracts config is used to fund accounts for contract deployment while the blockchain config is used for dev_funds accounts.

JSON.stringify unknown log messages

Add a unit test in the test app that sets a large ether value in the config before contract deployment and ensures the account balance is the value specified in the config.

## Reset EmbarkJS.Blockchain and EmbarkJS.Names providers
Prior to this commit, if subsequent unit tests contained different account configurations, the blockchain VM was essentially reset, however EmbarkJS was hanging on to the old providers it used from the previous configuation.

In addition, there is a limitation with `embark.registerActionForEvent` in that the action will be persisted across configuration changes. In our case, once the configuration was updated in a subsequent unit test, the directive subdomains would be attempted to be registered in ENS using the old configuration.

This commit does two things:
1) It resets the EmbarkJS.Blockchain and EmbarkJS.Names providers to the new chain configuration
2) Update to the ENS directives that prevents attempts at registered configured subdomains for previous configurations.