### PR TITLE
feat(@embark/cli): unify command history without needing a restart

### DIFF
--- a/src/cmd/cmd_controller.js
+++ b/src/cmd/cmd_controller.js
@@ -360,7 +360,11 @@ class EmbarkController {
         });
       },
       function startREPL(callback) {
-        new REPL({events: engine.events, env: engine.env}).start(callback);
+        new REPL({
+          events: engine.events,
+          env: engine.env,
+          ipc: engine.ipc
+        }).start(callback);
       }
     ], function (err, _result) {
       if (err) {

--- a/src/cmd/dashboard/dashboard.js
+++ b/src/cmd/dashboard/dashboard.js
@@ -9,6 +9,7 @@ class Dashboard {
     this.plugins = options.plugins;
     this.version = options.version;
     this.env = options.env;
+    this.ipc = options.ipc;
 
     this.events.on('firstDeploymentDone', this.checkWindowSize.bind(this));
     this.events.on('outputDone', this.checkWindowSize.bind(this));
@@ -24,7 +25,7 @@ class Dashboard {
   start(done) {
     let monitor;
 
-    monitor = new Monitor({env: this.env, events: this.events, version: this.version});
+    monitor = new Monitor({env: this.env, events: this.events, version: this.version, ipc: this.ipc});
     this.logger.logFunction = monitor.logEntry;
     let plugin = this.plugins.createPlugin('dashboard', {});
     plugin.registerAPICall(

--- a/src/cmd/dashboard/monitor.js
+++ b/src/cmd/dashboard/monitor.js
@@ -10,6 +10,7 @@ class Monitor {
     this.events = options.events;
     this.color = options.color || "green";
     this.minimal = options.minimal || false;
+    this.ipc = options.ipc;
 
     this.screen = blessed.screen({
       smartCSR: true,
@@ -53,7 +54,8 @@ class Monitor {
       env: this.env,
       inputStream: this.terminalReadableStream,
       outputStream: terminalWritableStream,
-      logText: this.logText
+      logText: this.logText,
+      ipc: this.ipc
     }).start(() => {
       this.terminal.focus();
     });


### PR DESCRIPTION
Send a message over IPC when a command is executed from the REPL so that command history is immediately unified across `embark run` and one/more `embark console`. Previously, for `embark console` to pick up a command entered in the REPL of an `embark run` of which it was an IPC client it would have to be restarted, and vice versa.