### PR TITLE
feat(@embark/core): Allow search to find contract by name

### DIFF
--- a/embark-ui/src/components/Layout.js
+++ b/embark-ui/src/components/Layout.js
@@ -96,7 +96,7 @@ class Layout extends React.Component {
       }
 
       if (nextProps.searchResult.className) {
-        this.props.history.push(`/embark/contracts/${nextProps.searchResult.className}/overview`);
+        this.props.history.push(`/embark/explorer/contracts/${nextProps.searchResult.className}`);
         return false;
       }
       if (nextProps.searchResult.address) {

--- a/embark-ui/src/sagas/searchSaga.js
+++ b/embark-ui/src/sagas/searchSaga.js
@@ -37,7 +37,7 @@ export function *searchExplorer(entity, payload) {
   yield fetchContracts({});
   const contracts = yield select(getContracts);
   result = contracts.find(contract => {
-    return contract.address === searchValue;
+    return contract.address === searchValue || contract.className.toLowerCase() === searchValue.toLowerCase();
   });
 
   if (result) {


### PR DESCRIPTION
In the cockpit, allow the search to find the contract by name. For example in the test_app, searching for “Token” (or “token”) in the cockpit, will take the user to the Token contract page.

![search for mytoken result](https://i.imgur.com/JhazMuK.png)