### PR TITLE
fix(@embark/ens): make resolve() work with promises and callbacks

### DIFF
--- a/src/lib/core/modules/coderunner/codeRunner.js
+++ b/src/lib/core/modules/coderunner/codeRunner.js
@@ -96,7 +96,7 @@ class CodeRunner {
       cb(null, value);
     } catch (error) {
       // Improve error message when there's no connection to node
-      if (error.message.indexOf(WEB3_INVALID_RESPONSE_ERROR) !== -1) {
+      if (error.message && error.message.indexOf(WEB3_INVALID_RESPONSE_ERROR) !== -1) {
         error.message += '. Are you connected to an Ethereum node?';
       }
 


### PR DESCRIPTION
Changes in https://github.com/embark-framework/embark/commit/c64c093a48626736ce9da64b603e1c3820ea3f22 resulted in a regression
that ENS functions within console/dashboard didn't work properly anymore.

This commit ensures that both APIs, `EmbarkJS.Names.resolve()` as well as
`EmbarkJS.Names.lookup()` can be either used using `async/await` or promised
based syntax within the console/dashboard.

Example:

```
await EmbarkJS.Names.resolve('me.eth.eth');

EmbarkJS.Names.resolve('me.eth.eth').then(val => ..., err => ...)

EmbarkJS.Names.resolve('me.eth.eth', (err, val) => ...)
```

Same with:

```
await EmbarkJS.Names.lookup('0x...');

EmbarkJS.Names.lookup('0x...').then(val => ..., err => ...)

EmbarkJS.Names.lookup('0x...', (err, val) => ...)
```