### PR TITLE
Contracts can point to an artifact file to bypass deploy and compile

### DIFF
--- a/src/lib/modules/contracts_manager/index.js
+++ b/src/lib/modules/contracts_manager/index.js
@@ -321,15 +321,29 @@ class ContractsManager {
         // we can skip this entirely
         if(!resetContracts) return callback();
 
-        for (const className in self.contractsConfig.contracts) {
-          const contract = self.contractsConfig.contracts[className];
+        async.eachOf(self.contractsConfig.contracts, (contract, className, eachCb) => {
+          if (!contract.artifact) {
+            contract.className = className;
+            contract.args = contract.args || [];
 
-          contract.className = className;
-          contract.args = contract.args || [];
+            self.contracts[className] = contract;
+            return eachCb();
+          }
 
-          self.contracts[className] = contract;
-        }
-        callback();
+          fs.readFile(fs.dappPath(contract.artifact), (err, artifactBuf) => {
+            if (err) {
+              self.logger.error(__('Error while reading the artifact for "{{className}}" at {{path}}', {className, path: contract.artifact}));
+              return eachCb(err);
+            }
+            try {
+              self.contracts[className] = JSON.parse(artifactBuf.toString());
+              eachCb();
+            } catch (e) {
+              self.logger.error(__('Artifact file does not seem to be valid JSON (%s)', contract.artifact));
+              eachCb(e.message);
+            }
+          });
+        }, callback);
       },
       function getGasPriceForNetwork(callback) {
         return callback(null, self.contractsConfig.gasPrice);


### PR DESCRIPTION
With that, in contracts.js, you can do:
```
SimpleStorage: {
  artifact: 'artifacts/contracts/SimpleStorage.json`
}
```
And it will not need the file and will not deploy it if the address is already specified.

Caveat: This requires the Embark artifacts. Should we do an artifact abstraction at some point to accept artifacts from Truffle or others?