### PR TITLE
fix(@embark/coderunner): use custom require function in vm context

### DIFF
--- a/src/lib/core/modules/coderunner/runCode.js
+++ b/src/lib/core/modules/coderunner/runCode.js
@@ -6,11 +6,21 @@ const noop = function() {};
 class RunCode {
   constructor({logger}) {
     this.logger = logger;
+    const customRequire = (mod) => {
+      return require(customRequire.resolve(mod));
+    };
+    customRequire.resolve = (mod) => {
+      return require.resolve(
+        mod,
+        {paths: [fs.dappPath('node_modules'), fs.embarkPath('node_modules')]}
+      );
+    };
     const newGlobal = Object.create(global);
     newGlobal.fs = fs;
     this.context = Object.assign({}, {
-      global: newGlobal, console, exports, require, module, __filename, __dirname, process,
-      setTimeout, setInterval, clearTimeout, clearInterval
+      global: newGlobal, console, exports, require: customRequire, module,
+      __filename, __dirname, process, setTimeout, setInterval, clearTimeout,
+      clearInterval
     });
   }
 


### PR DESCRIPTION
Supply a custom require function to the vm context for `doEval` so that module resolution succeeds for both DApp dependencies and Embark dependencies.