### PR TITLE
Better console command API

### DIFF
--- a/src/cmd/dashboard/repl.js
+++ b/src/cmd/dashboard/repl.js
@@ -1,6 +1,5 @@
 const repl = require("repl");
 const util = require("util");
-let fs = require('../../lib/core/fs');
 
 class REPL {
   constructor(options) {
@@ -21,17 +20,15 @@ class REPL {
     if ((typeof output) === "string") {
       if (this.logText) this.logText.log(output);
       return output;
-    } else {
-      const inspectedOutput = util.inspect(output, {colors: true});
-      if (this.logText) this.logText.log(inspectedOutput);
-      return inspectedOutput;
     }
-    return util.inspect(output, {colors: true});
+    const inspectedOutput = util.inspect(output, {colors: true});
+    if (this.logText) this.logText.log(inspectedOutput);
+    return inspectedOutput;
   }
 
   start(done) {
     this.replServer = repl.start({
-      prompt: "Embark (" + this.env + ") > ",
+      prompt: "Embark (".cyan + this.env.green + ") > ".cyan,
       useGlobal: true,
       eval: this.enhancedEval.bind(this),
       writer: this.enhancedWriter.bind(this),

--- a/src/lib/core/plugin.js
+++ b/src/lib/core/plugin.js
@@ -162,8 +162,8 @@ Plugin.prototype.addContractFile = function(file) {
 
 Plugin.prototype.registerConsoleCommand = function(optionsOrCb) {
   if (typeof optionsOrCb === 'function') {
-    this.logger.warn(__('Registering console commands with a function is deprecated'));
-    // TODO add docs on how to register
+    this.logger.warn(__('Registering console commands with function syntax is deprecated and will likely be removed in future versions of Embark.'));
+    // TODO add docs on how to register when they are written
   }
   this.console.push(optionsOrCb);
   this.addPluginType('console');

--- a/src/lib/core/plugin.js
+++ b/src/lib/core/plugin.js
@@ -163,7 +163,6 @@ Plugin.prototype.addContractFile = function(file) {
 Plugin.prototype.registerConsoleCommand = function(optionsOrCb) {
   if (typeof optionsOrCb === 'function') {
     this.logger.warn(__('Registering console commands with function syntax is deprecated and will likely be removed in future versions of Embark.'));
-    // TODO add docs on how to register when they are written
   }
   this.console.push(optionsOrCb);
   this.addPluginType('console');

--- a/src/lib/core/plugin.js
+++ b/src/lib/core/plugin.js
@@ -160,12 +160,12 @@ Plugin.prototype.addContractFile = function(file) {
   this.addPluginType('contractFiles');
 };
 
-Plugin.prototype.registerConsoleCommand = function(options, cb) {
-  if (typeof options === 'function') {
-    cb = options;
-    options = {};
+Plugin.prototype.registerConsoleCommand = function(optionsOrCb) {
+  if (typeof optionsOrCb === 'function') {
+    this.logger.warn(__('Registering console commands with a function is deprecated'));
+    // TODO add docs on how to register
   }
-  this.console.push({options, execute: cb});
+  this.console.push(optionsOrCb);
   this.addPluginType('console');
 };
 

--- a/src/lib/core/plugin.js
+++ b/src/lib/core/plugin.js
@@ -160,8 +160,12 @@ Plugin.prototype.addContractFile = function(file) {
   this.addPluginType('contractFiles');
 };
 
-Plugin.prototype.registerConsoleCommand = function(cb) {
-  this.console.push(cb);
+Plugin.prototype.registerConsoleCommand = function(options, cb) {
+  if (typeof options === 'function') {
+    cb = options;
+    options = {};
+  }
+  this.console.push({options, execute: cb});
   this.addPluginType('console');
 };
 

--- a/src/lib/core/plugin.js
+++ b/src/lib/core/plugin.js
@@ -162,7 +162,8 @@ Plugin.prototype.addContractFile = function(file) {
 
 Plugin.prototype.registerConsoleCommand = function(optionsOrCb) {
   if (typeof optionsOrCb === 'function') {
-    this.logger.warn(__('Registering console commands with function syntax is deprecated and will likely be removed in future versions of Embark.'));
+    this.logger.warn(__('Registering console commands with function syntax is deprecated and will likely be removed in future versions of Embark'));
+    this.logger.info(__('You can find the new API documentation here: %s', 'https://embark.status.im/docs/plugin_reference.html#registerConsoleCommand-options'.underline));
   }
   this.console.push(optionsOrCb);
   this.addPluginType('console');

--- a/src/lib/modules/console/index.ts
+++ b/src/lib/modules/console/index.ts
@@ -13,7 +13,7 @@ type MatchFunction = (cmd: string) => boolean;
 interface HelpDescription {
   matches: string[] | MatchFunction;
   description: string;
-  use?: string;
+  usage?: string;
 }
 
 class Console {
@@ -107,7 +107,7 @@ class Console {
         if (typeof helpDescription.matches === "object") {
           matches = helpDescription.matches as string[];
         }
-        helpText.push(`${(helpDescription.use || matches.join("/")).cyan} - ${helpDescription.description}`);
+        helpText.push(`${(helpDescription.usage || matches.join("/")).cyan} - ${helpDescription.description}`);
       });
       // Add end commands
       helpText.push("quit".cyan + " - " + __("to immediatly exit (alias: exit)"),
@@ -128,12 +128,11 @@ class Console {
     const plugins = this.plugins.getPluginsProperty("console", "console");
     const helpDescriptions = [];
     for (const plugin of plugins) {
-      // New API
       if (plugin.description) {
         helpDescriptions.push({
           description: plugin.description,
           matches: plugin.matches,
-          use: plugin.use,
+          usage: plugin.usage,
         });
       }
       if (plugin.matches) {
@@ -225,7 +224,7 @@ class Console {
         const [_cmdName, length] = cmd.split(" ");
         this.getHistory(length, callback);
       },
-      use: "history <optionalLength>",
+      usage: "history <optionalLength>",
     });
   }
 

--- a/src/lib/modules/console/index.ts
+++ b/src/lib/modules/console/index.ts
@@ -104,7 +104,7 @@ class Console {
       ];
       helpDescriptions.forEach((helpDescription) => {
         let matches = [] as string[];
-        if (typeof helpDescription.matches === "object") {
+        if (Array.isArray(helpDescription.matches)) {
           matches = helpDescription.matches as string[];
         }
         helpText.push(`${(helpDescription.usage || matches.join("/")).cyan} - ${helpDescription.description}`);
@@ -219,7 +219,10 @@ class Console {
   private registerConsoleCommands() {
     this.embark.registerConsoleCommand({
       description: __("display console commands history"),
-      matches: ["history"],
+      matches: (cmd: string) => {
+        const [cmdName] = cmd.split(" ");
+        return cmdName === "history";
+      },
       process: (cmd: string, callback: any) => {
         const [_cmdName, length] = cmd.split(" ");
         this.getHistory(length, callback);

--- a/src/lib/modules/console/index.ts
+++ b/src/lib/modules/console/index.ts
@@ -216,10 +216,11 @@ class Console {
     this.embark.registerConsoleCommand({
       description: __("display console commands history"),
       matches: ["history"],
+      process: (cmd: string, callback: any) => {
+        const [_cmdName, length] = cmd.split(" ");
+        this.getHistory(length, callback);
+      },
       use: "history <optionalLength>",
-    }, (cmd: string, callback: any) => {
-      const [_cmdName, length] = cmd.split(" ");
-      this.getHistory(length, callback);
     });
   }
 

--- a/src/lib/modules/console/index.ts
+++ b/src/lib/modules/console/index.ts
@@ -78,8 +78,6 @@ class Console {
         __("Welcome to Embark") + " " + this.version,
         "",
         __("possible commands are:"),
-        "versions - " + __("display versions in use for libraries and tools like web3 and solc"),
-        "history - " + __("display console commands history"),
         // TODO: only if the blockchain is actually active!
         // will need to pass te current embark state here
         "ipfs - " + __("instantiated js-ipfs object configured to the current environment (available if ipfs is enabled)"),
@@ -205,12 +203,13 @@ class Console {
   }
 
   private registerConsoleCommands() {
-    this.embark.registerConsoleCommand((cmd: string, options?: any) => {
-      const [cmdName, length] = cmd.split(" ");
-      return {
-        match: () => cmdName === "history",
-        process: (callback: any) => this.getHistory(length, callback),
-      };
+    this.embark.registerConsoleCommand({
+      description: __("display console commands history"),
+      matches: ["history"],
+      use: "history <optionalLength>",
+    }, (cmd: string, callback: any) => {
+      const [_cmdName, length] = cmd.split(" ");
+      this.getHistory(length, callback);
     });
   }
 

--- a/src/lib/modules/console/index.ts
+++ b/src/lib/modules/console/index.ts
@@ -9,8 +9,9 @@ import Web3 from "web3";
 import { Embark, Events } from "../../../typings/embark";
 import Suggestions from "./suggestions";
 
+type MatchFunction = (cmd: string) => boolean;
 interface HelpDescription {
-  matches: string[] | any; // (cmd: string): boolean;
+  matches: string[] | MatchFunction;
   description: string;
   use?: string;
 }
@@ -102,7 +103,11 @@ class Console {
         "plugin install <package> - " + __("Installs a plugin in the Dapp. eg: plugin install embark-solc"),
       ];
       helpDescriptions.forEach((helpDescription) => {
-        helpText.push(`${(helpDescription.use || helpDescription.matches.join("/")).cyan} - ${helpDescription.description}`);
+        let matches = [] as string[];
+        if (typeof helpDescription.matches === "object") {
+          matches = helpDescription.matches as string[];
+        }
+        helpText.push(`${(helpDescription.use || matches.join("/")).cyan} - ${helpDescription.description}`);
       });
       // Add end commands
       helpText.push("quit".cyan + " - " + __("to immediatly exit (alias: exit)"),

--- a/src/lib/modules/console/index.ts
+++ b/src/lib/modules/console/index.ts
@@ -9,6 +9,12 @@ import Web3 from "web3";
 import { Embark, Events } from "../../../typings/embark";
 import Suggestions from "./suggestions";
 
+interface HelpDescription {
+  matches: string[] | any; // (cmd: string): boolean;
+  description: string;
+  use?: string;
+}
+
 class Console {
   private embark: Embark;
   private events: Events;
@@ -72,7 +78,7 @@ class Console {
     });
   }
 
-  private processEmbarkCmd(cmd: string, helpDescriptions: any[]) {
+  private processEmbarkCmd(cmd: string, helpDescriptions: HelpDescription[]) {
     if (cmd === "help" || cmd === __("help") || cmd === "01189998819991197253") {
       const helpText = [
         __("Welcome to Embark") + " " + this.version,
@@ -118,19 +124,23 @@ class Console {
     const helpDescriptions = [];
     for (const plugin of plugins) {
       // New API
-      if (plugin.options.description) {
-        helpDescriptions.push(plugin.options);
+      if (plugin.description) {
+        helpDescriptions.push({
+          description: plugin.description,
+          matches: plugin.matches,
+          use: plugin.use,
+        });
       }
-      if (plugin.options.matches) {
-        const isFunction = typeof plugin.options.matches === "function";
-        if ((isFunction && plugin.options.matches.call(this, cmd))
-          || (!isFunction && plugin.options.matches.includes(cmd))) {
-          return plugin.execute.call(this, cmd, callback);
+      if (plugin.matches) {
+        const isFunction = typeof plugin.matches === "function";
+        if ((isFunction && plugin.matches.call(this, cmd))
+          || (!isFunction && plugin.matches.includes(cmd))) {
+          return plugin.process.call(this, cmd, callback);
         }
         continue;
       }
 
-      const pluginResult = plugin.execute.call(this, cmd, {});
+      const pluginResult = plugin.call(this, cmd, {});
 
       if (typeof pluginResult !== "object") {
         if (pluginResult !== false && pluginResult !== "false" && pluginResult !== undefined) {

--- a/src/lib/modules/ens/index.js
+++ b/src/lib/modules/ens/index.js
@@ -89,28 +89,41 @@ class ENS {
   }
 
   registerConsoleCommands() {
-    this.embark.registerConsoleCommand((cmd, _options) => {
-      let [cmdName, domain] = cmd.split(' ');
-      return {
-        match: () => cmdName === 'resolve',
-        process: (cb) => global.EmbarkJS.Names.resolve(domain, cb)
-      };
+    this.embark.registerConsoleCommand({
+      use: 'resolve <name>',
+      description: __('Resolves an ENS name'),
+      matches: (cmd) => {
+        let [cmdName] = cmd.split(' ');
+        return cmdName === 'resolve';
+      }
+    }, (cmd, cb) => {
+      let [_cmdName, domain] = cmd.split(' ');
+      global.EmbarkJS.Names.resolve(domain, cb);
     });
 
-    this.embark.registerConsoleCommand((cmd, _options) => {
-      let [cmdName, address] = cmd.split(' ');
-      return {
-        match: () => cmdName === 'lookup',
-        process: (cb) => global.EmbarkJS.Names.lookup(address, cb)
-      };
+    this.embark.registerConsoleCommand({
+      use: 'lookup <address>',
+      description: __('Lookup an ENS address'),
+      matches: (cmd) => {
+        let [cmdName] = cmd.split(' ');
+        return cmdName === 'lookup';
+      }
+    }, (cmd, cb) => {
+      let [_cmdName, address] = cmd.split(' ');
+        global.EmbarkJS.Names.lookup(address, cb);
     });
 
-    this.embark.registerConsoleCommand((cmd, _options) => {
-      let [cmdName, name, address] = cmd.split(' ');
-      return {
-        match: () => cmdName === 'registerSubDomain',
-        process: (cb) => global.EmbarkJS.Names.registerSubDomain(name, address, cb)
-      };
+
+    this.embark.registerConsoleCommand({
+      use: 'registerSubDomain <subDomain>',
+      description: __('Register an ENS sub-domain'),
+      matches: (cmd) => {
+        let [cmdName] = cmd.split(' ');
+        return cmdName === 'registerSubDomain';
+      }
+    }, (cmd, cb) => {
+      let [_cmdName, name, address] = cmd.split(' ');
+      global.EmbarkJS.Names.registerSubDomain(name, address, cb);
     });
   }
 

--- a/src/lib/modules/ens/index.js
+++ b/src/lib/modules/ens/index.js
@@ -90,7 +90,7 @@ class ENS {
 
   registerConsoleCommands() {
     this.embark.registerConsoleCommand({
-      use: 'resolve <name>',
+      usage: 'resolve <name>',
       description: __('Resolves an ENS name'),
       matches: (cmd) => {
         let [cmdName] = cmd.split(' ');
@@ -103,7 +103,7 @@ class ENS {
     });
 
     this.embark.registerConsoleCommand({
-      use: 'lookup <address>',
+      usage: 'lookup <address>',
       description: __('Lookup an ENS address'),
       matches: (cmd) => {
         let [cmdName] = cmd.split(' ');
@@ -117,7 +117,7 @@ class ENS {
 
 
     this.embark.registerConsoleCommand({
-      use: 'registerSubDomain <subDomain>',
+      usage: 'registerSubDomain <subDomain>',
       description: __('Register an ENS sub-domain'),
       matches: (cmd) => {
         let [cmdName] = cmd.split(' ');

--- a/src/lib/modules/ens/index.js
+++ b/src/lib/modules/ens/index.js
@@ -95,10 +95,11 @@ class ENS {
       matches: (cmd) => {
         let [cmdName] = cmd.split(' ');
         return cmdName === 'resolve';
-      }
-    }, (cmd, cb) => {
+      },
+      process: (cmd, cb) => {
       let [_cmdName, domain] = cmd.split(' ');
       global.EmbarkJS.Names.resolve(domain, cb);
+    }
     });
 
     this.embark.registerConsoleCommand({
@@ -107,10 +108,11 @@ class ENS {
       matches: (cmd) => {
         let [cmdName] = cmd.split(' ');
         return cmdName === 'lookup';
-      }
-    }, (cmd, cb) => {
-      let [_cmdName, address] = cmd.split(' ');
+      },
+      process: (cmd, cb) => {
+        let [_cmdName, address] = cmd.split(' ');
         global.EmbarkJS.Names.lookup(address, cb);
+      }
     });
 
 
@@ -120,10 +122,11 @@ class ENS {
       matches: (cmd) => {
         let [cmdName] = cmd.split(' ');
         return cmdName === 'registerSubDomain';
+      },
+      process: (cmd, cb) => {
+        let [_cmdName, name, address] = cmd.split(' ');
+        global.EmbarkJS.Names.registerSubDomain(name, address, cb);
       }
-    }, (cmd, cb) => {
-      let [_cmdName, name, address] = cmd.split(' ');
-      global.EmbarkJS.Names.registerSubDomain(name, address, cb);
     });
   }
 

--- a/src/lib/modules/library_manager/index.js
+++ b/src/lib/modules/library_manager/index.js
@@ -39,17 +39,19 @@ class LibraryManager {
 
   registerCommands() {
     const self = this;
-    this.embark.registerConsoleCommand((cmd, _options) => {
-      return {
-        match: () => cmd === "versions" || cmd === __('versions'),
-        process: (callback) => {
-          let text = [__('versions in use') + ':'];
-          for (let lib in self.versions) {
-            text.push(lib + ": " + self.versions[lib]);
-          }
-          callback(null, text.join('\n'));
-        }
-      };
+    const matches = ['versions'];
+    if (__('versions') !== matches[0]) {
+      matches.push(__('versions'));
+    }
+    this.embark.registerConsoleCommand({
+      matches,
+      description: __("display versions in use for libraries and tools like web3 and solc")
+    }, (cmd, callback) => {
+      let text = [__('versions in use') + ':'];
+      for (let lib in self.versions) {
+        text.push(lib + ": " + self.versions[lib]);
+      }
+      callback(null, text.join('\n'));
     });
   }
 

--- a/src/lib/modules/library_manager/index.js
+++ b/src/lib/modules/library_manager/index.js
@@ -45,13 +45,14 @@ class LibraryManager {
     }
     this.embark.registerConsoleCommand({
       matches,
-      description: __("display versions in use for libraries and tools like web3 and solc")
-    }, (cmd, callback) => {
-      let text = [__('versions in use') + ':'];
-      for (let lib in self.versions) {
-        text.push(lib + ": " + self.versions[lib]);
+      description: __("display versions in use for libraries and tools like web3 and solc"),
+      process: (cmd, callback) => {
+        let text = [__('versions in use') + ':'];
+        for (let lib in self.versions) {
+          text.push(lib + ": " + self.versions[lib]);
+        }
+        callback(null, text.join('\n'));
       }
-      callback(null, text.join('\n'));
     });
   }
 


### PR DESCRIPTION
Created a new API that sits on top of the current API for console command registration. This is NOT a breaking change.

It enables us to register the matches and the description inside the module so that the help command doesn't have to manualy list all the descriptions, but instead only reads them from the module.

This is what the API looks like:
```
this.embark.registerConsoleCommand({
      description: "description for the help command",
      matches: ["this", "that"],
// OR a function for more complex cases
      matches: function (cmd) {
          return cmd === 'this'; 
      },
      use: "that <option>" // Optional: This is the name of the command in the help. If not there, it will use `matches`
    }, (cmd: string, callback: any) => {
      this.doSomething(callback);
    });
``` 

What help looks like:
![image](https://user-images.githubusercontent.com/11926403/49952400-e180db00-fec9-11e8-9313-8b67871f50a2.png)

As you can see, I didn't put all of the commands in blue, because it's an automatic process and it will encourage us to convert more console registers to the new API.

An improvement that's possible with this new way is to add an `ordering` option that would tell the order in the help command. Basically, we have way more flexibility with an option object now.