### PR TITLE
Feat/smart compile

### DIFF
--- a/packages/embark/src/lib/core/config.js
+++ b/packages/embark/src/lib/core/config.js
@@ -59,7 +59,7 @@ var Config = function(options) {
     resolver = resolver || function(callback) {
       callback(fs.readFileSync(filename).toString());
     };
-    self.contractsFiles.push(new File({path: filename, type: Types.custom, resolver}));
+    self.contractsFiles.push(new File({path: filename, originalPath: filename, type: Types.custom, resolver}));
   });
 
   self.events.on('file-remove', (fileType, removedPath) => {
@@ -122,15 +122,16 @@ Config.prototype.reloadConfig = function() {
 };
 
 Config.prototype.loadContractFiles = function() {
-  const contracts = this.embarkConfig.contracts;
-  const newContractsFiles = this.loadFiles(contracts);
-  if (!this.contractFiles || newContractsFiles.length !== this.contractFiles.length || !deepEqual(newContractsFiles, this.contractFiles)) {
-    this.contractsFiles = this.contractsFiles.concat(newContractsFiles).filter((file, index, arr) => {
-      return !arr.some((file2, index2) => {
-        return file.path === file2.path && index < index2;
-      });
-    });
-  }
+  const loadedContractFiles = this.loadFiles(this.embarkConfig.contracts);
+  // `this.contractsFiles` could've been mutated at runtime using
+  // either `config:contractsFiles:add` event or through calls to
+  // `loadExternalContractsFiles()`, so we have to make sure we preserve
+  // those added files before we reset `this.contractsFiles`.
+  //
+  // We do that by determining the difference between `loadedContractFiles` and the ones
+  // already in memory in `this.contractsFiles`.
+  const addedContractFiles = this.contractsFiles.filter(existingFile => !loadedContractFiles.some(file => file.originalPath === existingFile.originalPath));
+  this.contractsFiles = loadedContractFiles.concat(addedContractFiles);
 };
 
 Config.prototype._updateBlockchainCors = function(){
@@ -360,20 +361,36 @@ Config.prototype.loadExternalContractsFiles = function() {
   }
   for (let contractName in contracts) {
     let contract = contracts[contractName];
+
     if (!contract.file) {
       continue;
     }
+
+    let externalContractFile = null;
+
     if (contract.file.startsWith('http') || contract.file.startsWith('git') || contract.file.startsWith('ipfs') || contract.file.startsWith('bzz')) {
-      const fileObj = utils.getExternalContractUrl(contract.file,this.providerUrl);
+      const fileObj = utils.getExternalContractUrl(contract.file, this.providerUrl);
       if (!fileObj) {
         return this.logger.error(__("HTTP contract file not found") + ": " + contract.file);
       }
-      const localFile = fileObj.filePath;
-      this.contractsFiles.push(new File({path: localFile, type: Types.http, basedir: '', externalUrl: fileObj.url, storageConfig: storageConfig}));
+      externalContractFile = new File({ path: fileObj.filePath, originalPath: fileObj.filePath, type: Types.http, basedir: '', externalUrl: fileObj.url, storageConfig });
     } else if (fs.existsSync(contract.file)) {
-      this.contractsFiles.push(new File({path: contract.file, type: Types.dappFile, basedir: '', storageConfig: storageConfig}));
+      externalContractFile = new File({ path: contract.file, originalPath: contract.file, type: Types.dappFile, basedir: '', storageConfig });
     } else if (fs.existsSync(path.join('./node_modules/', contract.file))) {
-      this.contractsFiles.push(new File({path: path.join('./node_modules/', contract.file), type: Types.dappFile, basedir: '', storageConfig: storageConfig}));
+      const completePath = path.join('./node_modules/', contract.file);
+      externalContractFile = new File({ path: completePath, originalPath: completePath, type: Types.dappFile, basedir: '', storageConfig });
+    }
+
+    if (externalContractFile) {
+      const index = this.contractsFiles.findIndex(contractFile => contractFile.originalPath === externalContractFile.originalPath);
+      // It's important that we only add `externalContractFile` if it doesn't exist already
+      // within `contractsFiles`, otherwise we keep adding duplicates in subsequent
+      // compilation routines creating a memory leak.
+      if (index > -1) {
+        this.contractsFiles[index] = externalContractFile;
+      } else {
+        this.contractsFiles.push(externalContractFile);
+      }
     } else {
       this.logger.error(__("contract file not found") + ": " + contract.file);
     }
@@ -572,7 +589,7 @@ Config.prototype.loadFiles = function(files) {
     return (file[0] === '$' || file.indexOf('.') >= 0);
   }).filter(function(file) {
     let basedir = findMatchingExpression(file, files);
-    readFiles.push(new File({path: file, type: Types.dappFile, basedir: basedir, storageConfig: storageConfig}));
+    readFiles.push(new File({path: file, originalPath: file, type: Types.dappFile, basedir: basedir, storageConfig: storageConfig}));
   });
 
   var filesFromPlugins = [];
@@ -606,9 +623,11 @@ Config.prototype.loadPluginContractFiles = function() {
   contractsPlugins.forEach(function(plugin) {
     plugin.contractsFiles.forEach(function(file) {
       var filename = file.replace('./','');
-      self.contractsFiles.push(new File({path: filename, pluginPath: plugin.pluginPath, type: Types.custom, storageConfig: storageConfig, resolver: function(callback) {
-        callback(plugin.loadPluginFile(file));
-      }}));
+      self.contractsFiles.push(new File({ path: filename, originalPath: path.join(plugin.pluginPath, filename), pluginPath: plugin.pluginPath, type: Types.custom, storageConfig,
+        resolver: function(callback) {
+          callback(plugin.loadPluginFile(file));
+        }
+      }));
     });
   });
 };

--- a/packages/embark/src/lib/core/file.ts
+++ b/packages/embark/src/lib/core/file.ts
@@ -25,6 +25,7 @@ export class File {
   public storageConfig: any;
   public providerUrl: string;
   public importRemappings: ImportRemapping[] = [];
+  public originalPath: string;
 
   constructor(options: any) {
     this.type = options.type;
@@ -34,6 +35,7 @@ export class File {
     this.pluginPath = options.pluginPath ? options.pluginPath : "";
     this.storageConfig = options.storageConfig;
     this.providerUrl = "";
+    this.originalPath = options.originalPath || '';
 
     if (this.type === Types.http) {
       const external = utils.getExternalContractUrl(options.externalUrl, this.providerUrl);

--- a/packages/embark/src/lib/modules/deployment/index.js
+++ b/packages/embark/src/lib/modules/deployment/index.js
@@ -100,10 +100,10 @@ class DeployManager {
                 return done(_err);
               }
               if (contracts.length === 0) {
-                self.logger.info(__("no contracts found"));
+                self.logger.info(__("None of your Smart Contracts needed compilation, nothing to deploy."));
                 return done();
               }
-              self.logger.info(__("finished deploying contracts"));
+              self.logger.info(__("Finished deployment."));
               done(err);
             });
           }

--- a/packages/embark/src/lib/utils/solidity/remapImports.ts
+++ b/packages/embark/src/lib/utils/solidity/remapImports.ts
@@ -65,7 +65,7 @@ const buildNewFile = (file: File, importPath: string) => {
     from = resolve(importPath);
     to = fs.dappPath(".embark", "node_modules", importPath);
     fs.copySync(from, to);
-    return new File({ path: to, type: Types.dappFile });
+    return new File({ path: to, type: Types.dappFile, originalPath: from });
   }
 
   // started with node_modules then further imports local paths in it's own repo/directory
@@ -73,7 +73,7 @@ const buildNewFile = (file: File, importPath: string) => {
     from = path.join(path.dirname(file.path.replace(".embark", ".")), importPath);
     to = path.join(path.dirname(file.path), importPath);
     fs.copySync(from, to);
-    return new File({ path: to, type: Types.dappFile });
+    return new File({ path: to, type: Types.dappFile, originalPath: from });
   }
 
   // local import, ie import "../path/to/contract" or "./path/to/contract"
@@ -81,7 +81,7 @@ const buildNewFile = (file: File, importPath: string) => {
   to = path.join(path.dirname(file.path), importPath);
 
   fs.copySync(from, to);
-  return new File({ path: to, type: Types.dappFile });
+  return new File({ path: to, type: Types.dappFile, originalPath: from });
 };
 
 const rescursivelyFindRemapImports = async (file: File, filesProcessed: string[] = []) => {


### PR DESCRIPTION
**The first commit fixes a memory leak, there's a separate PR for it in #1317 **

This PR introduces smart compilation (**But is not 100% ready, read on for why**). 

With these changes Embark will keep track of changes in Smart Contract by storing their content hashes on disc and reading+comparing them on subsequent compilation routines.

It also prevents Embark from executing afterDeploy hooks when no contract has
actually changed (and therefore no deployment has happened).

## There are 2 cases that still need to be addressed in this commit:

1. **Changes in Smart Contract configurations without changing the source itself**

  Prior to this commit, Embark would always deploy all contracts that have been compiled,
  which was every contract every time. With Smart Compilation, only a subset of contracts
  will be compiled on file change, causing unchanged contracts to potentially not be
  re-deployed. This is an issue when a user has changed a contracts configuration in the meantime.
  Smart Contracts will need to be redeployed when configuration values have changed as well,
  not just when the source has changed.

2. **After deploy hooks refer to non-compiled Smart Contracts instances**

  Since prior to this commit all Smart Contracts would always compile, they would also all
  be registered with Embark's VM, making them available in deployment hooks.

  With Smart Compilation, chances are most of the Smart Contracts are not compiled,
  causing them to not be registered with the VM and therefore after deployment hooks
  to possibly break.

## Possible solutions:

1. We could set an internal flag that controls whether Smart Compilation should happen or not,
  and set it to `false` when we know the contracts configuration file has changed. In those
  cases we would recompile/deploy all the contracts again.

2. We will need to register all Smart Contract instances with the VM that are needed. In order
  to find out which those are, we'll have to either parse deployment hooks (when they are strings)
  and figure out what a Smart Contracts are used (not sure based on which heuristics we want to do that), or, much more feasible, have users register`deps` on `afterDeploy` hooks, similar to `onDeploy` hooks. `deps` would just be a list of Smart Contract names that will need to be compiled in addition to the ones already compiled.

  Only problem here is to find a connection between a Smart Contract class name and a path to the
  source file of the contract for compilation.

  Alternatively, since we know the deploy hook dependencies should be compiled already, we also
  know that we can find their JS counterparts within `.embark/contracts/CONTRACT_NAME.js`, so we can simply import the instances from there and register those with the VM.
