### PR TITLE
feat(@embark/core): Disable regular txs until needed

### DIFF
--- a/embark-ui/src/actions/index.js
+++ b/embark-ui/src/actions/index.js
@@ -426,6 +426,13 @@ export const removeEditorTabs = {
   failure: () => action(REMOVE_EDITOR_TABS[FAILURE])
 };
 
+export const INIT_REGULAR_TXS = createRequestTypes('INIT_REGULAR_TXS');
+export const initRegularTxs = {
+  request: () => action(INIT_REGULAR_TXS[REQUEST], {mode: 'on'}),
+  success: () => action(INIT_REGULAR_TXS[SUCCESS]),
+  failure: () => action(INIT_REGULAR_TXS[FAILURE])
+};
+
 // Web Socket
 export const WATCH_NEW_PROCESS_LOGS = 'WATCH_NEW_PROCESS_LOGS';
 export const STOP_NEW_PROCESS_LOGS = 'STOP_NEW_PROCESS_LOGS';

--- a/embark-ui/src/sagas/index.js
+++ b/embark-ui/src/sagas/index.js
@@ -79,6 +79,7 @@ export const debugStepIntoForward = doRequest.bind(null, actions.debugStepIntoFo
 export const debugStepIntoBackward = doRequest.bind(null, actions.debugStepIntoBackward, api.debugStepIntoBackward);
 export const toggleBreakpoint = doRequest.bind(null, actions.toggleBreakpoint, api.toggleBreakpoint);
 export const authenticate = doRequest.bind(null, actions.authenticate, api.authenticate);
+export const initRegularTxs = doRequest.bind(null, actions.initRegularTxs, api.initRegularTxs);
 
 export const fetchCredentials = doRequest.bind(null, actions.fetchCredentials, storage.fetchCredentials);
 export const saveCredentials = doRequest.bind(null, actions.saveCredentials, storage.saveCredentials);
@@ -343,6 +344,10 @@ export function *watchRemoveEditorTabsSuccess() {
   yield takeEvery(actions.REMOVE_EDITOR_TABS[actions.SUCCESS], fetchEditorTabs);
 }
 
+export function *watchInitRegularTxs() {
+  yield takeEvery(actions.INIT_REGULAR_TXS[actions.REQUEST], initRegularTxs);
+}
+
 function createChannel(socket) {
   return eventChannel(emit => {
     socket.onmessage = ((message) => {
@@ -585,6 +590,7 @@ export default function *root() {
     fork(watchRemoveEditorTabsSuccess),
     fork(watchPostFileSuccess),
     fork(watchPostFolderSuccess),
-    fork(watchListenContracts)
+    fork(watchListenContracts),
+    fork(watchInitRegularTxs)
   ]);
 }

--- a/embark-ui/src/services/api.js
+++ b/embark-ui/src/services/api.js
@@ -228,6 +228,10 @@ export function toggleBreakpoint(payload) {
   return post('/debugger/breakpoint', {params: payload, credentials: payload.credentials});
 }
 
+export function initRegularTxs(payload) {
+  return get('/regular-txs', {params: payload, credentials: payload.credentials});
+}
+
 export function listenToDebugger(credentials) {
   return websocket(credentials, '/debugger');
 }

--- a/embark-ui/src/utils/utils.js
+++ b/embark-ui/src/utils/utils.js
@@ -23,8 +23,12 @@ export function ansiToHtml(text) {
   return convert.toHtml(text.replace(/\n/g,'<br>'));
 }
 
+export function getQueryParam(location, param) {
+  return qs.parse(location.search, {ignoreQueryPrefix: true})[param];
+}
+
 export function getQueryToken(location) {
-  return qs.parse(location.search, {ignoreQueryPrefix: true}).token;
+  return getQueryParam(location, 'token');
 }
 
 export function getDebuggerTransactionHash(location) {
@@ -32,9 +36,13 @@ export function getDebuggerTransactionHash(location) {
 }
 
 export function stripQueryToken(location) {
+  return stripQueryParam(location, 'token');
+}
+
+export function stripQueryParam(location, param) {
   const _location = Object.assign({}, location);
   _location.search = _location.search.replace(
-    /(\?|&?)(token=[\w-]*)(&?)/,
+    new RegExp(`(\\?|&?)(${param}=[\\w-]*)(&?)`),
     (_, p1, p2, p3) => (p2 ? (p3 === '&' ? p1 : '') : '')
   );
   return _location;

--- a/src/lib/constants.json
+++ b/src/lib/constants.json
@@ -53,7 +53,9 @@
       "eth_sendTransaction": "eth_sendTransaction",
       "eth_sendRawTransaction": "eth_sendRawTransaction",
       "eth_getTransactionReceipt": "eth_getTransactionReceipt"
-    }
+    },
+    "startRegularTxs": "startRegularTxs",
+    "stopRegularTxs": "stopRegularTxs"
   },
   "storage": {
     "init": "init",

--- a/src/lib/modules/blockchain_process/blockchainProcess.js
+++ b/src/lib/modules/blockchain_process/blockchainProcess.js
@@ -52,4 +52,10 @@ process.on('message', (msg) => {
     blockchainProcess = new BlockchainProcess(msg.options);
     return blockchainProcess.send({result: constants.blockchain.initiated});
   }
+  else if(msg.action === constants.blockchain.startRegularTxs){
+    blockchainProcess.blockchain.startRegularTxs(() => {});
+  }
+  else if(msg.action === constants.blockchain.stopRegularTxs){
+    blockchainProcess.blockchain.stopRegularTxs(() => {});
+  }
 });

--- a/src/lib/modules/blockchain_process/blockchainProcessLauncher.js
+++ b/src/lib/modules/blockchain_process/blockchainProcessLauncher.js
@@ -38,7 +38,8 @@ class BlockchainProcessLauncher {
         env: this.env,
         isDev: this.isDev,
         locale: this.locale,
-        certOptions: this.embark.config.webServerConfig.certOptions
+        certOptions: this.embark.config.webServerConfig.certOptions,
+        events: this.events
       }
     });
 
@@ -61,6 +62,14 @@ class BlockchainProcessLauncher {
 
     this.events.on('logs:ethereum:disable', () => {
       this.blockchainProcess.silent = true;
+    });
+    
+    this.events.on('regularTxs:start', () => {
+      this.blockchainProcess.send({action: constants.blockchain.startRegularTxs});
+    });
+
+    this.events.on('regularTxs:stop', () => {
+      this.blockchainProcess.send({action: constants.blockchain.stopRegularTxs});
     });
 
     this.events.on('exit', () => {

--- a/src/lib/modules/blockchain_process/dev_funds.js
+++ b/src/lib/modules/blockchain_process/dev_funds.js
@@ -60,18 +60,26 @@ class DevFunds {
     this.web3.eth.sendTransaction({value: "1000000000000000", to: "0xA2817254cb8E7b6269D1689c3E0eBadbB78889d1", from: this.web3.eth.defaultAccount});
   }
 
-  _regularTxs(cb) {
+  startRegularTxs(cb) {
     const self = this;
     self.web3.eth.net.getId().then((networkId) => {
       self.networkId = networkId;
       if (self.networkId !== 1337) {
         return;
       }
-      setInterval(function() { self._sendTx(); }, 1500);
+      this.regularTxsInt = setInterval(function() { self._sendTx(); }, 1500);
       if (cb) {
         cb();
       }
     });
+  }
+
+  stopRegularTxs(cb) {
+    if(this.regularTxsInt) {
+      clearInterval(this.regularTxsInt);
+      return cb();
+    }
+    cb('Regular txs not enabled.');
   }
 
   _fundAccounts(balance, cb) {
@@ -113,13 +121,12 @@ class DevFunds {
     }, cb);
   }
 
-  fundAccounts(pingForever = false, cb) {
+  fundAccounts(cb) {
     if (!this.web3) {
       return cb();
     }
     async.waterfall([
       (next) => {
-        if (pingForever) this._regularTxs();
         this._fundAccounts(this.balance, next);
       }
     ], cb);

--- a/src/lib/modules/code_generator/code_templates/web3-connector.js.ejs
+++ b/src/lib/modules/code_generator/code_templates/web3-connector.js.ejs
@@ -1,4 +1,4 @@
 EmbarkJS.Blockchain.autoEnable = <%= autoEnable %>;
-EmbarkJS.Blockchain.connect(<%- connectionList %>, {warnAboutMetamask: <%= warnAboutMetamask %>}, function(err) {
+EmbarkJS.Blockchain.connect(<%- connectionList %>, {warnAboutMetamask: <%= warnAboutMetamask %>, blockchainClient: "<%= blockchainClient %>"}, function(err) {
   <%- done  %>
 });

--- a/src/lib/modules/code_generator/index.js
+++ b/src/lib/modules/code_generator/index.js
@@ -26,6 +26,7 @@ class CodeGenerator {
     this.storageConfig = embark.config.storageConfig || {};
     this.communicationConfig = embark.config.communicationConfig || {};
     this.namesystemConfig = embark.config.namesystemConfig || {};
+    this.webServerConfig = embark.config.webServerConfig || {};
     this.env = options.env || 'development';
     this.plugins = options.plugins;
     this.events = embark.events;
@@ -124,7 +125,8 @@ class CodeGenerator {
           autoEnable: this.contractsConfig.dappAutoEnable,
           connectionList: connectionList,
           done: 'done(err);',
-          warnAboutMetamask: isDev
+          warnAboutMetamask: isDev,
+          blockchainClient: this.blockchainConfig.ethereumClientName
         });
       }
 

--- a/src/test/devFunds.js
+++ b/src/test/devFunds.js
@@ -110,7 +110,7 @@ describe('embark.DevFunds', function() {
         // provider.injectResult('0x11f4d0A3c12e86B4b5F39B213F7E19D048276DAe'); // send tx response
       });
 
-      devFunds.fundAccounts(devFunds.balance, (errFundAccounts) => {
+      devFunds.fundAccounts((errFundAccounts) => {
         assert.equal(errFundAccounts, null);
 
         // inject response for web3.eth.getAccounts


### PR DESCRIPTION
Regular transactions (aka “dev funds”) exist in embark as a workaround to a known bug in geth when using metamask. The workaround is to send a transaction at a regular interval (1.5s), which pushes through any transactions that were stuck. The problem is that the transaction logs and trace logs become cluttered and difficult to parse visually.

This PR disables regular transactions until the following conditions are met:
1. Embark is running geth
2. The user is running metamask in their browser
3. The user authenticates to the cockpit with `enableRegularTxs=1|true` in the query string.

A console warning is show in large letters in the browser with a link to the cockpit URL that includes the special query string to enable regular txs.

This could be extended later to have a button in the cockpit that start/stops regular txs. Or at least extended to allow disabling of regular txs once started.

If the user is using Geth and Metamask, a console warning message informing the user that they may experience stuck transactions is shown with the following PR: https://github.com/embark-framework/EmbarkJS/pull/34.