### PR TITLE
feat(@embark/core): Expose embark version to plugin constructor

### DIFF
--- a/src/cmd/cmd_controller.js
+++ b/src/cmd/cmd_controller.js
@@ -25,7 +25,7 @@ class EmbarkController {
     this.events = new Events();
     this.logger = new Logger({logLevel: Logger.logLevels.debug, events: this.events, context: this.context});
 
-    this.config = new Config({env: env, logger: this.logger, events: this.events, context: this.context});
+    this.config = new Config({env: env, logger: this.logger, events: this.events, context: this.context, version: this.version});
     this.config.loadConfigFiles(options);
     this.plugins = this.config.plugins;
   }

--- a/src/lib/core/config.js
+++ b/src/lib/core/config.js
@@ -31,6 +31,7 @@ var Config = function(options) {
   this.events = options.events;
   this.embarkConfig = {};
   this.context = options.context || [constants.contexts.any];
+  this.version = options.version;
   this.shownNoAccountConfigMsg = false; // flag to ensure "no account config" message is only displayed once to the user
   this.corsParts = [];
   this.providerUrl = null;
@@ -84,7 +85,7 @@ Config.prototype.loadConfigFiles = function(options) {
   this.embarkConfig = fs.readJSONSync(options.embarkConfig);
   this.embarkConfig.plugins = this.embarkConfig.plugins || {};
 
-  this.plugins = new Plugins({plugins: this.embarkConfig.plugins, logger: this.logger, interceptLogs: interceptLogs, events: this.events, config: this, context: this.context, env: this.env});
+  this.plugins = new Plugins({plugins: this.embarkConfig.plugins, logger: this.logger, interceptLogs: interceptLogs, events: this.events, config: this, context: this.context, env: this.env, version: this.version});
   this.plugins.loadPlugins();
 
   this.loadEmbarkConfigFile();

--- a/src/lib/core/engine.js
+++ b/src/lib/core/engine.js
@@ -30,7 +30,7 @@ class Engine {
     let options = _options || {};
     this.events = options.events || this.events || new Events();
     this.logger = options.logger || new Logger({context: this.context, logLevel: options.logLevel || this.logLevel || 'debug', events: this.events, logFile: this.logFile});
-    this.config = new Config({env: this.env, logger: this.logger, events: this.events, context: this.context, webServerConfig: this.webServerConfig});
+    this.config = new Config({env: this.env, logger: this.logger, events: this.events, context: this.context, webServerConfig: this.webServerConfig, version: this.version});
     this.config.loadConfigFiles({embarkConfig: this.embarkConfig, interceptLogs: this.interceptLogs});
     this.plugins = this.config.plugins;
     this.isDev = this.config && this.config.blockchainConfig && (this.config.blockchainConfig.isDev || this.config.blockchainConfig.default);

--- a/src/lib/core/plugin.js
+++ b/src/lib/core/plugin.js
@@ -42,6 +42,7 @@ var Plugin = function(options) {
   this.loaded = false;
   this.currentContext = options.context;
   this.acceptedContext = options.pluginConfig.context || [constants.contexts.any];
+  this.version = options.version;
 
   if (!Array.isArray(this.currentContext)) {
     this.currentContext = [this.currentContext];

--- a/src/lib/core/plugins.js
+++ b/src/lib/core/plugins.js
@@ -12,6 +12,7 @@ var Plugins = function(options) {
   this.config = options.config;
   this.context = options.context;
   this.env = options.env;
+  this.version = options.version;
 };
 
 Plugins.prototype.loadPlugins = function() {
@@ -94,7 +95,8 @@ Plugins.prototype.loadPlugin = function(pluginName, pluginConfig) {
     config: this.config,
     plugins: this.plugins,
     isInternal: false,
-    context: this.context
+    context: this.context,
+    version: this.version
   });
   pluginWrapper.loadPlugin();
   this.plugins.push(pluginWrapper);

--- a/src/lib/index.js
+++ b/src/lib/index.js
@@ -15,7 +15,7 @@ class Embark {
     this.events = new Events();
     this.logger = new Logger({logLevel: 'debug', events: this.events, context: this.context});
 
-    this.config = new Config({env: env, logger: this.logger, events: this.events, context: this.context});
+    this.config = new Config({env: env, logger: this.logger, events: this.events, context: this.context, version: this.version});
     this.config.loadConfigFiles(options);
     this.plugins = this.config.plugins;
   }


### PR DESCRIPTION
Expose Embark’s version to the plugin constructor, allowing plugins to make logical decisions based on the version of Embark.