### PR TITLE
refactor(@embark/blockchain_process): remove http-proxy-middleware

### DIFF
--- a/package.json
+++ b/package.json
@@ -118,7 +118,7 @@
     "hard-source-webpack-plugin": "0.12.0",
     "helmet": "3.13.0",
     "hosted-git-info": "2.7.1",
-    "http-proxy-middleware": "0.19.0",
+    "http-proxy": "1.17.0",
     "http-shutdown": "1.2.0",
     "i18n": "0.8.3",
     "ipfs-api": "17.2.4",

--- a/package.json
+++ b/package.json
@@ -131,6 +131,7 @@
     "multihashes": "0.4.14",
     "neo-blessed": "0.2.0",
     "netcat": "1.3.5",
+    "node-http-proxy-json": "0.1.6",
     "node-ipc": "9.1.1",
     "node-sass": "4.9.3",
     "npmlog": "4.1.2",

--- a/src/lib/modules/blockchain_process/blockchain.js
+++ b/src/lib/modules/blockchain_process/blockchain.js
@@ -147,14 +147,17 @@ Blockchain.prototype.initProxy = function () {
 };
 
 Blockchain.prototype.setupProxy = async function () {
+  const AccountParser = require('../../utils/accountParser');
   if (!this.proxyIpc) this.proxyIpc = new Ipc({ipcRole: 'client'});
+
+  const addresses = AccountParser.parseAccountsConfig(this.userConfig.accounts, false, this.logger);
 
   let wsProxy;
   if (this.config.wsRPC) {
-    wsProxy = proxy.serve(this.proxyIpc, this.config.wsHost, this.config.wsPort, true, this.config.wsOrigins, this.certOptions);
+    wsProxy = proxy.serve(this.proxyIpc, this.config.wsHost, this.config.wsPort, true, this.config.wsOrigins, addresses, this.certOptions);
   }
 
-  [this.rpcProxy, this.wsProxy] = await Promise.all([proxy.serve(this.proxyIpc, this.config.rpcHost, this.config.rpcPort, false, undefined, this.certOptions), wsProxy]);
+  [this.rpcProxy, this.wsProxy] = await Promise.all([proxy.serve(this.proxyIpc, this.config.rpcHost, this.config.rpcPort, false, null, addresses, this.certOptions), wsProxy]);
 };
 
 Blockchain.prototype.shutdownProxy = function () {

--- a/src/lib/modules/blockchain_process/httpProxyOverride.js
+++ b/src/lib/modules/blockchain_process/httpProxyOverride.js
@@ -1,0 +1,123 @@
+/* global require */
+
+const http = require('http');
+const https = require('https');
+const httpProxyWsIncoming = require('http-proxy/lib/http-proxy/passes/ws-incoming');
+const common = require('http-proxy/lib/http-proxy/common');
+
+const CRLF = '\r\n';
+
+httpProxyWsIncoming.stream = (req, socket, options, head, server, cb) => {
+  const createHttpHeader = function(line, headers) {
+    return Object.keys(headers).reduce(function (head, key) {
+      const value = headers[key];
+      if (!Array.isArray(value)) {
+        head.push(`${key}: ${value}`);
+        return head;
+      }
+      for (let i = 0; i < value.length; i++) {
+        head.push(`${key}: ${value[i]}`);
+      }
+      return head;
+    }, [line])
+      .join(CRLF) + `${CRLF}${CRLF}`;
+  };
+
+  common.setupSocket(socket);
+
+  if (head && head.length) socket.unshift(head);
+
+  const protocol = common.isSSL.test(options.target.protocol) ? https : http;
+
+  const proxyReq = protocol.request(
+    common.setupOutgoing(options.ssl || {}, options, req)
+  );
+
+  // Enable developers to modify the proxyReq before headers are sent
+  if (server) {
+    server.emit('proxyReqWs', proxyReq, req, socket, options, head);
+  }
+
+  // Error Handler
+  proxyReq.on('error', onOutgoingError);
+  proxyReq.on('response', function (res) {
+    // if upgrade event isn't going to happen, close the socket
+    if (!res.upgrade) {
+      const {httpVersion, statusCode, statusMessage, headers} = res;
+      socket.write(createHttpHeader(
+        `HTTP/${httpVersion} ${statusCode} ${statusMessage}`,
+        headers
+      ));
+      res.pipe(socket);
+    }
+  });
+
+  proxyReq.on('upgrade', function(proxyRes, proxySocket, proxyHead) {
+    proxySocket.on('error', onOutgoingError);
+
+    // Allow us to listen when the websocket has completed
+    proxySocket.on('end', function () {
+      server.emit('close', proxyRes, proxySocket, proxyHead);
+    });
+
+    // The pipe below will end proxySocket if socket closes cleanly, but not
+    // if it errors (eg, vanishes from the net and starts returning
+    // EHOSTUNREACH). We need to do that explicitly.
+    socket.on('error', function () {
+      proxySocket.end();
+    });
+
+    common.setupSocket(proxySocket);
+
+    if (proxyHead && proxyHead.length) proxySocket.unshift(proxyHead);
+
+    // Remark: Handle writing the headers to the socket when switching protocols
+    // Also handles when a header is an array
+    socket.write(createHttpHeader(
+      'HTTP/1.1 101 Switching Protocols',
+      proxyRes.headers
+    ));
+
+    let proxyStream = proxySocket;
+
+    if (options.createWsServerTransformStream) {
+      const wsServerTransformStream = options.createWsServerTransformStream(
+        req,
+        proxyReq,
+        proxyRes,
+      );
+
+      wsServerTransformStream.on('error', onOutgoingError);
+      proxyStream = proxyStream.pipe(wsServerTransformStream);
+    }
+
+    proxyStream = proxyStream.pipe(socket);
+
+    if (options.createWsClientTransformStream) {
+      const wsClientTransformStream = options.createWsClientTransformStream(
+        req,
+        proxyReq,
+        proxyRes,
+      );
+
+      wsClientTransformStream.on('error', onOutgoingError);
+      proxyStream = proxyStream.pipe(wsClientTransformStream);
+    }
+
+    proxyStream.pipe(proxySocket);
+
+    server.emit('open', proxySocket);
+    server.emit('proxySocket', proxySocket);  //DEPRECATED.
+  });
+
+  return proxyReq.end(); // XXX: CHECK IF THIS IS THIS CORRECT
+
+  function onOutgoingError(err) {
+    if (cb) {
+      cb(err, req, socket);
+    } else {
+      server.emit('error', err, req, socket);
+    }
+    socket.end();
+  }
+};

--- a/src/lib/modules/blockchain_process/simulator.js
+++ b/src/lib/modules/blockchain_process/simulator.js
@@ -67,7 +67,7 @@ class Simulator {
   }
 
   runCommand(cmds, useProxy, host, port) {
-    const ganache_main = require.resolve('ganache-cli', {paths: fs.embarkPath('node_modules')});
+    const ganache_main = require.resolve('ganache-cli', {paths: [fs.embarkPath('node_modules')]});
     const ganache_json = pkgUp.sync(path.dirname(ganache_main));
     const ganache_root = path.dirname(ganache_json);
     const ganache_bin = require(ganache_json).bin;

--- a/src/lib/modules/code_generator/index.js
+++ b/src/lib/modules/code_generator/index.js
@@ -290,7 +290,7 @@ class CodeGenerator {
       function getWeb3Location(next) {
         self.events.request("version:get:web3", function(web3Version) {
           if (web3Version === "1.0.0-beta") {
-            return next(null, require.resolve("web3", {paths: fs.embarkPath("node_modules")}));
+            return next(null, require.resolve("web3", {paths: [fs.embarkPath("node_modules")]}));
           }
           self.events.request("version:getPackageLocation", "web3", web3Version, function(err, location) {
             return next(null, fs.dappPath(location));
@@ -356,7 +356,7 @@ class CodeGenerator {
       function getWeb3Location(next) {
         self.events.request("version:get:web3", function(web3Version) {
           if (web3Version === "1.0.0-beta") {
-            return next(null, require.resolve("web3", {paths: fs.embarkPath("node_modules")}));
+            return next(null, require.resolve("web3", {paths: [fs.embarkPath("node_modules")]}));
           }
           self.events.request("version:getPackageLocation", "web3", web3Version, function(err, location) {
             return next(null, fs.dappPath(location));

--- a/yarn.lock
+++ b/yarn.lock
@@ -1953,6 +1953,11 @@ buffer@^5.0.5:
     base64-js "^1.0.2"
     ieee754 "^1.1.4"
 
+bufferhelper@^0.2.1:
+  version "0.2.1"
+  resolved "https://registry.yarnpkg.com/bufferhelper/-/bufferhelper-0.2.1.tgz#fa74a385724a58e242f04ad6646c2366f83b913e"
+  integrity sha1-+nSjhXJKWOJC8ErWZGwjZvg7kT4=
+
 builtin-modules@^1.0.0, builtin-modules@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/builtin-modules/-/builtin-modules-1.1.1.tgz#270f076c5a72c02f5b65a47df94c5fe3a278892f"
@@ -2477,7 +2482,7 @@ concat-map@0.0.1:
   resolved "https://registry.yarnpkg.com/concat-map/-/concat-map-0.0.1.tgz#d8a96bd77fd68df7793a73036a3ba0d5405d477b"
   integrity sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=
 
-concat-stream@^1.4.10, concat-stream@^1.5.0, concat-stream@^1.6.0:
+concat-stream@^1.4.10, concat-stream@^1.5.0, concat-stream@^1.5.1, concat-stream@^1.6.0:
   version "1.6.2"
   resolved "https://registry.yarnpkg.com/concat-stream/-/concat-stream-1.6.2.tgz#904bdf194cd3122fc675c77fc4ac3d4ff0fd1a34"
   integrity sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==
@@ -6884,6 +6889,14 @@ node-gyp@^3.8.0:
     semver "~5.3.0"
     tar "^2.0.0"
     which "1"
+
+node-http-proxy-json@0.1.6:
+  version "0.1.6"
+  resolved "https://registry.yarnpkg.com/node-http-proxy-json/-/node-http-proxy-json-0.1.6.tgz#4b554befd04e607f3726092d67b60bf888906849"
+  integrity sha1-S1VL79BOYH83JgktZ7YL+IiQaEk=
+  dependencies:
+    bufferhelper "^0.2.1"
+    concat-stream "^1.5.1"
 
 node-ipc@9.1.1:
   version "9.1.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -4965,17 +4965,7 @@ http-https@^1.0.0:
   resolved "https://registry.yarnpkg.com/http-https/-/http-https-1.0.0.tgz#2f908dd5f1db4068c058cd6e6d4ce392c913389b"
   integrity sha1-L5CN1fHbQGjAWM1ubUzjkskTOJs=
 
-http-proxy-middleware@0.19.0:
-  version "0.19.0"
-  resolved "https://registry.yarnpkg.com/http-proxy-middleware/-/http-proxy-middleware-0.19.0.tgz#40992b5901dc44bc7bc3795da81b0b248eca02d8"
-  integrity sha512-Ab/zKDy2B0404mz83bgki0HHv/xqpYKAyFXhopAiJaVAUSJfLYrpBYynTl4ZSUJ7TqrAgjarTsxdX5yBb4unRQ==
-  dependencies:
-    http-proxy "^1.17.0"
-    is-glob "^4.0.0"
-    lodash "^4.17.10"
-    micromatch "^3.1.10"
-
-http-proxy@^1.17.0:
+http-proxy@1.17.0:
   version "1.17.0"
   resolved "https://registry.yarnpkg.com/http-proxy/-/http-proxy-1.17.0.tgz#7ad38494658f84605e2f6db4436df410f4e5be9a"
   integrity sha512-Taqn+3nNvYRfJ3bGvKfBSRwy1v6eePlm3oc/aWVxZp57DQr5Eq3xhKJi7Z4hZpS8PC3H4qI+Yly5EmFacGuA/g==


### PR DESCRIPTION
The problems described in embark PR #1166 can be resolved by implementing the blockchain proxy with `http-proxy` directly instead of using `express` together with `http-proxy-middleware`. The ultimate cause of the buggy behavior (the "stuck sockets" problems described in #1166) is unknown.

The need to swallow some errors as described in embark PR #1181 is also eliminated by dropping `http-proxy-middleware` and `express`.