### PR TITLE
fix: allow to use embark in dev deps

### DIFF
--- a/src/bin/embark.js
+++ b/src/bin/embark.js
@@ -630,9 +630,9 @@ PkgJsonLocalExpected.prototype.logMissingFile = function () {
 
 PkgJsonLocalExpected.prototype.setEmbarkDep = function () {
   if (isObject(this.json)) {
-    if (this.json.dependencies) {
+    if (this.json.dependencies && this.json.dependencies.embark) {
       this.embarkDep = this.json.dependencies.embark;
-    } else if (this.json.devDependencies) {
+    } else if (this.json.devDependencies && this.json.devDependencies.embark) {
       this.embarkDep = this.json.devDependencies.embark;
     }
   }


### PR DESCRIPTION
Currently if you install embark in dev deps and you have deps the shim tells you it is not found because the first check was only looking at the existence of deps not at the existence of deps and embark