### PR TITLE
refactor(@embark/utils): use timeouts to improve utils.pingEndpoint

### DIFF
--- a/src/lib/modules/blockchain_process/proxy.js
+++ b/src/lib/modules/blockchain_process/proxy.js
@@ -109,7 +109,7 @@ exports.serve = async (ipc, host, port, ws, origin) => {
         'http',
         origin ? origin.split(',')[0] : undefined,
         (err) => {
-          if (!err || (Date.now() - start > 10000)) {
+          if (!err || (Date.now() - start > 600000)) {
             resolve();
           } else {
             utils.timer(250).then(waitOnTarget).then(resolve);


### PR DESCRIPTION
For reasons unknown, sockets underlying http and websocket requests made by `utils.pingEndpoint` could become stuck and after a *long* time eventually hang up. This can happen even when the endpoint being pinged is perfectly responsive, e.g. when checking it with `curl` in another terminal. The root cause may be a bug or poorly documented behavior in node.js itself. The effects of the stuck sockets are experienced more often when the CPU is under moderate-heavy load, and also more often when pinging embark's blockchain proxy vs. pinging geth, ipfs, etc. directly.

Use timeouts to cut short the stuck sockets. Usually, after one-to-several retries (which may get stuck) following a stuck socket, connections behave as expected (learned by experience). Assume that `T` time of inactivity on a "ping socket" indicates that socket is stuck; increase `T` exponentially on each retry until it reaches a max of 3000ms, and don't continue retrying beyond 600000ms (10 minutes). Make the initial `T` value 100ms. Once a retry is underway following a timeout event, ignore all further events on the previous ping attempt.

Note that when the CPU is moderately busy, one of the slowest steps is launching embark's child processes, e.g. ipfs, geth, etc. However, even under very heavy load, with the revised `pingEndpoint` embark seems to always eventually start/detect services correctly. And under light to moderate load, the effect of the stuck sockets is much less noticeable.

Use a weboscket client from the `ws` package instead of manually building websocket headers.

Use `pingEndpoint` for the IPFS module's `_checkService` method to avoid the same stuck socket problem that was affecting blockchain detection.