### PR TITLE
fix(@embark/whisper): ensure web3 is ready when whisper info is requested

### DIFF
--- a/src/lib/modules/whisper/index.js
+++ b/src/lib/modules/whisper/index.js
@@ -30,18 +30,18 @@ class Whisper {
     this.connectToProvider();
 
     this.events.request('processes:register', 'whisper', (cb) => {
-      this.web3.shh.getInfo((err) => {
-        if (err) {
-          const message = err.message || err;
-          if (message.indexOf('not supported') > -1) {
-            this.logger.error('Whisper is not supported on your node. Are you using the simulator?');
-            return this.logger.trace(message);
+      this.waitForWeb3Ready(() => {
+        this.web3.shh.getInfo((err) => {
+          if (err) {
+            const message = err.message || err;
+            if (message.indexOf('not supported') > -1) {
+              this.logger.error('Whisper is not supported on your node. Are you using the simulator?');
+              return this.logger.trace(message);
+            }
           }
-        }
-        this.setServiceCheck();
-        this.addWhisperToEmbarkJS();
-        this.addSetProvider();
-        this.waitForWeb3Ready(() => {
+          this.setServiceCheck();
+          this.addWhisperToEmbarkJS();
+          this.addSetProvider();
           this.registerAPICalls();
           cb();
         });


### PR DESCRIPTION

In https://github.com/embark-framework/embark/commit/1461e95c39d0ec4b7b5b0d08f51b2d2cb5110349 we've introduced a guard that ensures whisper isn't crashing
when Embark is used with the Simulator. This unfortunately also introduced
code that tries to connect to an existing websocket provider that isn't actually
ready at the time it tries to connect.

This commit ensures `web3.shh.getInfo()` is only called once `web3` is ready
and therefore the WS connection as well.