### PR TITLE
build: cleanup eslint configuration

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -5,18 +5,17 @@
     "node": true
   },
   "extends": [
-    "eslint:recommended",
-    "plugin:react/recommended"
+    "eslint:recommended"
   ],
-  "parserOptions": {
-    "sourceType": "module",
-    "ecmaVersion": 2018,
-    "ecmaFeatures": {
-      "jsx": true
-    }
-  },
   "globals": {
     "__": true
+  },
+  "parserOptions": {
+    "ecmaFeatures": {
+      "jsx": true
+    },
+    "ecmaVersion": 2018,
+    "sourceType": "module"
   },
   "plugins": [
     "react"
@@ -200,10 +199,13 @@
     "no-unmodified-loop-condition": "error",
     "no-unneeded-ternary": "error",
     "no-unused-expressions": "error",
-    "no-unused-vars": ["error", {
-      "argsIgnorePattern": "^_",
-      "varsIgnorePattern": "^_"
-    }],
+    "no-unused-vars": [
+      "error",
+      {
+        "argsIgnorePattern": "^_",
+        "varsIgnorePattern": "^_"
+      }
+    ],
     "no-use-before-define": "off",
     "no-useless-call": "off",
     "no-useless-computed-key": "error",

--- a/packages/embark/package.json
+++ b/packages/embark/package.json
@@ -38,6 +38,9 @@
     "watch:build": "npm run build -- --verbose --watch",
     "watch:typecheck": "npm run typecheck -- --preserveWatchOutput --watch"
   },
+  "eslintConfig": {
+    "extends": "../../.eslintrc.json"
+  },
   "dependencies": {
     "@babel/core": "7.1.2",
     "@babel/plugin-proposal-class-properties": "7.1.0",
@@ -189,7 +192,6 @@
     "embark-test-contract-0": "0.0.2",
     "embark-test-contract-1": "0.0.1",
     "eslint": "5.7.0",
-    "eslint-plugin-react": "7.11.1",
     "mocha-sinon": "1.2.0",
     "npm-run-all": "4.1.5",
     "nyc": "13.1.0",


### PR DESCRIPTION
Move `packages/embark`'s eslint config into the monorepo root.

Remove `"plugin:react/recommended"` since it's not commonly needed.

Put a `"eslintConfig"` config key/object in `packages/embark`'s `package.json` that directs eslint to extend the root config; other `packages/*` can do likewise.