### PR TITLE
fix(@embark/solidity): fix binding in method call

### DIFF
--- a/src/lib/modules/solidity/solcP.js
+++ b/src/lib/modules/solidity/solcP.js
@@ -67,7 +67,7 @@ class SolcProcess extends ProcessWrapper {
       if (semver.gte(this.solc.version(), '0.5.0')) {
         func = this.solc.compile;
       }
-      let output = func(JSON.stringify(jsonObj), this.findImports);
+      let output = func(JSON.stringify(jsonObj), this.findImports.bind(this));
       cb(null, output);
     } catch (err) {
       cb(err.message);


### PR DESCRIPTION
This commit fixes a bug where it throws while trying to compile solidity
files as it dereferences its `this`.

Unfortunately passing methods as lambda callbacks doesn't correctly
resolve its `this` scope even within fat arrow functions, resulting in
unexpected behaviour where `this` inside lambda is `undefined`.