### PR TITLE
fix: estimate gas automatically when not specified

### DIFF
--- a/packages/embark/src/lib/modules/deployment/contract_deployer.js
+++ b/packages/embark/src/lib/modules/deployment/contract_deployer.js
@@ -302,7 +302,7 @@ class ContractDeployer {
         next();
       },
       function estimateCorrectGas(next) {
-        if (contract.gas === 'auto') {
+        if (contract.gas === 'auto' || !contract.gas) {
           return self.blockchain.estimateDeployContractGas(deployObject, (err, gasValue) => {
             if (err) {
               return next(err);


### PR DESCRIPTION
This allows for contract bytecode/abi to be specified on the contract config.