### PR TITLE
fix(@embark/blockchain_process): proxy listens on the specified host

### DIFF
--- a/src/lib/modules/blockchain_process/proxy.js
+++ b/src/lib/modules/blockchain_process/proxy.js
@@ -2,7 +2,7 @@
 
 require('./httpProxyOverride');
 const Asm = require('stream-json/Assembler');
-const {canonicalHost, defaultHost} = require('../../utils/host');
+const {canonicalHost} = require('../../utils/host');
 const constants = require('../../constants.json');
 const {Duplex} = require('stream');
 const http = require('http');
@@ -237,7 +237,7 @@ class Proxy {
     return new Promise(resolve => {
       server.listen(
         port - constants.blockchain.servicePortOnProxy,
-        defaultHost,
+        host,
         () => { resolve(server); }
       );
     });


### PR DESCRIPTION
Change the blockchain proxy so that it listens on the `host` argument passed to `Proxy#serve` rather than on `defaultHost`.