### PR TITLE
feat(blockchainConfig): enable having auto cors plus other origins

### DIFF
--- a/src/lib/core/config.js
+++ b/src/lib/core/config.js
@@ -162,13 +162,15 @@ Config.prototype._updateBlockchainCors = function(){
   corsParts.push(constants.embarkResourceOrigin);
 
   let cors = corsParts.join(',');
-  if(blockchainConfig.rpcCorsDomain === 'auto'){
-    if(cors.length) blockchainConfig.rpcCorsDomain = cors;
-    else blockchainConfig.rpcCorsDomain = '';
+  if (blockchainConfig.rpcCorsDomain === 'auto') {
+    blockchainConfig.rpcCorsDomain = cors;
+  } else if (blockchainConfig.rpcCorsDomain.indexOf('auto') > -1) {
+    blockchainConfig.rpcCorsDomain = blockchainConfig.rpcCorsDomain.replace('auto', cors);
   }
-  if(blockchainConfig.wsOrigins === 'auto'){
-    if(cors.length) blockchainConfig.wsOrigins = cors;
-    else blockchainConfig.wsOrigins = '';
+  if (blockchainConfig.wsOrigins === 'auto') {
+    blockchainConfig.wsOrigins = cors;
+  } else if (blockchainConfig.wsOrigins.indexOf('auto') > -1) {
+    blockchainConfig.wsOrigins = blockchainConfig.wsOrigins.replace('auto', cors);
   }
 };
 


### PR DESCRIPTION
This was originally supposed to be a fix to the Parity + Metmask bug (it's currently impossible to use both at the same time right now because Parity's CORS are really harsh). The only way to make both work together is to tell Parity to accept Metamask's extension url as explained here: https://github.com/MetaMask/metamask-extension/issues/5098#issuecomment-416883083

However, that extension url is unique per user. Doing `moz-extension://*` works but is super insecure.

So, for now, I will add documentation on how to make Parity with Metamask work and since the solution is to add the Metamask url to the cors, I thought it'd be great if it was possible to have the following in our config: 
```
rpcCorsDomain: "auto,ANOTHER_URL",
```
And now it is 🙂 

Sorry for the long write for such a small change. I literally spend one day on this only to find nothing is possible except that.