### PR TITLE
feat(@embark/core): Recursively import contracts

### DIFF
--- a/package.json
+++ b/package.json
@@ -97,6 +97,7 @@
     "decompress": "4.2.0",
     "deep-equal": "1.0.1",
     "ejs": "2.6.1",
+    "embark-test-contract-0": "0.0.2",
     "embarkjs": "0.5.0",
     "eth-ens-namehash": "2.0.8",
     "ethereumjs-tx": "1.3.7",

--- a/src/test/contracts/recursive_test_0.sol
+++ b/src/test/contracts/recursive_test_0.sol
@@ -1,0 +1,19 @@
+pragma solidity ^0.5.0;
+
+import "./recursive_test_1.sol";
+
+contract SimpleStorageRecursive0 {
+    uint public storedData;
+
+    constructor (uint initialValue) public {
+        storedData = initialValue;
+    }
+
+    function set(uint x) public {
+        storedData = x;
+    }
+
+    function get() public view returns (uint retVal) {
+        return storedData;
+    }
+}

--- a/src/test/contracts/recursive_test_1.sol
+++ b/src/test/contracts/recursive_test_1.sol
@@ -1,0 +1,19 @@
+pragma solidity ^0.5.0;
+
+import "./recursive_test_2.sol";
+
+contract SimpleStorageRecursive1 {
+    uint public storedData;
+
+    constructor(uint initialValue) public {
+        storedData = initialValue;
+    }
+
+    function set(uint x) public {
+        storedData = x;
+    }
+
+    function get() public view returns (uint retVal) {
+        return storedData;
+    }
+}

--- a/src/test/contracts/recursive_test_2.sol
+++ b/src/test/contracts/recursive_test_2.sol
@@ -1,0 +1,19 @@
+pragma solidity ^0.5.0;
+
+import "embark-test-contract-0/recursive_test_3.sol";
+
+contract SimpleStorageRecursive2 {
+    uint public storedData;
+
+    constructor(uint initialValue) public {
+        storedData = initialValue;
+    }
+
+    function set(uint x) public {
+        storedData = x;
+    }
+
+    function get() public view returns (uint retVal) {
+        return storedData;
+    }
+}

--- a/src/test/file.js
+++ b/src/test/file.js
@@ -26,6 +26,32 @@ describe('embark.File', function () {
       });
     });
 
+    it('should find and add remappings for all recursive imports', function (done) {
+      const contract = fs.readFileSync('./dist/test/contracts/recursive_test_0.sol').toString();
+      const file = new File({filename: './dist/test/contracts/recursive_test_0.sol',
+    path: path.join(__dirname, './contracts/recursive_test_0.sol')});
+
+      file.parseFileForImport(contract, () => {
+        assert.deepEqual(file.importRemappings[0], {
+          prefix: "./recursive_test_1.sol",
+          target: path.join(__dirname, "./contracts/recursive_test_1.sol")
+        });
+        assert.deepEqual(file.importRemappings[1], {
+          prefix: "./recursive_test_2.sol",
+          target: path.join(__dirname, "./contracts/recursive_test_2.sol")
+        });
+        assert.deepEqual(file.importRemappings[2], {
+          prefix: "embark-test-contract-0/recursive_test_3.sol",
+          target: path.resolve(path.join("node_modules", "./embark-test-contract-0/recursive_test_3.sol"))
+        });
+        assert.deepEqual(file.importRemappings[3], {
+          prefix: "embark-test-contract-1/recursive_test_4.sol",
+          target: path.resolve(path.join("node_modules", "./embark-test-contract-1/recursive_test_4.sol"))
+        });
+        done();
+      });
+    });
+
     it('should find all the imports but not call download because not a http contract', function (done) {
       const contract = fs.readFileSync('./dist/test/contracts/contract_with_import.sol').toString();
       const file = new File({filename: '.embark/contracts/embark-framework/embark/master/test_app/app/contracts/simple_storage.sol',

--- a/yarn.lock
+++ b/yarn.lock
@@ -4089,6 +4089,18 @@ elliptic@^6.0.0, elliptic@^6.2.3, elliptic@^6.4.0:
     minimalistic-assert "^1.0.0"
     minimalistic-crypto-utils "^1.0.0"
 
+embark-test-contract-0@0.0.2:
+  version "0.0.2"
+  resolved "https://registry.yarnpkg.com/embark-test-contract-0/-/embark-test-contract-0-0.0.2.tgz#53913fb40e3df4b816a7bef9f00a5f78fa3d56b4"
+  integrity sha512-bETRyZERYMGwmHuXBlgQGkRmSZoB5sb8kW5M240PsxbO05FE1YyPNcPcDM2+FEJozHFMl9hqxrbt69X7Zzn7xw==
+  dependencies:
+    embark-test-contract-1 "^0.0.1"
+
+embark-test-contract-1@^0.0.1:
+  version "0.0.1"
+  resolved "https://registry.yarnpkg.com/embark-test-contract-1/-/embark-test-contract-1-0.0.1.tgz#802b84150e8038fef6681a3f23b6f4c0dc5b3e80"
+  integrity sha512-yFaXMOXOMfYRNFOKEspdXrZzyovceWedtegHtbfs8RZWRzRYY+v6ZDtGm13TRJt3Qt4VZhKky0l7G/SHZMGHCA==
+
 embarkjs@0.5.0:
   version "0.5.0"
   resolved "https://registry.yarnpkg.com/embarkjs/-/embarkjs-0.5.0.tgz#b5b282289896b62f7ef4d4df40566d1777f4b83e"


### PR DESCRIPTION
Add support to recursively import contracts. If we have three contracts

1. A imports B
2. B imports C

Then prior to this PR, contract A would import contract B, and a remapping would be added to the contract so the compiler would know how to find contract B. However, contract B imports contracts C, and because the `parseFileForImport` method was not recursive, the remappings were not able to go one level deeper to remap the path to contract C, and thus the compiler would not know how to locate contract C, and would complain with the error `File outside of allowed directories.`

With the introduction of this PR, the `parseFileForImport` method is now recursive, and so any contract imported is also checked for it's own imports that can be remapped. Specifically, this use case is applicable when there is a dependency containing contracts that imports one of it's own dependency's contracts, ie:

```
pragma solididty ^0.5.0;

import "dependency-1/contract-1.sol";
```
where the dependencies look like:
```
|- node_modules
|--- dependency-1
|----- contract-1.sol <--- contains import "dependency-2/contract-2.sol"
|--- dependency-2
|----- contract-2.sol
```

Add unit tests that verify recursive imports work.
Add embark depdendency that installs a contract used in the recursive unit tests.