### PR TITLE
fix(@embark/whisper): use a new WebsocketProvider on each retry

### DIFF
--- a/src/lib/modules/whisper/index.js
+++ b/src/lib/modules/whisper/index.js
@@ -67,6 +67,7 @@ class Whisper {
       return cb();
     }
     if (this.web3.currentProvider.connection.readyState !== 1) {
+      this.connectToProvider();
       return setTimeout(this.waitForWeb3Ready.bind(this, cb), 50);
     }
     this.web3Ready = true;


### PR DESCRIPTION
`waitForWeb3Ready` was never making it to the point it sets `this.web3Ready = true` and invokes its callback because once the provider's connection's `readyState` is `3` ("closed or couldn't be opened") there is no possibility it will change to `1` ("open and ready").

Call the `connectToProvider` method before setting up a retry with `setTimeout` so that a new instance of `Web3.providers.WebsocketProvider` is used on each retry.