### PR TITLE
fix: command handlers named consistently

### DIFF
--- a/src/lib/modules/api/index.ts
+++ b/src/lib/modules/api/index.ts
@@ -64,13 +64,13 @@ export default class Api {
 
   private listenToCommands() {
     this.embark.events.setCommandHandler("api:url", (cb) => cb(this.apiUrl));
-    this.embark.events.setCommandHandler("start-api", (cb) => this.embark.events.request("processes:launch", "api", cb));
-    this.embark.events.setCommandHandler("stop-api",  (cb) => this.embark.events.request("processes:stop", "api", cb));
-    this.embark.events.setCommandHandler("logs:api:turnOn",  (cb) => {
+    this.embark.events.setCommandHandler("api:start", (cb) => this.embark.events.request("processes:launch", "api", cb));
+    this.embark.events.setCommandHandler("api:stop",  (cb) => this.embark.events.request("processes:stop", "api", cb));
+    this.embark.events.setCommandHandler("logs:api:enable",  (cb) => {
       this.api.enableLogging();
       cb();
     });
-    this.embark.events.setCommandHandler("logs:api:turnOff",  (cb) => {
+    this.embark.events.setCommandHandler("logs:api:disable",  (cb) => {
       this.api.disableLogging();
       cb();
     });
@@ -81,7 +81,7 @@ export default class Api {
       description: __("Start or stop the API"),
       matches: ["api start"],
       process: (cmd: string, callback: () => void) => {
-        this.embark.events.request("start-api", callback);
+        this.embark.events.request("api:start", callback);
       },
       usage: "api start/stop",
     });
@@ -89,21 +89,21 @@ export default class Api {
     this.embark.registerConsoleCommand({
       matches: ["api stop"],
       process: (cmd: string, callback: () => void) => {
-        this.embark.events.request("stop-api", callback);
+        this.embark.events.request("api:stop", callback);
       },
     });
 
     this.embark.registerConsoleCommand({
       matches: ["log api on"],
       process: (cmd: string, callback: () => void) => {
-        this.embark.events.request("logs:api:turnOn", callback);
+        this.embark.events.request("logs:api:enable", callback);
       },
     });
 
     this.embark.registerConsoleCommand({
       matches: ["log api off"],
       process: (cmd: string, callback: () => void) => {
-        this.embark.events.request("logs:api:turnOff", callback);
+        this.embark.events.request("logs:api:disable", callback);
       },
     });
   }

--- a/src/lib/modules/authenticator/index.js
+++ b/src/lib/modules/authenticator/index.js
@@ -63,7 +63,7 @@ class Authenticator {
         if (this.singleUseToken) {
           // Generate another authentication token.
           this.authToken = uuid();
-          this.events.request('authenticator:displayUrl', false);
+          this.events.request('authenticator:url:display', false);
           emittedToken = uuid();
         } else {
           emittedToken = this.authToken;
@@ -88,10 +88,10 @@ class Authenticator {
 
   registerEvents() {
     this.events.once('outputDone', () => {
-      this.events.request('authenticator:displayUrl', true);
+      this.events.request('authenticator:url:display', true);
     });
 
-    this.events.setCommandHandler('authenticator:displayUrl', (firstOutput) => {
+    this.events.setCommandHandler('authenticator:url:display', (firstOutput) => {
       if(!firstOutput) this.logger.info(__('Previous token has now been used.'));
       this.events.request('api:url', (apiUrl) => {
         this.logger.info(__('Access the web backend with the following url: %s', (`${apiUrl}?token=${this.authToken}`.underline)));

--- a/src/lib/modules/blockchain_process/index.js
+++ b/src/lib/modules/blockchain_process/index.js
@@ -37,12 +37,12 @@ class BlockchainModule {
   }
 
   listenToCommands() {
-    this.events.setCommandHandler('logs:ethereum:turnOn',  (cb) => {
+    this.events.setCommandHandler('logs:ethereum:enable',  (cb) => {
       this.events.emit('logs:ethereum:enable');
       return cb(null, 'Enabling Geth logs');
     });
 
-    this.events.setCommandHandler('logs:ethereum:turnOff',  (cb) => {
+    this.events.setCommandHandler('logs:ethereum:disable',  (cb) => {
       this.events.emit('logs:ethereum:disable');
       return cb(null, 'Disabling Geth logs');
     });
@@ -52,13 +52,13 @@ class BlockchainModule {
     this.embark.registerConsoleCommand({
       matches: ['log blockchain on'],
       process: (cmd, callback) => {
-        this.events.request('logs:ethereum:turnOn', callback);
+        this.events.request('logs:ethereum:enable', callback);
       }
     });
     this.embark.registerConsoleCommand({
       matches: ['log blockchain off'],
       process: (cmd, callback) => {
-        this.events.request('logs:ethereum:turnOff', callback);
+        this.events.request('logs:ethereum:disable', callback);
       }
     });
   }

--- a/src/lib/modules/ipfs/index.js
+++ b/src/lib/modules/ipfs/index.js
@@ -142,12 +142,12 @@ class IPFS {
   }
 
   listenToCommands() {
-    this.events.setCommandHandler('logs:ipfs:turnOn',  (cb) => {
+    this.events.setCommandHandler('logs:ipfs:enable',  (cb) => {
       this.events.emit('logs:storage:enable');
       return cb(null, 'Enabling IPFS logs');
     });
 
-    this.events.setCommandHandler('logs:ipfs:turnOff',  (cb) => {
+    this.events.setCommandHandler('logs:ipfs:disable',  (cb) => {
       this.events.emit('logs:storage:disable');
       return cb(null, 'Disabling IPFS logs');
     });
@@ -157,13 +157,13 @@ class IPFS {
     this.embark.registerConsoleCommand({
       matches: ['log ipfs on'],
       process: (cmd, callback) => {
-        this.events.request('logs:ipfs:turnOn', callback);
+        this.events.request('logs:ipfs:enable', callback);
       }
     });
     this.embark.registerConsoleCommand({
       matches: ['log ipfs off'],
       process: (cmd, callback) => {
-        this.events.request('logs:ipfs:turnOff', callback);
+        this.events.request('logs:ipfs:disable', callback);
       }
     });
   }

--- a/src/lib/modules/pipeline/index.js
+++ b/src/lib/modules/pipeline/index.js
@@ -149,7 +149,7 @@ class Pipeline {
           self.isFirstBuild = false;
           return next();
         }
-        self.events.request('build-placeholder', next);
+        self.events.request('placeholder:build', next);
       },
       (next) => self.buildContracts(next),
       (next) => self.buildWeb3JS(next),

--- a/src/lib/modules/swarm/index.js
+++ b/src/lib/modules/swarm/index.js
@@ -129,12 +129,12 @@ class Swarm {
   }
 
   listenToCommands() {
-    this.events.setCommandHandler('logs:swarm:turnOn',  (cb) => {
+    this.events.setCommandHandler('logs:swarm:enable',  (cb) => {
       this.events.emit('logs:storage:enable');
       return cb(null, 'Enabling Swarm logs');
     });
 
-    this.events.setCommandHandler('logs:swarm:turnOff',  (cb) => {
+    this.events.setCommandHandler('logs:swarm:disable',  (cb) => {
       this.events.emit('logs:storage:disable');
       return cb(null, 'Disabling Swarm logs');
     });
@@ -144,13 +144,13 @@ class Swarm {
     this.embark.registerConsoleCommand({
       matches: ['log swarm on'],
       process: (cmd, callback) => {
-        this.events.request('logs:swarm:turnOn', callback);
+        this.events.request('logs:swarm:enable', callback);
       }
     });
     this.embark.registerConsoleCommand({
       matches: ['log swarm off'],
       process: (cmd, callback) => {
-        this.events.request('logs:swarm:turnOff', callback);
+        this.events.request('logs:swarm:disable', callback);
       }
     });
   }

--- a/src/lib/modules/webserver/index.js
+++ b/src/lib/modules/webserver/index.js
@@ -67,7 +67,7 @@ class WebServer {
           this.events.request('processes:launch', 'webserver', (_err, message, port) => {
             this.logger.info(message);
             this.port = port;
-            this.events.request('open-browser', () => {});
+            this.events.request('browser:open', () => {});
           });
         });
       });
@@ -101,12 +101,12 @@ class WebServer {
   }
 
   listenToCommands() {
-    this.events.setCommandHandler('build-placeholder', (cb) => this.buildPlaceholderPage(cb));
-    this.events.setCommandHandler('open-browser', (cb) => this.openBrowser(cb));
-    this.events.setCommandHandler('start-webserver', (cb) => this.events.request('processes:launch', 'webserver', cb));
-    this.events.setCommandHandler('stop-webserver',  (cb) => this.events.request('processes:stop', 'webserver', cb));
-    this.events.setCommandHandler('logs:webserver:turnOn',  (cb) => this.server.enableLogging(cb));
-    this.events.setCommandHandler('logs:webserver:turnOff',  (cb) => this.server.disableLogging(cb));
+    this.events.setCommandHandler('placeholder:build', (cb) => this.buildPlaceholderPage(cb));
+    this.events.setCommandHandler('browser:open', (cb) => this.openBrowser(cb));
+    this.events.setCommandHandler('webserver:start', (cb) => this.events.request('processes:launch', 'webserver', cb));
+    this.events.setCommandHandler('webserver:stop',  (cb) => this.events.request('processes:stop', 'webserver', cb));
+    this.events.setCommandHandler('logs:webserver:enable',  (cb) => this.server.enableLogging(cb));
+    this.events.setCommandHandler('logs:webserver:disable',  (cb) => this.server.disableLogging(cb));
   }
 
   registerConsoleCommands() {
@@ -115,14 +115,14 @@ class WebServer {
       description: __("Start or stop the websever"),
       matches: ['webserver start'],
       process: (cmd, callback) => {
-        this.events.request('start-webserver', callback);
+        this.events.request('webserver:start', callback);
       }
     });
 
     this.embark.registerConsoleCommand({
       matches: ['webserver stop'],
       process: (cmd, callback) => {
-        this.events.request('stop-webserver', callback);
+        this.events.request('webserver:stop', callback);
       }
     });
 
@@ -130,21 +130,21 @@ class WebServer {
       description: __("Open a browser window at the Dapp's url"),
       matches: ['browser open'],
       process: (cmd, callback) => {
-        this.events.request('open-browser', callback);
+        this.events.request('browser:open', callback);
       }
     });
 
     this.embark.registerConsoleCommand({
       matches: ['log webserver on'],
       process: (cmd, callback) => {
-        this.events.request('logs:webserver:turnOn', callback);
+        this.events.request('logs:webserver:enable', callback);
       }
     });
 
     this.embark.registerConsoleCommand({
       matches: ['log webserver off'],
       process: (cmd, callback) => {
-        this.events.request('logs:webserver:turnOff', callback);
+        this.events.request('logs:webserver:disable', callback);
       }
     });
   }

--- a/src/lib/modules/webserver/server.js
+++ b/src/lib/modules/webserver/server.js
@@ -23,7 +23,7 @@ class Server {
 
     this.protocol = options.protocol || 'http';
     this.certOptions = options.certOptions;
-    
+
     this.events.once('outputDone', () => {
       this.logger.info(this._getMessage());
     });
@@ -56,7 +56,7 @@ class Server {
     this.app = express();
     this.secureServer = this.protocol === 'https' ? https.createServer(self.certOptions, (req, res) => self.app.handle(req, res)) : null;
     const expressWs = this.protocol === 'https' ? expressWebSocket(this.app, this.secureServer) : expressWebSocket(this.app);
-    
+
     // Assign Logging Function
     this.app.use(function(req, res, next) {
       if (self.logging) {
@@ -101,7 +101,7 @@ class Server {
           return next();
         }
         self.isFirstStart = false;
-        self.events.request('build-placeholder', next);
+        self.events.request('placeholder:build', next);
       },
       function listen(next) {
         if (self.protocol === 'https'){
@@ -122,7 +122,7 @@ class Server {
           return next();
         }
         self.opened = true;
-        self.events.request('open-browser', next);
+        self.events.request('browser:open', next);
       }
     ], function(err) {
       if (err) {


### PR DESCRIPTION
Now they're named following a `noun:[noun:]verb` convention.