### PR TITLE
fix(@embark/core): Show transaction log for errors

### DIFF
--- a/embark-ui/src/components/ContractTransactions.js
+++ b/embark-ui/src/components/ContractTransactions.js
@@ -1,10 +1,12 @@
+import {TX_STATUS_CODES} from "../constants";
 import PropTypes from "prop-types";
 import React from 'react';
 import {Row, Col, Table, FormGroup, Label, Input, Form} from 'reactstrap';
+import * as classNames from 'classnames';
 
 import DebugButton from './DebugButton'
 
-const TX_STATES = {Success: '0x1', Fail: '0x0', Any: ''};
+const TX_STATES = {Success: TX_STATUS_CODES.success, Fail: TX_STATUS_CODES.failure, Any: ''};
 const EVENT = 'event';
 const FUNCTION = 'function';
 const CONSTRUCTOR = 'constructor';
@@ -115,21 +117,24 @@ class ContractTransactions extends React.Component {
                   <th>Gas Used</th>
                   <th>Block number</th>
                   <th>Status</th>
-                  <th>Transaction hash</th>
+                  <th>Result</th>
                 </tr>
               </thead>
               <tbody>
                 {
                   this.dataToDisplay().map((log, index) => {
+                    const rowClass = classNames({'bg-danger': log.error});
+                    const cellClass = classNames({'text-light': log.error});
                     return (
-                      <tr key={'log-' + index}>
-                        <td><DebugButton forceDebuggable transaction={{hash: log.transactionHash}}/></td>
-                        <td>{`${log.name}.${log.functionName}(${log.paramString})`}</td>
-                        <td>{log.events.join(', ')}</td>
-                        <td>{log.gasUsed}</td>
-                        <td>{log.blockNumber}</td>
-                        <td>{log.status}</td>
-                        <td>{log.transactionHash}</td>
+                      <tr key={'log-' + index} className={rowClass}>
+                        <td className={cellClass}><DebugButton forceDebuggable transaction={{hash: log.transactionHash}}/></td>
+                        <td className={cellClass}>{`${log.name}.${log.functionName}(${log.paramString})`}</td>
+                        <td className={cellClass}>{log.events.join(', ')}</td>
+                        <td className={cellClass}>{log.gasUsed}</td>
+                        <td className={cellClass}>{log.blockNumber}</td>
+                        <td className={cellClass}>{log.status}</td>
+                        {log.transactionHash && <td className={cellClass}>{log.transactionHash}</td>}
+                        {log.error && <td className={cellClass}>{log.error}</td>}
                       </tr>
                     );
                   })

--- a/embark-ui/src/components/DebugButton.js
+++ b/embark-ui/src/components/DebugButton.js
@@ -12,8 +12,9 @@ class DebugButton extends React.Component {
   }
 
   isDebuggable() {
-    return this.props.forceDebuggable ||
-      (this.props.contracts && this.props.contracts.find(contract => contract.address === this.props.transaction.to));
+    return this.props.transaction.hash && 
+      (this.props.forceDebuggable ||
+      (this.props.contracts && this.props.contracts.find(contract => contract.address === this.props.transaction.to)));
   }
 
   render() {

--- a/embark-ui/src/constants.js
+++ b/embark-ui/src/constants.js
@@ -12,3 +12,8 @@ export const OPERATIONS = {
   MORE: 1,
   LESS: -1
 };
+export const TX_STATUS_CODES = {
+  "success": "0x1",
+  "failure": "0x0",
+  "unknown": "0x01"
+}

--- a/src/lib/constants.json
+++ b/src/lib/constants.json
@@ -53,6 +53,11 @@
       "eth_sendTransaction": "eth_sendTransaction",
       "eth_sendRawTransaction": "eth_sendRawTransaction",
       "eth_getTransactionReceipt": "eth_getTransactionReceipt"
+    },
+    "statusCodes": {
+      "success": "0x1",
+      "failure": "0x0",
+      "unknown": "0x01"
     }
   },
   "storage": {

--- a/src/lib/modules/ens/index.js
+++ b/src/lib/modules/ens/index.js
@@ -6,7 +6,7 @@ const embarkJsUtils = require('embarkjs').Utils;
 const reverseAddrSuffix = '.addr.reverse';
 const ENSFunctions = require('./ENSFunctions');
 import {ZERO_ADDRESS} from '../../utils/addressUtils';
-import {ens} from '../../constants';
+import {ens, blockchain} from '../../constants';
 
 const ENS_WHITELIST = ens.whitelist;
 const NOT_REGISTERED_ERROR = 'Name not yet registered';
@@ -224,7 +224,7 @@ class ENS {
       },
       function setContent(resolver, defaultAccount, next) {
         resolver.methods.setContent(hashedName, contentHash).send({from: defaultAccount}).then((transaction) => {
-          if (transaction.status !== "0x1" && transaction.status !== "0x01" && transaction.status !== true) {
+          if (transaction.status !== blockchain.statusCodes.success && transaction.status !== blockchain.statusCodes.unknown && transaction.status !== true) {
             return next('Association failed. Status: ' + transaction.status);
           }
           next();

--- a/src/lib/modules/ens/register.js
+++ b/src/lib/modules/ens/register.js
@@ -1,5 +1,6 @@
 /*global web3*/
 const namehash = require('eth-ens-namehash');
+const constants = require('../../constants');
 // Price of ENS registration contract functions
 const ENS_GAS_PRICE = 700000;
 
@@ -15,7 +16,7 @@ function registerSubDomain(ens, registrar, resolver, defaultAccount, subdomain, 
   secureSend(web3, toSend, {from: defaultAccount, gas: ENS_GAS_PRICE}, false)
     // Set resolver for the node
     .then(transac => {
-      if (transac.status !== "0x1" && transac.status !== "0x01" && transac.status !== true) {
+      if (transaction.status !== constants.blockchain.statusCodes.success && transaction.status !== constants.blockchain.statusCodes.unknown  && transac.status !== true) {
         logger.warn('Failed transaction', transac);
         return callback('Failed to register. Check gas cost.');
       }

--- a/src/typings/json.d.ts
+++ b/src/typings/json.d.ts
@@ -1,0 +1,4 @@
+declare module "*.json" {
+  const value: any;
+  export default value;
+}


### PR DESCRIPTION
When a transaction errors in the cockpit, show the error in the transaction log.

This does not catch errors in web3 that do not make it server-side (ie when executing a tx from the console or from the browser).

Add unit test for contract error logs in the `ContractManager`

![tx errors in cockpit](https://i.imgur.com/hGU1Fpy.png)