### PR TITLE
feat(scaffold): use ipfs in scaffold and upload file

### DIFF
--- a/src/lib/modules/scaffolding/framework/reactBuilder/templates/dapp.js.hbs
+++ b/src/lib/modules/scaffolding/framework/reactBuilder/templates/dapp.js.hbs
@@ -32,13 +32,19 @@ class {{capitalize name}}Form{{@index}} extends Component {
         };
     }
 
-    handleChange(e, name){
+    handleChangeFile(e) {
+        const {input} = this.state;
+        input.file = [e.target];
+        this.setState({input});
+    }
+
+    handleChange(e, name) {
         const {input} = this.state;
         input[name] = e.target.value;
         this.setState({input});
     }
 
-    handleCheckbox(e, name){
+    handleCheckbox(e, name) {
         const {input} = this.state;
         input[name] = e.target.checked;
         this.setState({input});
@@ -52,6 +58,7 @@ class {{capitalize name}}Form{{@index}} extends Component {
         this.setState({output: null, error: null, receipt: null});
 
         try {
+        {{#if isStandard}}
         {{#ifview stateMutability}}
             const result = await {{../contractName}}.methods{{methodname ../functions name inputs}}({{#each inputs}}input.{{#ifeq name ''}}field{{else}}{{trim name}}{{/ifeq}}{{#unless @last}}, {{/unless}}{{/each}}).call();
             {{#iflengthgt outputs 1}}
@@ -59,10 +66,10 @@ class {{capitalize name}}Form{{@index}} extends Component {
             {{#each outputs}}
                 {{emptyname name @index}}: result[{{@index}}]{{#unless @last}},{{/unless}}
             {{/each}}
-            }}); 
+            }});
             {{else}}
-            this.setState({output: result});  
-            {{/iflengthgt}}           
+            this.setState({output: result});
+            {{/iflengthgt}}
         {{else}}
             {{#each inputs}}
             {{#ifarr type}}
@@ -73,7 +80,7 @@ class {{capitalize name}}Form{{@index}} extends Component {
             const toSend = {{../contractName}}.methods{{methodname ../functions name inputs}}({{#each inputs}}input.{{#ifeq name ''}}field{{else}}{{trim name}}{{/ifeq}}{{#unless @last}}, {{/unless}}{{/each}});
 
             const estimatedGas = await toSend.estimateGas({from: web3.eth.defaultAccount});
-            
+
             const receipt = await toSend.send({
                 {{#if payable}}
                 value: value,
@@ -86,6 +93,51 @@ class {{capitalize name}}Form{{@index}} extends Component {
 
             this.setState({receipt});
         {{/ifview}}
+        {{/if}}
+
+        {{#if isIpfsText}}
+        {{#ifview stateMutability}}
+            const result = await {{../contractName}}.methods{{methodname ../functions name inputs}}({{#each inputs}}input.{{#ifeq name ''}}field{{else}}{{trim name}}{{/ifeq}}{{#unless @last}}, {{/unless}}{{/each}}).call();
+            const data = await EmbarkJS.Storage.get(result);
+            this.setState({output: data});
+        {{else}}
+            const hash = await EmbarkJS.Storage.saveText(input.{{inputs.1.name}});
+            const toSend = {{../contractName}}.methods{{methodname ../functions name inputs}}(input.{{inputs.0.name}}, hash);
+
+            const estimatedGas = await toSend.estimateGas({from: web3.eth.defaultAccount});
+
+            const receipt = await toSend.send({
+                from: web3.eth.defaultAccount,
+                gasLimit: estimatedGas
+            });
+
+            console.log(receipt);
+
+            this.setState({receipt});
+        {{/ifview}}
+        {{/if}}
+
+        {{#if isIpfsFile}}
+        {{#ifview stateMutability}}
+            const result = await {{../contractName}}.methods{{methodname ../functions name inputs}}({{#each inputs}}input.{{#ifeq name ''}}field{{else}}{{trim name}}{{/ifeq}}{{#unless @last}}, {{/unless}}{{/each}}).call();
+            const url = EmbarkJS.Storage.getUrl(result);
+            this.setState({output: url});
+        {{else}}
+            const hash = await EmbarkJS.Storage.uploadFile(input.file)
+            const toSend = {{../contractName}}.methods{{methodname ../functions name inputs}}(input._id, hash);
+
+            const estimatedGas = await toSend.estimateGas({from: web3.eth.defaultAccount});
+
+            const receipt = await toSend.send({
+                from: web3.eth.defaultAccount,
+                gasLimit: estimatedGas
+            });
+
+            console.log(receipt);
+
+            this.setState({receipt});
+        {{/ifview}}
+        {{/if}}
         } catch(err) {
             console.error(err);
             this.setState({error: err.message});
@@ -99,6 +151,34 @@ class {{capitalize name}}Form{{@index}} extends Component {
             <h3>{{name}}</h3>
             <form>
             {{#if inputs.length}}
+            {{#if isIpfsFile}}
+            {{#ifview stateMutability}}
+                <FormGroup>
+                    <ControlLabel>_id</ControlLabel>
+                    <FormControl
+                        type="text"
+                        placeholder="uint256"
+                        onChange={(e) => this.handleChange(e, '_id')}
+                    />
+                </FormGroup>
+            {{else}}
+                <FormGroup>
+                    <ControlLabel>_id</ControlLabel>
+                    <FormControl
+                        type="text"
+                        placeholder="uint256"
+                        onChange={(e) => this.handleChange(e, '_id')}
+                    />
+                </FormGroup>
+                <FormGroup>
+                    <ControlLabel>File</ControlLabel>
+                    <FormControl
+                        type="file"
+                        onChange={(e) => this.handleChangeFile(e)}
+                    />
+                </FormGroup>
+            {{/ifview}}
+            {{else}}
                 {{#each inputs}}
                 <FormGroup>
                     <ControlLabel>{{#ifeq name ''}}field{{else}}{{name}}{{/ifeq}}</ControlLabel>
@@ -115,14 +195,15 @@ class {{capitalize name}}Form{{@index}} extends Component {
                     />
                     {{/ifeq}}
                 </FormGroup>
-                {{/each}}      
+                {{/each}}
+            {{/if}}
             {{/if}}
             {{#if payable}}
                 <FormGroup>
                     <ControlLabel>Value</ControlLabel>
                     <InputGroup>
                         <InputGroup.Addon>Ξ</InputGroup.Addon>
-                        <FormControl 
+                        <FormControl
                             type="text"
                             defaultValue={ value }
                             placeholder="{{type}}"
@@ -159,7 +240,7 @@ class {{capitalize name}}Form{{@index}} extends Component {
                 <Fragment>
                     <Alert bsStyle={isSuccess(receipt.status) ? 'success' : 'danger'}>{isSuccess(receipt.status) ? 'Success' : 'Failure / Revert'} - Transaction Hash: {receipt.transactionHash}</Alert>
                 </Fragment>
-                
+
                 }
             {{/ifview}}
             </form>


### PR DESCRIPTION
there is 2 IPFS case:

* text
the text is save to ipfs then the hash is save to the contract
When using the accessor, we directly return the text, ipfs is transparent

* image
the image is save to ipfs then the hash is save to the contract
When using the accessor, we return the url to the file
When using the setter, we present a file upload input

![screenshot at dec 06 13-46-43](https://user-images.githubusercontent.com/491074/49588044-a0367b80-f95d-11e8-8fbd-319b3aee10b2.png)
![screenshot at dec 06 13-46-33](https://user-images.githubusercontent.com/491074/49588063-ad536a80-f95d-11e8-935e-af5a2339d82a.png)


