### PR TITLE
feat(compiler): add a new compiler api that checks for compatibility

### DIFF
--- a/src/lib/core/plugin.js
+++ b/src/lib/core/plugin.js
@@ -94,7 +94,7 @@ Plugin.prototype.loadPlugin = function() {
     this.pluginModule = this.pluginModule.default;
     return new this.pluginModule(this);
   }
-  (this.pluginModule.call(this, this));
+  this.pluginModule.call(this, this);
 };
 
 Plugin.prototype.loadInternalPlugin = function() {

--- a/src/lib/modules/solidity/index.js
+++ b/src/lib/modules/solidity/index.js
@@ -77,7 +77,7 @@ class Solidity {
         }
         self.solcW = new SolcW(self.embark, {logger: self.logger, events: self.events, ipc: self.ipc, useDashboard: self.useDashboard, providerUrl: self.providerUrl});
 
-        self.logger.info(__("loading solc compiler") + "..");
+        self.logger.info(__("loading solc compiler") + "...");
         self.solcW.load_compiler(function (err) {
           self.solcAlreadyLoaded = true;
           callback(err);


### PR DESCRIPTION
This is needed because the solc plugin has a version check to see if it is compatible. However, there was a race condition in it, because it only registered itself if the version was ok, but Embark was sometime faster than the version check, so it compiled straight away with Embark's compiler.

The new API is NOT breaking, it just enables plugins to callback with `false` as the result and it tells Embark that the version was not compatible. Embark will then use the next available compiler in the list.

If no compiler works (which should never happen since Embark downloads it), it shows an error.

API used here: https://github.com/embark-framework/embark-solc/pull/21