### PR TITLE
fix(@embark/core): Support legacy Parity version parsing

### DIFF
--- a/src/lib/modules/blockchain_process/parityClient.js
+++ b/src/lib/modules/blockchain_process/parityClient.js
@@ -120,7 +120,7 @@ class ParityClient {
 
   parseVersion(rawVersionOutput) {
     let parsed;
-    const match = rawVersionOutput.match(/version Parity-Ethereum\/(.*?)\//);
+    const match = rawVersionOutput.match(/version Parity(?:-Ethereum)?\/(.*?)\//);
     if (match) {
       parsed = match[1].trim();
     }


### PR DESCRIPTION
Parse legacy version of Parity. Pre-version 2 of Parity outputs “Parity <version>” instead of the post-version 2 “Parity-Ethereum”. Embark was emitting an error when the version of an older Parity client could not be parsed, and no warning messages regarding the version were shown.

This PR modifies the regex that parses the version so that older versions of Parity can be detected and the appropriate warning message can appear.