### PR TITLE
fix: allow to debug instanceOf contracts

### DIFF
--- a/embark-ui/src/containers/EditorContainer.js
+++ b/embark-ui/src/containers/EditorContainer.js
@@ -35,6 +35,7 @@ class EditorContainer extends React.Component {
 
     this.state = {
       currentAsideTab: {},
+      debuggingContract: null,
       showHiddenFiles: false,
       currentFile: this.props.currentFile,
       editorHeight: this.DEFAULT_HEIGHT,
@@ -78,11 +79,11 @@ class EditorContainer extends React.Component {
       this.setState({currentFile: this.props.currentFile});
     }
 
-    if(this.props.contracts && this.props.transaction !== prevProps.transaction && this.props.transaction) {
+    if(this.props.contracts.length && this.props.transaction) {
       const debuggingContract = this.props.contracts.find(contract => contract.address === this.props.transaction.to)
-      if (debuggingContract) {
+      if (this.state.debuggingContract !== debuggingContract) {
         const editorWidth = this.getNewEditorWidth(OPERATIONS.LESS)
-        this.setState({currentAsideTab: TextEditorToolbarTabs.Debugger, editorWidth})
+        this.setState({currentAsideTab: TextEditorToolbarTabs.Debugger, editorWidth, debuggingContract})
         this.props.fetchFile({path: debuggingContract.path});
       }
     }

--- a/embark-ui/src/reducers/selectors.js
+++ b/embark-ui/src/reducers/selectors.js
@@ -234,7 +234,7 @@ export function getDebuggerInfo(state) {
 }
 
 export function getDebuggerLine(state) {
-  if (!state.debuggerInfo.sources) return;
+  if (!state.debuggerInfo.sources || !state.debuggerInfo.sources.lineColumnPos[0]) return;
   return state.debuggerInfo.sources.lineColumnPos[0].start.line + 1;
 }
 

--- a/src/lib/modules/contracts_manager/index.js
+++ b/src/lib/modules/contracts_manager/index.js
@@ -423,6 +423,9 @@ class ContractsManager {
             }));
           }
 
+          contract.path = parentContract.path;
+          contract.originalFilename = parentContract.originalFilename;
+          contract.filename = parentContract.filename;
           contract.code = parentContract.code;
           contract.runtimeBytecode = parentContract.runtimeBytecode;
           contract.realRuntimeBytecode = (parentContract.realRuntimeBytecode || parentContract.runtimeBytecode);


### PR DESCRIPTION
In order to start debugging contracts, the filename is required.
Instance of contracts use the parent contract filename