### PR TITLE
Fix for error running anything on Windows with Git Bash

### DIFF
--- a/src/lib/modules/pipeline/webpack.config.js
+++ b/src/lib/modules/pipeline/webpack.config.js
@@ -2,7 +2,7 @@
 
 const path = require('path');
 
-const dappPath = process.env.DAPP_PATH;
+const dappPath = path.normalize(process.env.DAPP_PATH);
 const embarkPath = process.env.EMBARK_PATH;
 
 const dappNodeModules = path.join(dappPath, 'node_modules');


### PR DESCRIPTION
I had to eject the webpack config and add this to get any project at all to run on Windows/Git Bash without this error:

Invalid configuration object. Webpack has been initialised using a configuration object that does not match the API schema.                                                                                                                                                                              ││  - configuration.context: The provided value "C:/Users/xxx/GitHub/xxxxxx" is not an absolute path!                                                                                                                                                                                              ││    -> The base directory (absolute path!) for resolving the `entry` option. If `output.pathinfo` is set, the included pathinfo is shortened to this directory.

Not sure if this is the best place, but should work on any platform.

Context (Environment)
OS: Windows 10, Git Bash v2.20.0 64bit
Embark Version: 3.2.7
Node Version: 10.14.2
NPM Version: 6.4.1