### PR TITLE
fix(@embark/core): Fix `—template` URL support

### DIFF
--- a/src/lib/utils/template_generator.js
+++ b/src/lib/utils/template_generator.js
@@ -1,7 +1,16 @@
-let fs = require('../core/fs.js');
-let hostedGitInfo = require('hosted-git-info');
-let utils = require('./utils.js');
-let semver = require('semver');
+const fs = require('../core/fs.js');
+const hostedGitInfo = require('hosted-git-info');
+const utils = require('./utils.js');
+const semver = require('semver');
+
+const REPLACEMENTS = {
+  'git@github.com/': 'git@github.com:',
+  'git@bitbucket.org/': 'git@bitbucket.org:',
+  'git@gitlab.com/': 'git@gitlab.com:',
+  'github.com/': '',
+  'bitbucket.org/': 'bitbucket:',
+  'gitlab.com/': 'gitlab:'
+};
 
 class TemplateGenerator {
   constructor(templateName) {
@@ -128,6 +137,11 @@ class TemplateGenerator {
   getExternalProject(uri) {
     let url, folder, hgi;
     let fallback, url_fallback, folder_fallback, hgi_fallback, embarkVersion;
+    
+    // reformat uri before parsing with hosted-git-info. Allows for further syntax support.
+    Object.keys(REPLACEMENTS).forEach(replacement => {
+      if(uri.indexOf(replacement) === 0) uri = uri.replace(replacement, REPLACEMENTS[replacement]);
+    });
     hgi = hostedGitInfo.fromUrl(uri);
     if (!hgi || hgi.user.includes('#')) {
       let templateAndBranch = uri.split('#');

--- a/src/test/template.js
+++ b/src/test/template.js
@@ -12,6 +12,9 @@ describe('TemplateGenerator', function () {
     before(() => {
       templateGenerator = new TemplateGenerator();
       sinon.stub(request, 'get').callsFake((options, callback) => {
+        if (options.url.indexOf('status-im/dreddit-devcon') > 0) {
+          return callback(null, {}, {default_branch: 'start'});
+        }
         callback(null, {}, {default_branch: 'master'});
       });
     });
@@ -23,15 +26,14 @@ describe('TemplateGenerator', function () {
         let embarkVersion = semver(require('../../package.json').version);
         let branch = `${embarkVersion.major}.${embarkVersion.minor}`;
         assert.strictEqual(result.url, `https://codeload.github.com/embark-framework/embark-typescript-template/tar.gz/${branch}`);
-        assert.strictEqual(result.filePath.replace(/\\/g,'/'), `.embark/templates/embark-framework/embark-typescript-template/${branch}/archive.zip`);
+        assert.strictEqual(result.filePath.replace(/\\/g, '/'), `.embark/templates/embark-framework/embark-typescript-template/${branch}/archive.zip`);
         assert.strictEqual(result.browse, `https://github.com/embark-framework/embark-typescript-template/tree/${branch}`);
 
         result = templateGenerator.getExternalProject("typescript#features/branch");
         assert.strictEqual(result.url, "https://codeload.github.com/embark-framework/embark-typescript-template/tar.gz/features%2Fbranch");
-        assert.strictEqual(result.filePath.replace(/\\/g,'/'), ".embark/templates/embark-framework/embark-typescript-template/features/branch/archive.zip");
+        assert.strictEqual(result.filePath.replace(/\\/g, '/'), ".embark/templates/embark-framework/embark-typescript-template/features/branch/archive.zip");
         assert.strictEqual(result.browse, "https://github.com/embark-framework/embark-typescript-template/tree/features/branch");
       });
-
     });
 
     describe('with git host URL', function () {
@@ -42,92 +44,169 @@ describe('TemplateGenerator', function () {
 
         result = await templateGenerator.getExternalProject("https://github.com/embark-framework/embark");
         assert.strictEqual(result.url, "https://codeload.github.com/embark-framework/embark/tar.gz/master");
-        assert.strictEqual(result.filePath.replace(/\\/g,'/'), ".embark/templates/embark-framework/embark/master/archive.zip");
+        assert.strictEqual(result.filePath.replace(/\\/g, '/'), ".embark/templates/embark-framework/embark/master/archive.zip");
         assert.strictEqual(result.browse, "https://github.com/embark-framework/embark");
 
         result = await templateGenerator.getExternalProject("https://github.com/embark-framework/embark#features/branch");
         assert.strictEqual(result.url, "https://codeload.github.com/embark-framework/embark/tar.gz/features%2Fbranch");
-        assert.strictEqual(result.filePath.replace(/\\/g,'/'), ".embark/templates/embark-framework/embark/features/branch/archive.zip");
+        assert.strictEqual(result.filePath.replace(/\\/g, '/'), ".embark/templates/embark-framework/embark/features/branch/archive.zip");
         assert.strictEqual(result.browse, "https://github.com/embark-framework/embark/tree/features/branch");
       });
 
       it('returns correct info for Bitbucket URL', async function () {
         let result = await templateGenerator.getExternalProject("https://bitbucket.org/embark-framework/embark");
         assert.strictEqual(result.url, "https://bitbucket.org/embark-framework/embark/get/master.tar.gz");
-        assert.strictEqual(result.filePath.replace(/\\/g,'/'), ".embark/templates/embark-framework/embark/master/archive.zip");
+        assert.strictEqual(result.filePath.replace(/\\/g, '/'), ".embark/templates/embark-framework/embark/master/archive.zip");
         assert.strictEqual(result.browse, "https://bitbucket.org/embark-framework/embark");
 
         result = await templateGenerator.getExternalProject("https://bitbucket.org/embark-framework/embark#features/branch");
         assert.strictEqual(result.url, "https://bitbucket.org/embark-framework/embark/get/features%2Fbranch.tar.gz");
-        assert.strictEqual(result.filePath.replace(/\\/g,'/'), ".embark/templates/embark-framework/embark/features/branch/archive.zip");
+        assert.strictEqual(result.filePath.replace(/\\/g, '/'), ".embark/templates/embark-framework/embark/features/branch/archive.zip");
         assert.strictEqual(result.browse, "https://bitbucket.org/embark-framework/embark/src/features/branch");
       });
 
       it('returns correct info for GitLab URL', async function () {
         let result = await templateGenerator.getExternalProject("https://gitlab.com/embark-framework/embark");
         assert.strictEqual(result.url, "https://gitlab.com/embark-framework/embark/repository/archive.tar.gz?ref=master");
-        assert.strictEqual(result.filePath.replace(/\\/g,'/'), ".embark/templates/embark-framework/embark/master/archive.zip");
+        assert.strictEqual(result.filePath.replace(/\\/g, '/'), ".embark/templates/embark-framework/embark/master/archive.zip");
         assert.strictEqual(result.browse, "https://gitlab.com/embark-framework/embark");
 
         result = await templateGenerator.getExternalProject("https://gitlab.com/embark-framework/embark#features/branch");
         assert.strictEqual(result.url, "https://gitlab.com/embark-framework/embark/repository/archive.tar.gz?ref=features%2Fbranch");
-        assert.strictEqual(result.filePath.replace(/\\/g,'/'), ".embark/templates/embark-framework/embark/features/branch/archive.zip");
+        assert.strictEqual(result.filePath.replace(/\\/g, '/'), ".embark/templates/embark-framework/embark/features/branch/archive.zip");
         assert.strictEqual(result.browse, "https://gitlab.com/embark-framework/embark/tree/features/branch");
       });
-
     });
 
     describe('with git host shortcut', function () {
-
       it('returns correct info for GitHub shortcut', async function () {
         let result = await templateGenerator.getExternalProject("github:embark-framework/embark");
         assert.strictEqual(result.url, "https://codeload.github.com/embark-framework/embark/tar.gz/master");
 
         result = await templateGenerator.getExternalProject("embark-framework/embark");
         assert.strictEqual(result.url, "https://codeload.github.com/embark-framework/embark/tar.gz/master");
-        assert.strictEqual(result.filePath.replace(/\\/g,'/'), ".embark/templates/embark-framework/embark/master/archive.zip");
+        assert.strictEqual(result.filePath.replace(/\\/g, '/'), ".embark/templates/embark-framework/embark/master/archive.zip");
         assert.strictEqual(result.browse, "https://github.com/embark-framework/embark");
 
         result = await templateGenerator.getExternalProject("embark-framework/embark#features/branch");
         assert.strictEqual(result.url, "https://codeload.github.com/embark-framework/embark/tar.gz/features%2Fbranch");
-        assert.strictEqual(result.filePath.replace(/\\/g,'/'), ".embark/templates/embark-framework/embark/features/branch/archive.zip");
+        assert.strictEqual(result.filePath.replace(/\\/g, '/'), ".embark/templates/embark-framework/embark/features/branch/archive.zip");
+        assert.strictEqual(result.browse, "https://github.com/embark-framework/embark/tree/features/branch");
+
+        result = await templateGenerator.getExternalProject("github.com/embark-framework/embark");
+        assert.strictEqual(result.url, "https://codeload.github.com/embark-framework/embark/tar.gz/master");
+        assert.strictEqual(result.filePath.replace(/\\/g, '/'), ".embark/templates/embark-framework/embark/master/archive.zip");
+        assert.strictEqual(result.browse, "https://github.com/embark-framework/embark");
+
+        result = await templateGenerator.getExternalProject("github.com/embark-framework/embark#features/branch");
+        assert.strictEqual(result.url, "https://codeload.github.com/embark-framework/embark/tar.gz/features%2Fbranch");
+        assert.strictEqual(result.filePath.replace(/\\/g, '/'), ".embark/templates/embark-framework/embark/features/branch/archive.zip");
         assert.strictEqual(result.browse, "https://github.com/embark-framework/embark/tree/features/branch");
       });
 
       it('returns correct info for Bitbucket shortcut', async function () {
         let result = await templateGenerator.getExternalProject("bitbucket:embark-framework/embark");
         assert.strictEqual(result.url, "https://bitbucket.org/embark-framework/embark/get/master.tar.gz");
-        assert.strictEqual(result.filePath.replace(/\\/g,'/'), ".embark/templates/embark-framework/embark/master/archive.zip");
+        assert.strictEqual(result.filePath.replace(/\\/g, '/'), ".embark/templates/embark-framework/embark/master/archive.zip");
         assert.strictEqual(result.browse, "https://bitbucket.org/embark-framework/embark");
 
         result = await templateGenerator.getExternalProject("bitbucket:embark-framework/embark#features/branch");
         assert.strictEqual(result.url, "https://bitbucket.org/embark-framework/embark/get/features%2Fbranch.tar.gz");
-        assert.strictEqual(result.filePath.replace(/\\/g,'/'), ".embark/templates/embark-framework/embark/features/branch/archive.zip");
+        assert.strictEqual(result.filePath.replace(/\\/g, '/'), ".embark/templates/embark-framework/embark/features/branch/archive.zip");
+        assert.strictEqual(result.browse, "https://bitbucket.org/embark-framework/embark/src/features/branch");
+
+        result = await templateGenerator.getExternalProject("bitbucket.org/embark-framework/embark");
+        assert.strictEqual(result.url, "https://bitbucket.org/embark-framework/embark/get/master.tar.gz");
+        assert.strictEqual(result.filePath.replace(/\\/g, '/'), ".embark/templates/embark-framework/embark/master/archive.zip");
+        assert.strictEqual(result.browse, "https://bitbucket.org/embark-framework/embark");
+
+        result = await templateGenerator.getExternalProject("bitbucket.org/embark-framework/embark#features/branch");
+        assert.strictEqual(result.url, "https://bitbucket.org/embark-framework/embark/get/features%2Fbranch.tar.gz");
+        assert.strictEqual(result.filePath.replace(/\\/g, '/'), ".embark/templates/embark-framework/embark/features/branch/archive.zip");
         assert.strictEqual(result.browse, "https://bitbucket.org/embark-framework/embark/src/features/branch");
       });
 
       it('returns correct info for GitLab shortcut', async function () {
         let result = await templateGenerator.getExternalProject("gitlab:embark-framework/embark");
         assert.strictEqual(result.url, "https://gitlab.com/embark-framework/embark/repository/archive.tar.gz?ref=master");
-        assert.strictEqual(result.filePath.replace(/\\/g,'/'), ".embark/templates/embark-framework/embark/master/archive.zip");
+        assert.strictEqual(result.filePath.replace(/\\/g, '/'), ".embark/templates/embark-framework/embark/master/archive.zip");
         assert.strictEqual(result.browse, "https://gitlab.com/embark-framework/embark");
 
         result = await templateGenerator.getExternalProject("gitlab:embark-framework/embark#features/branch");
         assert.strictEqual(result.url, "https://gitlab.com/embark-framework/embark/repository/archive.tar.gz?ref=features%2Fbranch");
-        assert.strictEqual(result.filePath.replace(/\\/g,'/'), ".embark/templates/embark-framework/embark/features/branch/archive.zip");
+        assert.strictEqual(result.filePath.replace(/\\/g, '/'), ".embark/templates/embark-framework/embark/features/branch/archive.zip");
+        assert.strictEqual(result.browse, "https://gitlab.com/embark-framework/embark/tree/features/branch");
+
+        result = await templateGenerator.getExternalProject("gitlab.com/embark-framework/embark");
+        assert.strictEqual(result.url, "https://gitlab.com/embark-framework/embark/repository/archive.tar.gz?ref=master");
+        assert.strictEqual(result.filePath.replace(/\\/g, '/'), ".embark/templates/embark-framework/embark/master/archive.zip");
+        assert.strictEqual(result.browse, "https://gitlab.com/embark-framework/embark");
+
+        result = await templateGenerator.getExternalProject("gitlab.com/embark-framework/embark#features/branch");
+        assert.strictEqual(result.url, "https://gitlab.com/embark-framework/embark/repository/archive.tar.gz?ref=features%2Fbranch");
+        assert.strictEqual(result.filePath.replace(/\\/g, '/'), ".embark/templates/embark-framework/embark/features/branch/archive.zip");
         assert.strictEqual(result.browse, "https://gitlab.com/embark-framework/embark/tree/features/branch");
       });
+    });
 
+    describe('with default branch other than master', function () {
+      it('returns correct info for GitHub repo with a non-master default branch', async function () {
+        let result = await templateGenerator.getExternalProject("status-im/dreddit-devcon");
+        assert.strictEqual(result.url, "https://codeload.github.com/status-im/dreddit-devcon/tar.gz/start");
+        assert.strictEqual(result.filePath.replace(/\\/g, '/'), ".embark/templates/status-im/dreddit-devcon/start/archive.zip");
+        assert.strictEqual(result.browse, "https://github.com/status-im/dreddit-devcon");
+
+        result = await templateGenerator.getExternalProject("status-im/dreddit-devcon#features/branch");
+        assert.strictEqual(result.url, "https://codeload.github.com/status-im/dreddit-devcon/tar.gz/features%2Fbranch");
+        assert.strictEqual(result.filePath.replace(/\\/g, '/'), ".embark/templates/status-im/dreddit-devcon/features/branch/archive.zip");
+        assert.strictEqual(result.browse, "https://github.com/status-im/dreddit-devcon/tree/features/branch");
+      });
+    });
+
+    describe('with SSH URL', function () {
+      it('returns correct info for GitHub SSH repo', async function () {
+        let result = await templateGenerator.getExternalProject("git@github.com/embark-framework/embark");
+        assert.strictEqual(result.url, "https://codeload.github.com/embark-framework/embark/tar.gz/master");
+        assert.strictEqual(result.filePath.replace(/\\/g, '/'), ".embark/templates/embark-framework/embark/master/archive.zip");
+        assert.strictEqual(result.browse, "https://github.com/embark-framework/embark");
+
+        result = await templateGenerator.getExternalProject("git@github.com/embark-framework/embark#features/branch");
+        assert.strictEqual(result.url, "https://codeload.github.com/embark-framework/embark/tar.gz/features%2Fbranch");
+        assert.strictEqual(result.filePath.replace(/\\/g, '/'), ".embark/templates/embark-framework/embark/features/branch/archive.zip");
+        assert.strictEqual(result.browse, "https://github.com/embark-framework/embark/tree/features/branch");
+      });
+
+      it('returns correct info for BitBucket SSH repo', async function () {
+        let result = await templateGenerator.getExternalProject("git@bitbucket.org/embark-framework/embark");
+        assert.strictEqual(result.url, "https://bitbucket.org/embark-framework/embark/get/master.tar.gz");
+        assert.strictEqual(result.filePath.replace(/\\/g, '/'), ".embark/templates/embark-framework/embark/master/archive.zip");
+        assert.strictEqual(result.browse, "https://bitbucket.org/embark-framework/embark");
+
+        result = await templateGenerator.getExternalProject("git@bitbucket.org/embark-framework/embark#features/branch");
+        assert.strictEqual(result.url, "https://bitbucket.org/embark-framework/embark/get/features%2Fbranch.tar.gz");
+        assert.strictEqual(result.filePath.replace(/\\/g, '/'), ".embark/templates/embark-framework/embark/features/branch/archive.zip");
+        assert.strictEqual(result.browse, "https://bitbucket.org/embark-framework/embark/src/features/branch");
+      });
+
+      it('returns correct info for GitLab SSH repo', async function () {
+        let result = await templateGenerator.getExternalProject("git@gitlab.com/embark-framework/embark");
+        assert.strictEqual(result.url, "https://gitlab.com/embark-framework/embark/repository/archive.tar.gz?ref=master");
+        assert.strictEqual(result.filePath.replace(/\\/g, '/'), ".embark/templates/embark-framework/embark/master/archive.zip");
+        assert.strictEqual(result.browse, "https://gitlab.com/embark-framework/embark");
+
+        result = await templateGenerator.getExternalProject("git@gitlab.com/embark-framework/embark#features/branch");
+        assert.strictEqual(result.url, "https://gitlab.com/embark-framework/embark/repository/archive.tar.gz?ref=features%2Fbranch");
+        assert.strictEqual(result.filePath.replace(/\\/g, '/'), ".embark/templates/embark-framework/embark/features/branch/archive.zip");
+        assert.strictEqual(result.browse, "https://gitlab.com/embark-framework/embark/tree/features/branch");
+      });
     });
 
     describe('with unsupported template specifier', function () {
-
       it('raises an exception', function () {
         assert.throws(() => templateGenerator.getExternalProject("bad://format"), /Unsupported/);
         assert.throws(() => templateGenerator.getExternalProject("bad://format#/also/bad"), /Unsupported/);
         assert.throws(() => templateGenerator.getExternalProject(/force an error/), Error);
       });
-
     });
 
   });


### PR DESCRIPTION
Support for all template URL syntax as spec’d in https://our.status.im/embark-3-2-much-more-than-a-moonshot/ (Everyone Gets A Template section).

Unit tests were added for all missing cases.

# Test results
| Test case        | Command           | Successful?  | Output |
| :----------------------------------------- | :--------------------------------------------------------- | :---: | :-------- |
| ~~1a. Normal React template, no URL~~  			| ~~`embark new 1-normal-template-react --template react`~~ | ~~No~~ | ~~see below~~ |
```
Installing template from https://github.com/embark-framework/embark-react-template/tree/4.0
Downloading template...
Download failed, response code 404
Retrying with the default branch...
It may not be compatible with your Embark version 4.0.0-alpha.2
Installing template from https://github.com/embark-framework/embark-react-template
Downloading template...
Download failed, response code 404
Does the template really exist?
Embark's supported templates: https://embark.status.im/templates/
```
~~**Failure reason**: https://github.com/embark-framework/embark-react-template repo doesn't exist~~
~~**Do we know what happened to this repo?**~~

** **UPDATE** **
This was never really meant to be a test case :) The react template can be installed using the command:
```
embark demo
```

| Test case        | Command           | Successful?  | Output |
| :----------------------------------------- | :--------------------------------------------------------- | :---: | :-------- |
| 1b. Normal TypeScript template, no URL  			| `embark new 1-normal-template-typescript --template typescript` |  Yes | see below |
```
Installing template from https://github.com/embark-framework/embark-typescript-template/tree/4.0
Downloading template...
Download failed, response code 404
Retrying with the default branch...
It may not be compatible with your Embark version 4.0.0-alpha.2
Installing template from https://github.com/embark-framework/embark-typescript-template
Downloading template...
Installing packages...
Init complete

App ready at 1-normal-template-typescript
```
| Test case        | Command           | Successful?  | Output |
| :----------------------------------------- | :--------------------------------------------------------- | :---: | :-------- |
| 1c. Normal Vyper template, no URL  			| `embark new 1-normal-template-vyper --template vyper` | Yes |see below |
```
Installing template from https://github.com/embark-framework/embark-vyper-template/tree/4.0
Downloading template...
Download failed, response code 404
Retrying with the default branch...
It may not be compatible with your Embark version 4.0.0-alpha.2
Installing template from https://github.com/embark-framework/embark-vyper-template
Downloading template...
Installing packages...
Init complete

App ready at 1-normal-template-vyper
```
| Test case        | Command           | Successful?  | Output |
| :----------------------------------------- | :--------------------------------------------------------- | :---: | :-------- |
| 1d. Normal Vue.js template, no URL  			| `embark new 1-normal-template-vue --template vue` |  Yes |see below|
```
Installing template from https://github.com/embark-framework/embark-vue-template/tree/4.0
Downloading template...
Download failed, response code 404
Retrying with the default branch...
It may not be compatible with your Embark version 4.0.0-alpha.2
Installing template from https://github.com/embark-framework/embark-vue-template
Downloading template...
Installing packages...
Init complete

App ready at 1-normal-template-vue
```
| Test case        | Command           | Successful?  | Output |
| :----------------------------------------- | :--------------------------------------------------------- | :---: | :-------- |
| 1e. Normal Bamboo template, no URL  			| `embark new 1-normal-template-bamboo --template bamboo` |  Yes |see below|
```
Installing template from https://github.com/embark-framework/embark-bamboo-template/tree/4.0
Downloading template...
Download failed, response code 404
Retrying with the default branch...
It may not be compatible with your Embark version 4.0.0-alpha.2
Installing template from https://github.com/embark-framework/embark-bamboo-template
Downloading template...
Installing packages...
Init complete

App ready at 1-normal-template-bamboo
```
| Test case        | Command           | Successful?  | Output |
| :----------------------------------------- | :--------------------------------------------------------- | :---: | :-------- |
| 2. Github repo download  	 			| `embark new 2-github-repo --template status-im/dreddit-devcon`      |   Yes  |see below|
```
Installing template from https://github.com/status-im/dreddit-devcon
Downloading template...
Installing packages...
Init complete

App ready at 2-github-repo
```
| Test case        | Command           | Successful?  | Output |
| :----------------------------------------- | :--------------------------------------------------------- | :---: | :-------- |
| 3a. Github template with non-existant branch  	| `embark new 3-github-branch --template status-im/dreddit-devcon#start-here`      |  Yes   |
```
Installing template from https://github.com/status-im/dreddit-devcon/tree/start-here
Downloading template...
Download failed, response code 404
Does the template really exist?
```
| Test case        | Command           | Successful?  | Output |
| :----------------------------------------- | :--------------------------------------------------------- | :---: | :-------- |
| 3b. Github template with other branch  	| `embark new 3-github-branch --template status-im/dreddit-devcon#start`      |  Yes  |see below|
```
Installing template from https://github.com/status-im/dreddit-devcon/tree/start
Downloading template...
Installing packages...
Init complete

App ready at 3-github-branch
```
| Test case        | Command           | Successful?  | Output |
| :----------------------------------------- | :--------------------------------------------------------- | :---: | :-------- |
| 4. Github download with git url  		| `embark new 4-github-git-url --template git@github.com/status-im/dreddit-devcon`      |  No  |see below|
```
Unsupported template name or git host URL
```
**Failure reason:** Incorrect syntax. Repo owner need to postfix the host, ie `git@github.com:status-im/dreddit-devcon`. Fixed in this PR.

| Test case        | Command           | Successful?  | Output |
| :----------------------------------------- | :--------------------------------------------------------- | :---: | :-------- |
| 5. Github download with https url  		| `embark new 5-github-https-url --template https://github.com/status-im/dappcon-workshop-dapp` |  Yes  |see below|
```
Installing template from https://github.com/status-im/dappcon-workshop-dapp
Downloading template...
Installing packages...
Init complete

App ready at 5-github-https-url
```
| Test case        | Command           | Successful?  | Output |
| :----------------------------------------- | :--------------------------------------------------------- | :---: | :-------- |
| 6. Github download with no protocol  	| `embark new 6-github-url-no-protocol --template github.com/status-im/dappcon-workshop-dapp` |  No  |see below|
```
Unsupported template name or git host URL
```
**Failure reason:** Incorrect syntax. Can remove the github host, ie `status-im/dappcon-workshop-dapp`. Fixed in this PR.

| Test case        | Command           | Successful?  | Output |
| :----------------------------------------- | :--------------------------------------------------------- | :---: | :-------- |
| 7. Github repo with no branch, and a default branch that is not `master` | `embark new 7-github-default-branch-not-master --template status-im/dreddit-devcon`      |  Yes  |see below|
```
Installing template from https://github.com/status-im/dreddit-devcon
Downloading template...
Installing packages...
Init complete

App ready at 7-github-default-branch-not-master
```