### PR TITLE
fix(@embark/core): fix(@embark/core): Fix recursive import remapping

### DIFF
--- a/src/lib/utils/solidity/remapImports.ts
+++ b/src/lib/utils/solidity/remapImports.ts
@@ -128,7 +128,7 @@ const replaceImports = (remapImports: RemapImport[]) => {
   Object.keys(byPath).forEach((p) => {
     let source = fs.readFileSync(p, "utf-8");
     byPath[p].forEach(({searchValue, replaceValue}) => {
-      source = source.replace(`${searchValue}`, `${replaceValue}`);
+      source = source.replace(`import "${searchValue}"`, `import "${replaceValue}"`);
     });
     fs.writeFileSync(p, source);
   });


### PR DESCRIPTION
Remapping of imports was failing if the file had already had it’s import replaced with a pattern that would match with subsequent replacement attempts. For example, if the dapp contract contained
```
import ".embark/node_modules/zeppelin-solidity/contracts/ownership/Ownable.sol”;
```
which lives in `node_modules`, then `zeppelin-solidity/contracts/ownership/Ownable.sol` would be replaced with `.embark/node_modules/zeppelin-solidity/contracts/ownership/Ownable.sol`, resulting in:
```
import ".embark/node_modules/zeppelin-solidity/contracts/ownership/Ownable.sol";
```
On subsequent replacements of the same file, the same replacement would occur, resulting in the incorrect
```
import ".embark/node_modules/.embark/node_modules/zeppelin-solidity/contracts/ownership/Ownable.sol";
```