### PR TITLE
Move blockchain connect to EmbarkJS and let dapps call it

### DIFF
--- a/src/lib/constants.json
+++ b/src/lib/constants.json
@@ -83,5 +83,9 @@
       "eth",
       "xyz"
     ]
+  },
+  "dappConfig": {
+    "dir": "config",
+    "blockchain": "blockchain.json"
   }
 }

--- a/src/lib/core/config.js
+++ b/src/lib/core/config.js
@@ -486,7 +486,8 @@ Config.prototype.loadEmbarkConfigFile = function() {
         "optimize": true,
         "optimize-runs": 200
       }
-    }
+    },
+    "generationDir": "embarkArtifacts"
   };
 
   this.embarkConfig = utils.recursiveMerge(configObject, this.embarkConfig);

--- a/src/lib/modules/code_generator/code_templates/web3-connector.js.ejs
+++ b/src/lib/modules/code_generator/code_templates/web3-connector.js.ejs
@@ -1,4 +1,0 @@
-EmbarkJS.Blockchain.autoEnable = <%= autoEnable %>;
-EmbarkJS.Blockchain.connect(<%- connectionList %>, {warnAboutMetamask: <%= warnAboutMetamask %>, blockchainClient: "<%= blockchainClient %>"}, function(err) {
-  <%- done  %>
-});

--- a/src/lib/modules/code_generator/index.js
+++ b/src/lib/modules/code_generator/index.js
@@ -12,7 +12,6 @@ const Templates = {
   define_when_env_loaded: require('./code_templates/define-when-env-loaded.js.ejs'),
   main_context: require('./code_templates/main-context.js.ejs'),
   define_web3_simple: require('./code_templates/define-web3-simple.js.ejs'),
-  web3_connector: require('./code_templates/web3-connector.js.ejs'),
   do_when_loaded: require('./code_templates/do-when-loaded.js.ejs'),
   exec_when_env_loaded: require('./code_templates/exec-when-env-loaded.js.ejs')
 };
