### PR TITLE
build: cleanup .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,9 +1,12 @@
 .DS_Store
 .idea
+.nyc_output
 .vscode
 @embark*.tgz
 NOTES
 TODO
+coverage
+dist
 embark*.tgz
 lerna-debug.log
 node_modules

--- a/packages/embark-ui/.gitignore
+++ b/packages/embark-ui/.gitignore
@@ -2,5 +2,4 @@
 .env.local
 .env.production.local
 .env.test.local
-/build
-/coverage
+build

--- a/packages/embark/.gitignore
+++ b/packages/embark/.gitignore
@@ -1,3 +1,0 @@
-.nyc_output
-/coverage
-/dist


### PR DESCRIPTION
Put common patterns we expect to use across most `packages/*` into the top-level `.gitignore`. If there are package-specific patterns they can go in that package's `.gitignore`. For example, `packages/embark-ui` ignores its `build/` directory while commonly we ignore the packages' `dist/` directories.