### PR TITLE
fix(contracts): fix linking libraries with long paths using output

### DIFF
--- a/src/lib/modules/contracts_manager/index.js
+++ b/src/lib/modules/contracts_manager/index.js
@@ -332,6 +332,7 @@ class ContractsManager {
           contract.code = compiledContract.code;
           contract.runtimeBytecode = compiledContract.runtimeBytecode;
           contract.realRuntimeBytecode = (compiledContract.realRuntimeBytecode || compiledContract.runtimeBytecode);
+          contract.linkReferences = compiledContract.linkReferences;
           contract.swarmHash = compiledContract.swarmHash;
           contract.gasEstimates = compiledContract.gasEstimates;
           contract.functionHashes = compiledContract.functionHashes;
@@ -467,12 +468,13 @@ class ContractsManager {
             self.contractDependencies[className] = self.contractDependencies[className].concat(contract.deps);
           }
 
-          // look in code for dependencies
-          if (contract.code) {
-            let libMatches = (contract.code.match(/:(.*?)(?=_)/g) || []);
-            for (let match of libMatches) {
-              self.contractDependencies[className].push(match.substr(1));
-            }
+          // look in linkReferences for dependencies
+          if (contract.linkReferences) {
+            Object.values(contract.linkReferences).forEach(fileReference => {
+              Object.keys(fileReference).forEach(libName => {
+                self.contractDependencies[className].push(libName);
+              });
+            });
           }
 
           // look in arguments for dependencies

--- a/src/lib/modules/solidity/index.js
+++ b/src/lib/modules/solidity/index.js
@@ -136,6 +136,7 @@ class Solidity {
 
             compiled_object[className] = {};
             compiled_object[className].code = contract.evm.bytecode.object;
+            compiled_object[className].linkReferences = contract.evm.bytecode.linkReferences;
             compiled_object[className].runtimeBytecode = contract.evm.deployedBytecode.object;
             compiled_object[className].realRuntimeBytecode = contract.evm.deployedBytecode.object.slice(0, -68);
             compiled_object[className].swarmHash = contract.evm.deployedBytecode.object.slice(-68).slice(0, 64);


### PR DESCRIPTION
Replacement for: https://github.com/embark-framework/embark/pull/1232

Now uses the `linkReferences` that comes from the solc output. Solc docs: https://solidity.readthedocs.io/en/v0.5.1/using-the-compiler.html?highlight=linkReferences