### PR TITLE
fix(parity): create password file even when there are no accounts

### DIFF
--- a/src/lib/modules/blockchain_process/parityClient.js
+++ b/src/lib/modules/blockchain_process/parityClient.js
@@ -257,9 +257,6 @@ class ParityClient {
         });
       },
       function updatePasswordFile(passwordList, next) {
-        if (!self.config.account.password) {
-          return next();
-        }
         fs.writeFile(self.config.account.devPassword, passwordList, next);
       }
     ], (err) => {


### PR DESCRIPTION
Caused issues when starting Parity with no accounts in the config (so the basic template)