### PR TITLE
Fix tests hanging when connecting to a node

### DIFF
--- a/src/cmd/cmd_controller.js
+++ b/src/cmd/cmd_controller.js
@@ -646,7 +646,7 @@ class EmbarkController {
         });
         engine.startService("storage");
         engine.startService("codeGenerator");
-        engine.startService("console");
+        engine.startService("console", {forceRegister: true});
         engine.startService("pluginCommand");
         if (options.coverage) {
           engine.startService("codeCoverage");

--- a/src/lib/core/engine.js
+++ b/src/lib/core/engine.js
@@ -162,14 +162,15 @@ class Engine {
     this.registerModule('plugin_cmd', {embarkConfigFile: this.embarkConfig, embarkConfig: this.config.embarkConfig, packageFile: 'package.json'});
   }
 
-  console(_options) {
+  console(options) {
     this.registerModule('console', {
       events: this.events,
       plugins: this.plugins,
       version: this.version,
       ipc: this.ipc,
       logger: this.logger,
-      config: this.config
+      config: this.config,
+      forceRegister: options.forceRegister
     });
     this.registerModule('authenticator');
   }

--- a/src/lib/modules/console/index.ts
+++ b/src/lib/modules/console/index.ts
@@ -21,6 +21,7 @@ class Console {
   private cmdHistoryFile: string;
   private suggestions: Suggestions;
   private providerReady: boolean;
+  private forceRegister: boolean;
 
   constructor(embark: Embark, options: any) {
     this.embark = embark;
@@ -30,6 +31,7 @@ class Console {
     this.logger = options.logger;
     this.ipc = options.ipc;
     this.config = options.config;
+    this.forceRegister = options.forceRegister;
     this.history = [];
     this.cmdHistoryFile = options.cmdHistoryFile || fs.dappPath(".embark", "cmd_history");
     this.providerReady = false;
@@ -148,7 +150,7 @@ class Console {
     this.events.emit("runcode:register", "EmbarkJS", EmbarkJS, false);
 
     EmbarkJS.Blockchain.done = true;
-    if (this.ipc.connected) {
+    if (this.ipc.connected && !this.forceRegister) {
       return;
     }
 


### PR DESCRIPTION
Was caused because tests require the console to register providers, but we have a flag to not register when ipc is connected. So added a flag to force registration (only used for tests right now)