### PR TITLE
Fix logger.info not defined

### DIFF
--- a/src/cmd/cmd_controller.js
+++ b/src/cmd/cmd_controller.js
@@ -32,7 +32,8 @@ class EmbarkController {
 
   blockchain(env, client) {
     this.context = [constants.contexts.blockchain];
-    return require('../lib/modules/blockchain_process/blockchain.js')(this.config.blockchainConfig, client, env, null, null, this.logger, this.events, true).run();
+    return require('../lib/modules/blockchain_process/blockchain.js')(this.config.blockchainConfig, client, env,
+      this.config.webServerConfig.certOptions, null, null, this.logger, this.events, true).run();
   }
 
   simulator(options) {


### PR DESCRIPTION
Was caused by the new certOptions needed by the blockchain client.
It was added to the blockchain process but not the basic blockchain client (`embark blockchain`)