### PR TITLE
fix(blockchain): fix metamask using the old web3

### DIFF
--- a/src/lib/modules/blockchain_connector/embarkjs.js
+++ b/src/lib/modules/blockchain_connector/embarkjs.js
@@ -3,8 +3,14 @@
 const __embarkWeb3 = {};
 
 __embarkWeb3.init = function(_config) {
-  this.web3 = global.web3 || new Web3();
-  global.web3 = global.web3 || this.web3;
+  // Check if the global web3 object uses the old web3 (0.x)
+  if (global.web3 && typeof global.web3.version !== 'string') {
+    // If so, use a new instance using 1.0, but use its provider
+    this.web3 = new Web3(global.web3.currentProvider);
+  } else {
+    this.web3 = global.web3 || new Web3();
+  }
+  global.web3 = this.web3;
 };
 
 __embarkWeb3.getInstance = function () {


### PR DESCRIPTION
Caused Dapps to crash because we expect web3 1.x but metamask injects a 0.x web3 instance.
Fixed by using a 1.x instance with the metamask provider.