### PR TITLE
Fix crash on using whisper with the simualtor

### DIFF
--- a/src/lib/modules/whisper/index.js
+++ b/src/lib/modules/whisper/index.js
@@ -30,12 +30,21 @@ class Whisper {
     this.connectToProvider();
 
     this.events.request('processes:register', 'whisper', (cb) => {
-      this.setServiceCheck();
-      this.addWhisperToEmbarkJS();
-      this.addSetProvider();
-      this.waitForWeb3Ready(() => {
-        this.registerAPICalls();
-        cb();
+      this.web3.shh.getInfo((err) => {
+        if (err) {
+          const message = err.message || err;
+          if (message.indexOf('not supported') > -1) {
+            this.logger.error('Whisper is not supported on your node. Are you using the simulator?');
+            return this.logger.trace(message);
+          }
+        }
+        this.setServiceCheck();
+        this.addWhisperToEmbarkJS();
+        this.addSetProvider();
+        this.waitForWeb3Ready(() => {
+          this.registerAPICalls();
+          cb();
+        });
       });
     });
 


### PR DESCRIPTION
Was caused because in embarkjs.js, there is a `throw` when the provider doesn't work, which it doesn't with the simulator (ganache-cli doesn't support whisper).

Instead of removing the throw, I instead detect if Whisper is supported and if nt, I stop trying to make it work.