### PR TITLE
build: cleanup .yarnrc

### DIFF
--- a/packages/.yarnrc
+++ b/packages/.yarnrc
@@ -1,0 +1,1 @@
+--install.no-lockfile true

--- a/packages/embark-ui/.yarnrc
+++ b/packages/embark-ui/.yarnrc
@@ -1,3 +1,0 @@
---*.scripts-prepend-node-path true
---install.check-files true
---install.no-lockfile true

--- a/packages/embark/.yarnrc
+++ b/packages/embark/.yarnrc
@@ -1,3 +1,0 @@
---*.scripts-prepend-node-path true
---install.check-files true
---install.no-lockfile true

--- a/test_dapps/.yarnrc
+++ b/test_dapps/.yarnrc
@@ -1,2 +1,0 @@
---*.scripts-prepend-node-path true
---install.check-files true

--- a/test_dapps/packages/.yarnrc
+++ b/test_dapps/packages/.yarnrc
@@ -1,0 +1,1 @@
+--install.no-lockfile true

--- a/test_dapps/packages/contracts_app/.yarnrc
+++ b/test_dapps/packages/contracts_app/.yarnrc
@@ -1,3 +1,0 @@
---*.scripts-prepend-node-path true
---install.check-files true
---install.no-lockfile true

--- a/test_dapps/packages/test_app/.yarnrc
+++ b/test_dapps/packages/test_app/.yarnrc
@@ -1,3 +1,0 @@
---*.scripts-prepend-node-path true
---install.check-files true
---install.no-lockfile true

--- a/test_dapps/packages/test_app/extensions/embark-service/.yarnrc
+++ b/test_dapps/packages/test_app/extensions/embark-service/.yarnrc
@@ -1,3 +1,0 @@
---*.scripts-prepend-node-path true
---install.check-files true
---install.no-lockfile true

--- a/test_dapps/packages/test_app/extensions/embark-service/package-lock.json
+++ b/test_dapps/packages/test_app/extensions/embark-service/package-lock.json
@@ -1,7 +1,8 @@
 {
   "name": "embark-service",
-  "requires": true,
+  "version": "0.0.1",
   "lockfileVersion": 1,
+  "requires": true,
   "dependencies": {
     "haml": {
       "version": "0.4.3",

--- a/test_dapps/packages/test_app/extensions/embark-service/package.json
+++ b/test_dapps/packages/test_app/extensions/embark-service/package.json
@@ -7,5 +7,6 @@
   "private": true,
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"
-  }
+  },
+  "version": "0.0.1"
 }


### PR DESCRIPTION
Yarn merges `.yarnrc` from the current working directory with `.yarnrc` files higher in the directory tree, so that file isn't needed in each package.

Unfortunately, npm doesn't do the same for `.npmrc` files, so a similar cleanup isn't possible.

Add version info to `test_app/extensions/embark-service/package.json` to that `yarn install` can work correctly if manually invoked in `test_app`.