### PR TITLE
 feat(@embark/core): Support directives in ENS config

### DIFF
--- a/src/lib/modules/blockchain_process/blockchain.js
+++ b/src/lib/modules/blockchain_process/blockchain.js
@@ -402,7 +402,7 @@ Blockchain.prototype.initChainAndGetAddress = function (callback) {
     function listAccounts(next) {
       self.runCommand(self.client.listAccountsCommand(), {}, (err, stdout, _stderr) => {
         if (err || stdout === undefined || stdout.indexOf("Fatal") >= 0) {
-          this.logger.info(__("no accounts found").green);
+          self.logger.info(__("no accounts found").green);
           return next();
         }
         let firstAccountFound = self.client.parseListAccountsCommandResultToAddress(stdout);
@@ -410,7 +410,7 @@ Blockchain.prototype.initChainAndGetAddress = function (callback) {
           console.log(__("no accounts found").green);
           return next();
         }
-        this.logger.info(__("already initialized").green);
+        self.logger.info(__("already initialized").green);
         address = firstAccountFound;
         next(ALREADY_INITIALIZED);
       });

--- a/test_apps/test_app/config/namesystem.json
+++ b/test_apps/test_app/config/namesystem.json
@@ -8,7 +8,9 @@
     "register": {
       "rootDomain": "embark.eth",
       "subdomains": {
-        "status": "0x4a17f35f0a9927fb4141aa91cbbc72c1b31598de"
+        "status": "0x4a17f35f0a9927fb4141aa91cbbc72c1b31598de",
+        "mytoken": "$MyToken",
+        "MyToken2": "$MyToken2"
       }
     }
   }

--- a/test_apps/test_app/test/namesystem_spec.js
+++ b/test_apps/test_app/test/namesystem_spec.js
@@ -1,0 +1,38 @@
+/*global describe, it, web3, config*/
+const assert = require('assert');
+const MyToken = require('Embark/contracts/MyToken');
+const MyToken2 = require('Embark/contracts/MyToken2');
+const EmbarkJS = require('Embark/EmbarkJS');
+
+config({
+  contracts: {
+    "Token": {
+      deploy: false,
+      args: [1000]
+    },
+    "MyToken": {
+      instanceOf: "Token"
+    },
+    "MyToken2": {
+      instanceOf: "Token",
+      args: [2000]
+    }
+  }
+});
+
+describe("ENS functions", function() {
+  it('should allow directives in ENS subdomains', async function() {
+    const myTokenAddress = await EmbarkJS.Names.resolve('mytoken.embark.eth');
+    assert.strictEqual(MyToken.options.address, myTokenAddress);
+    
+    const myToken2Address = await EmbarkJS.Names.resolve('MyToken2.embark.eth');
+    assert.strictEqual(MyToken2.options.address, myToken2Address);
+    
+    const myTokenName = await EmbarkJS.Names.lookup(MyToken.options.address.toLowerCase());
+    assert.strictEqual(myTokenName, 'mytoken.embark.eth');
+    
+    const myToken2Name = await EmbarkJS.Names.lookup(MyToken2.options.address.toLowerCase());
+    assert.strictEqual(myToken2Name, 'MyToken2.embark.eth');
+  });
+});
+


### PR DESCRIPTION
Support directives in ENS configurations, such that subdomains can be registered to addresses of deployed tokens.

The following directives are supported:
```
"register": {
      "rootDomain": "embark.eth",
      "subdomains": {
        "status": "0x4a17f35f0a9927fb4141aa91cbbc72c1b31598de",
        "mytoken": "$MyToken",
        "MyToken2": "$MyToken2"
      }
    }
```

Add unit test for these directives.