### PR TITLE
fix(@embark/core): Fix contract testing with `remix_tests`

### DIFF
--- a/src/lib/modules/contracts_manager/index.js
+++ b/src/lib/modules/contracts_manager/index.js
@@ -291,9 +291,21 @@ class ContractsManager {
           callback();
         });
       },
-      function compileContracts(callback) {
+      function allContractsCompiled(callback) {
+        const allContractsCompiled = 
+          self.compiledContracts && 
+          self.contractsFiles && 
+          self.contractsFiles.every(contractFile => 
+            Object.values(self.compiledContracts).find(contract => 
+              contract.originalFilename === contractFile.filename
+            )
+          );
+        callback(null, allContractsCompiled);
+      },
+      function compileContracts(allContractsCompiled, callback) {
         self.events.emit("status", __("Compiling..."));
-        if (self.compileOnceOnly && self.compiledContracts && Object.keys(self.compiledContracts).length) {
+        const hasCompiledContracts = self.compiledContracts && Object.keys(self.compiledContracts).length;
+        if (self.compileOnceOnly && hasCompiledContracts && allContractsCompiled) {
           return callback();
         }
         self.events.request("compiler:contracts", self.contractsFiles, compilerOptions, function (err, compiledObject) {

--- a/src/lib/modules/solidity/index.js
+++ b/src/lib/modules/solidity/index.js
@@ -143,6 +143,7 @@ class Solidity {
             compiled_object[className].gasEstimates = contract.evm.gasEstimates;
             compiled_object[className].functionHashes = contract.evm.methodIdentifiers;
             compiled_object[className].abiDefinition = contract.abi;
+            compiled_object[className].userdoc = contract.userdoc;
             compiled_object[className].filename = filename;
             compiled_object[className].originalFilename = originalFilepaths[filename];
           }

--- a/src/lib/modules/tests/test.js
+++ b/src/lib/modules/tests/test.js
@@ -219,26 +219,8 @@ class Test {
         });
       },
       function changeGlobalWeb3(accounts, next) {
-        self.events.request('blockchain:get', (web3) => {
-          global.web3 = web3;
-          self.vm = new VM({
-            sandbox: {
-              EmbarkJS,
-              web3: web3,
-              Web3: Web3,
-              IpfsApi
-            }
-          });
-          self.events.request("code-generator:embarkjs:provider-code", (code) => {
-            self.vm.doEval(code, false, (err, _result) => {
-              if(err) return next(err);
-              self.events.request("code-generator:embarkjs:init-provider-code", (code) => {
-                self.vm.doEval(code, false, (err, _result) => {
-                  next(err, accounts);
-                });
-              });
-            });
-          });
+        self.resetEmbarkJS((err) => {
+          next(err, accounts);
         });
       }
     ], (err, accounts) => {
@@ -247,6 +229,30 @@ class Test {
         if (!self.options.inProcess) process.exit(1);
       }
       callback(null, accounts);
+    });
+  }
+
+  resetEmbarkJS(cb) {
+    this.events.request('blockchain:get', (web3) => {
+      global.web3 = web3;
+      this.vm = new VM({
+        sandbox: {
+          EmbarkJS,
+          web3: web3,
+          Web3: Web3,
+          IpfsApi
+        }
+      });
+      this.events.request("code-generator:embarkjs:provider-code", (code) => {
+        this.vm.doEval(code, false, (err, _result) => {
+          if(err) return cb(err);
+          this.events.request("code-generator:embarkjs:init-provider-code", (code) => {
+            this.vm.doEval(code, false, (err, _result) => {
+              cb(err);
+            });
+          });
+        });
+      });
     });
   }
 


### PR DESCRIPTION
Remix_test-injected contract files were not correctly being tested due to an update in the `remix-tests` signature. I'm really not sure how tests were not completely bombing out during testing.

This PR introduces a few changes:

1. Ensure all contract files have been compiled before skipping compilation. This can occur if contract files have been added after a compilation round has already completed (ie in the tests).
2. Update solc tests to support latest `remix_tests.runTests` signature and include `userdoc` in compiled contracts.
3. Ensure `EmbarkJS` is reset before executing solc tests - like in the js tests, this is required for built EmbarkJS contract objects to behave correctly when it's functions are executed against the chain.
4. Refactor “all files already compiled” function.

BLOCKER: base branch `feat/replace-node-vm` must be merged in https://github.com/embark-framework/embark/pull/1234 before this can be merged.