### PR TITLE
Revert "Fix for error running anything on Windows with Git Bash"

### DIFF
--- a/src/lib/modules/pipeline/webpack.config.js
+++ b/src/lib/modules/pipeline/webpack.config.js
@@ -2,7 +2,7 @@
 
 const path = require('path');
 
-const dappPath = path.normalize(process.env.DAPP_PATH);
+const dappPath = process.env.DAPP_PATH;
 const embarkPath = process.env.EMBARK_PATH;
 
 const dappNodeModules = path.join(dappPath, 'node_modules');


### PR DESCRIPTION
Reverts embark-framework/embark#1198

The change introduced by #1198 is not needed for embark v4, it only helps with v3.2.x.

It’s a weird edge case. When running node in Git Bash on Windows:
```
> process.env.PWD
'/c/Users/micha/dapps/embark_demo'
```

On Windows, `process.env.PWD` is normally undefined.

When normalized, that `'/c/'` path can’t be successfully used with `path.join`. I tried `existsSync` when joining it (normalized) with `'embark.json'` and got `false`. Swapping it for `process.cwd()`, `existsSync` reports `true` as expected.

I’m not sure why it was working out when the normalized path is processed by webpack. If we wanted to properly fix it and cut a new 3.2.x release, we would need to change things here:

https://github.com/embark-framework/embark/blob/v3.2.7/cmd/cmd.js#L9-L11

We could detect Windows *and* a `PWD` that begins with `/`, and in that case overwrite with `process.cwd()`.