### PR TITLE
fix: adjust module resolution behavior

### DIFF
--- a/src/lib/core/env.js
+++ b/src/lib/core/env.js
@@ -1,5 +1,6 @@
 /* global __dirname module process require */
 
+const {execSync} = require('child_process');
 const {delimiter} = require('path');
 const {joinPath} = require('../utils/utils.js');
 
@@ -49,10 +50,24 @@ const PKG_PATH = 'PKG_PATH';
 const DEFAULT_PKG_PATH = anchoredValue(PWD);
 anchoredValue(PKG_PATH, DEFAULT_PKG_PATH);
 
+let YARN_GLOBAL_PATH;
+try {
+  YARN_GLOBAL_PATH = joinPath(
+    execSync('yarn global dir', {stdio: ['pipe', 'pipe', 'ignore']})
+      .toString()
+      .trim(),
+    'node_modules'
+  );
+} catch (e) {
+  YARN_GLOBAL_PATH = '';
+}
+
 const NODE_PATH = 'NODE_PATH';
 // NOTE: setting NODE_PATH at runtime won't effect lookup behavior in the
 // current process, but will take effect in child processes
 process.env[NODE_PATH] = joinPath(anchoredValue(EMBARK_PATH), 'node_modules') +
+  (YARN_GLOBAL_PATH ? delimiter : '') +
+  (YARN_GLOBAL_PATH || '') +
   (process.env[NODE_PATH] ? delimiter : '') +
   (process.env[NODE_PATH] || '');
 

--- a/src/lib/modules/pipeline/webpack.config.js
+++ b/src/lib/modules/pipeline/webpack.config.js
@@ -7,6 +7,15 @@ const embarkPath = process.env.EMBARK_PATH;
 
 const dappNodeModules = path.join(dappPath, 'node_modules');
 const embarkNodeModules = path.join(embarkPath, 'node_modules');
+let nodePathNodeModules;
+if (process.env.NODE_PATH) {
+  nodePathNodeModules = process.env.NODE_PATH.split(path.delimiter);
+} else {
+  nodePathNodeModules = [];
+}
+if (!nodePathNodeModules.includes(embarkNodeModules)) {
+  nodePathNodeModules.unshift(embarkNodeModules);
+}
 
 function requireFromEmbark(mod) {
   return require(requireFromEmbark.resolve(mod));
@@ -187,14 +196,16 @@ const base = {
     ],
     modules: [
       ...versions,
+      'node_modules',
       dappNodeModules,
-      embarkNodeModules
+      ...nodePathNodeModules
     ]
   },
   resolveLoader: {
     modules: [
+      'node_modules',
       dappNodeModules,
-      embarkNodeModules
+      ...nodePathNodeModules
     ]
   }
 };

--- a/src/lib/modules/whisper/js/communicationFunctions.js
+++ b/src/lib/modules/whisper/js/communicationFunctions.js
@@ -93,8 +93,7 @@ function listenTo(options, callback) {
         return callback(null, data);
       }
       promise.cb(payload, data, result);
-    })
-    .catch(callback);
+    });
 
   return promise;
 }


### PR DESCRIPTION
Include yarn's global path when modifying `NODE_PATH` since dependencies are deduped when a package is installed globally with yarn, which is different from npm's behavior.

Fix webpack resolution by listing relative `'node_modules'` in `resolve/Loader:{modules:[...]}`. This ensures that dependecies' dependecies are resolved correctly when webpack builds a DApp.

Remove the invocation of `.catch()` on a subscription object which lacks that method.