### PR TITLE
feat: add option --no-single-use-cockpit-token

### DIFF
--- a/src/cmd/cmd.js
+++ b/src/cmd/cmd.js
@@ -142,6 +142,7 @@ class Cmd {
       .option('--loglevel [loglevel]', __('level of logging to display') + ' ["error", "warn", "info", "debug", "trace"]', /^(error|warn|info|debug|trace)$/i, 'debug')
       .option('--locale [locale]', __('language to use (default: en)'))
       .option('--pipeline [pipeline]', __('webpack config to use (default: development)'))
+      .option('--no-single-use-auth-token', __('disable the single use of token in cockpit'))
       .description(__('run dapp (default: %s)', 'development'))
       .action(function(env, options) {
         i18n.setOrDetectLocale(options.locale);
@@ -156,7 +157,8 @@ class Cmd {
           logFile: options.logfile,
           logLevel: options.loglevel,
           webpackConfigName: options.pipeline || 'development',
-          openBrowser: !options.nobrowser ? null : false
+          openBrowser: !options.nobrowser ? null : false,
+          singleUseAuthToken: options.singleUseAuthToken
         });
       });
   }
@@ -169,6 +171,7 @@ class Cmd {
       .option('--loglevel [loglevel]', __('level of logging to display') + ' ["error", "warn", "info", "debug", "trace"]', /^(error|warn|info|debug|trace)$/i, 'debug')
       .option('--locale [locale]', __('language to use (default: en)'))
       .option('--pipeline [pipeline]', __('webpack config to use (default: development)'))
+      .option('--no-single-use-auth-token', __('disable the single use of token in cockpit'))
       .description(__('Start the Embark console'))
       .action(function(env, options) {
         i18n.setOrDetectLocale(options.locale);
@@ -178,6 +181,7 @@ class Cmd {
           locale: options.locale,
           logFile: options.logfile,
           logLevel: options.loglevel,
+          singleUseAuthToken: options.singleUseAuthToken,
           webpackConfigName: options.pipeline || 'development'
         });
       });

--- a/src/cmd/cmd_controller.js
+++ b/src/cmd/cmd_controller.js
@@ -94,6 +94,7 @@ class EmbarkController {
       useDashboard: options.useDashboard,
       webServerConfig: webServerConfig,
       webpackConfigName: options.webpackConfigName,
+      singleUseAuthToken: options.singleUseAuthToken,
       ipcRole: 'server'
     });
 
@@ -273,6 +274,7 @@ class EmbarkController {
       logFile: options.logFile,
       logLevel: options.logLevel,
       context: this.context,
+      singleUseAuthToken: options.singleUseAuthToken,
       webpackConfigName: options.webpackConfigName
     });
 

--- a/src/lib/core/engine.js
+++ b/src/lib/core/engine.js
@@ -18,6 +18,7 @@ class Engine {
     this.useDashboard = options.useDashboard;
     this.webServerConfig = options.webServerConfig;
     this.webpackConfigName = options.webpackConfigName;
+    this.singleUseAuthToken = options.singleUseAuthToken;
     this.ipcRole = options.ipcRole || 'client';
   }
 
@@ -258,7 +259,7 @@ class Engine {
   }
 
   cockpitService() {
-    this.registerModule('authenticator');
+    this.registerModule('authenticator', {singleUseAuthToken: this.singleUseAuthToken});
     this.registerModule('api', {plugins: this.plugins});
   }
 


### PR DESCRIPTION
This option is added to run and console.
This can be usefull while developing on cockpit,
the auto reload don't always ask to authenticate