@@ -47,12 +46,6 @@ class CodeGenerator {
 
     this.events.on('config:load:contracts', (contractConfig) => {
       this.generateConfigs(contractConfig);
-    });
-
-    this.events.setCommandHandler('provider-code', function(cb) {
-      let providerCode = self.generateProvider(false);
-
-      cb(providerCode);
     });
 
     this.events.setCommandHandler('code', function(cb) {
@@ -96,55 +89,6 @@ class CodeGenerator {
     self.events.setCommandHandler('code-generator:embarkjs:init-provider-code', (cb) => {
       cb(self.getInitProviderCode());
     });
-  }
-
-  generateProvider(isDeployment) {
-    let self = this;
-    let result = "";
-    let providerPlugins;
-
-    result += Templates.main_context();
-    result += Templates.load_manager();
-    result += Templates.define_when_env_loaded();
-
-    if (self.blockchainConfig === {} || self.blockchainConfig.enabled === false) {
-      return result;
-    }
-
-    if (this.plugins) {
-      providerPlugins = this.plugins.getPluginsFor('clientWeb3Provider');
-    }
-
-    if (this.plugins && providerPlugins.length > 0) {
-      providerPlugins.forEach(function(plugin) {
-        result += plugin.generateProvider(self) + "\n";
-      });
-    } else {
-      let web3Load;
-
-      if (this.contractsConfig === {} || this.contractsConfig.enabled === false) {
-        return result;
-      }
-
-      if (isDeployment) {
-        let connection = utils.buildUrlFromConfig(this.contractsConfig.deployment);
-        web3Load = Templates.define_web3_simple({url: connection, done: 'done();'});
-      } else {
-        let connectionList = "[" + this.contractsConfig.dappConnection.map((x) => '"' + x + '"').join(',') + "]";
-        let isDev = self.blockchainConfig.isDev;
-        web3Load = Templates.web3_connector({
-          autoEnable: this.contractsConfig.dappAutoEnable,
-          connectionList: connectionList,
-          done: 'done(err);',
-          warnAboutMetamask: isDev || false,
-          blockchainClient: this.blockchainConfig.ethereumClientName
-        });
-      }
-
-      result += Templates.do_when_loaded({block: web3Load, environment: this.env});
-    }
-
-    return result;
   }
 
   generateContracts(contractsList, useEmbarkJS, isDeployment, useLoader) {
@@ -193,15 +137,37 @@ class CodeGenerator {
     return result;
   }
 
+  checkIfNeedsUpdate(file, newOutput, callback) {
+    fs.readFile(file, (err, content) => {
+      if (err) {
+        return callback(null, true);
+      }
+      callback(null, content.toString() !== newOutput);
+    });
+  }
+
   generateConfigs(contractConfig) {
-    this.dappConfigs.blockchain = {dappConnection: contractConfig.dappConnection};
+    this.dappConfigs.blockchain = {
+      dappConnection: contractConfig.dappConnection,
+      dappAutoEnable: contractConfig.dappAutoEnable,
+      warnIfMetamask: this.blockchainConfig.isDev,
+      blockchainClient: this.blockchainConfig.ethereumClientName
+    };
+    const dir = utils.joinPath(this.embarkConfig.generationDir, constants.dappConfig.dir);
+    const filePath = utils.joinPath(dir, constants.dappConfig.blockchain);
+    const configString = JSON.stringify(this.dappConfigs.blockchain, null, 2);
     async.waterfall([
       (next) => {
-        fs.mkdirp(utils.joinPath(this.embarkConfig.buildDir, constants.dappConfig.dir), next);
+        fs.mkdirp(dir, next);
       },
       (_dir, next) => {
-        fs.writeFile(utils.joinPath(this.embarkConfig.buildDir, constants.dappConfig.dir, constants.dappConfig.blockchain),
-          JSON.stringify(this.dappConfigs.blockchain, null, 2), next);
+        this.checkIfNeedsUpdate(filePath, configString, next);
+      },
+      (needsUpdate, next) => {
+        if (!needsUpdate) {
+          return next();
+        }
+        fs.writeFile(filePath, configString, next);
       }
     ], (err) => {
       if (err) {
@@ -256,7 +222,7 @@ class CodeGenerator {
     return result;
   }
 
-  _getInitCode(codeType, config) {
+   _getInitCode(codeType, config) {
     let result = "";
     let pluginsWithCode = this.plugins.getPluginsFor('initCode');
     for (let plugin of pluginsWithCode) {
@@ -274,7 +240,6 @@ class CodeGenerator {
   generateABI(contractsList, options) {
     let result = "";
 
-    result += this.generateProvider(options.deployment);
     result += this.generateContracts(contractsList, options.useEmbarkJS, options.deployment, true);
     result += this.generateStorageInitialization(options.useEmbarkJS);
     result += this.generateCommunicationInitialization(options.useEmbarkJS);
@@ -419,12 +384,10 @@ class CodeGenerator {
         code += `\nimport Web3 from '${web3Location}';\n`;
         code += "\nglobal.Web3 = Web3;\n";
 
-        code += "\n if (typeof web3 === 'undefined') {";
-        code += "\n var web3 = new Web3();\n";
-        code += "\n }";
+        code += "\nif (typeof web3 === 'undefined') {";
+        code += "\n  var web3 = new Web3();";
+        code += "\n}";
 
-        let providerCode = self.generateProvider(false);
-        code += providerCode;
         code += "\nexport default web3;\n";
         next(null, code);
       }

--- a/src/test/code_generator.js
+++ b/src/test/code_generator.js
@@ -27,14 +27,15 @@ describe('embark.CodeGenerator', function() {
         deployedAddress: "0x124",
         code: '123456'
       }
-    ]
+    ];
 
     const TestEvents = {
       request: (cmd, cb) => {
         cb(currentSolcVersion);
       },
       setCommandHandler: () => {
-      }
+      },
+      on: () => {}
     };
     let generator = new CodeGenerator({config: {blockchainConfig: {}}, events: TestEvents}, {});
 

--- a/templates/boilerplate/app/js/index.js
+++ b/templates/boilerplate/app/js/index.js
@@ -1,6 +1,11 @@
 import EmbarkJS from 'Embark/EmbarkJS';
+import config from '../../embarkArtifacts/config/blockchain.json';
 
 // import your contracts
 // e.g if you have a contract named SimpleStorage:
 //import SimpleStorage from 'Embark/contracts/SimpleStorage';
 
+
+EmbarkJS.Blockchain.connect(config, (err) => {
+  // You can execute contract calls after the connection
+});

--- a/templates/boilerplate/embark.json
+++ b/templates/boilerplate/embark.json
@@ -20,5 +20,6 @@
       "optimize": true,
       "optimize-runs": 200
     }
-  }
+  },
+  "generationDir": "embarkArtifacts"
 }

--- a/templates/demo/app/dapp.js
+++ b/templates/demo/app/dapp.js
@@ -7,6 +7,7 @@ import Blockchain from './components/blockchain';
 import Whisper from './components/whisper';
 import Storage from './components/storage';
 import ENS from './components/ens';
+import config from '../embarkArtifacts/config/blockchain';
 
 import './dapp.css';
 
@@ -27,7 +28,7 @@ class App extends React.Component {
   }
 
   componentDidMount() {
-    EmbarkJS.onReady((err) => {
+    EmbarkJS.Blockchain.connect(config, (err) => {
       this.setState({blockchainEnabled: true});
       if (err) {
         // If err is not null then it means something went wrong connecting to ethereum

--- a/templates/demo/embark.json
+++ b/templates/demo/embark.json
@@ -19,5 +19,6 @@
       "optimize": true,
       "optimize-runs": 200
     }
-  }
+  },
+  "generationDir": "embarkArtifacts"
 }


### PR DESCRIPTION
Dapps now need to call the connect, but it has a callback and returns a promise, so it can replace `onReady`.

The folder where the generations are generated can be changed in `embark.json`.

We only regenerate when there is an actual change.

Goes hand in hand with https://github.com/embark-framework/EmbarkJS/pull/38