### PR TITLE
fix(logHandler): stringify objects instead of trying to split it

### DIFF
--- a/src/lib/utils/logHandler.js
+++ b/src/lib/utils/logHandler.js
@@ -55,9 +55,13 @@ class LogHandler {
       processedMessages = [msg.message];
     } else if (Array.isArray(msg.message)) {
       msg.message.forEach(message => {
-        if (Array.isArray(message)) message = message.join('\n');
-        let lines = message.split("\n");
-        lines.forEach(line => processedMessages.push(line));
+        if (Array.isArray(message)) {
+          return message.forEach(line => processedMessages.push(line));
+        }
+        if (typeof message === 'object') {
+          return processedMessages.push(JSON.stringify(msg.message));
+        }
+        message.toString().split("\n").forEach(line => processedMessages.push(line));
       });
     } else if (typeof msg.message === 'object') {
       processedMessages.push(JSON.stringify(msg.message));


### PR DESCRIPTION
Got this error by trying to connect via WS in the Dapp when I deactivated WS.
It threw an error in the log handler because somehow it tried to log an empty object.
Now this is handled