### PR TITLE
fix(@embark/core): Fix VM2 + Remap Imports + Monorepo + Tests

### DIFF
--- a/packages/embark/src/lib/core/engine.js
+++ b/packages/embark/src/lib/core/engine.js
@@ -182,12 +182,7 @@ class Engine {
   }
 
   codeRunnerService(_options) {
-    const CodeRunner = require('./modules/coderunner/codeRunner.js');
-    this.codeRunner = new CodeRunner({
-      config: this.config,
-      plugins: this.plugins,
-      events: this.events,
-      logger: this.logger,
+    this.registerModule('codeRunner', {
       ipc: this.ipc
     });
   }

--- a/packages/embark/src/lib/core/file.ts
+++ b/packages/embark/src/lib/core/file.ts
@@ -1,3 +1,4 @@
+import {__} from "i18n";
 import * as path from "path";
 import { ImportRemapping, prepareForCompilation } from "../utils/solidity/remapImports";
 
@@ -41,15 +42,15 @@ export class File {
     } else if (this.type === Types.http) {
       const external = utils.getExternalContractUrl(options.externalUrl, this.providerUrl);
       this.externalUrl = external.url;
-      this.path = fs.dappPath(external.filePath);
+      this.path = path.normalize(fs.dappPath(external.filePath));
     } else {
-      this.path = options.path.replace(/\\/g, "/");
+      this.path = path.normalize(options.path);
     }
   }
 
   public async prepareForCompilation(isCoverage = false) {
     if (!this.path.endsWith(".sol")) {
-      return Promise.reject("this method is only supported for Solidity files");
+      return Promise.reject(__("This method is only supported for Solidity files"));
     }
     return prepareForCompilation(this, isCoverage);
   }

--- a/packages/embark/src/lib/modules/blockchain_connector/index.js
+++ b/packages/embark/src/lib/modules/blockchain_connector/index.js
@@ -45,6 +45,8 @@ class BlockchainConnector {
       });
     });
 
+    self.events.setCommandHandler("blockchain:ready", self.onReady.bind(this));
+
     self.events.setCommandHandler("blockchain:web3:isReady", (cb) => {
       cb(self.isWeb3Ready);
     });
@@ -68,7 +70,6 @@ class BlockchainConnector {
     this.registerServiceCheck();
     this.registerRequests();
     this.registerAPIRequests();
-    this.registerWeb3Object();
     this.registerEvents();
     this.subscribeToPendingTransactions();
   }
@@ -192,8 +193,9 @@ class BlockchainConnector {
 
   _emitWeb3Ready() {
     this.isWeb3Ready = true;
-    this.events.emit(WEB3_READY);
-    this.registerWeb3Object();
+    this.registerWeb3Object(() => {
+      this.events.emit(WEB3_READY);
+    });
     this.subscribeToPendingTransactions();
   }
 
@@ -690,10 +692,10 @@ class BlockchainConnector {
     });
   }
 
-  registerWeb3Object() {
+  registerWeb3Object(cb = () => {}) {
     // doesn't feel quite right, should be a cmd or plugin method
     // can just be a command without a callback
-    this.events.emit("runcode:register", "web3", this.web3, false);
+    this.events.emit("runcode:register", "web3", this.web3, false, cb);
   }
 
   subscribeToPendingTransactions() {

--- a/packages/embark/src/lib/modules/deployment/contract_deployer.js
+++ b/packages/embark/src/lib/modules/deployment/contract_deployer.js
@@ -340,10 +340,11 @@ class ContractDeployer {
 
 
           self.events.request('code-generator:contract:custom', contract, (contractCode) => {
-            self.events.request('runcode:eval', contractCode, () => {}, true);
-            self.plugins.runActionsForEvent('deploy:contract:deployed', {contract: contract}, () => {
-              return next(null, receipt);
-            });
+            self.events.request('runcode:eval', contractCode, () => {
+              self.plugins.runActionsForEvent('deploy:contract:deployed', {contract: contract}, () => {
+                return next(null, receipt);
+              });
+            }, true);
           });
         }, hash => {
           self.logFunction(contract)(__("deploying") + " " + contract.className.bold.cyan + " " + __("with").green + " " + contract.gas + " " + __("gas at the price of").green + " " + contract.gasPrice + " " + __("Wei, estimated cost:").green + " " + estimatedCost + " Wei".green + " (txHash: " + hash.bold.cyan + ")");

--- a/packages/embark/src/lib/modules/pipeline/index.js
+++ b/packages/embark/src/lib/modules/pipeline/index.js
@@ -292,7 +292,7 @@ class Pipeline {
                 self.logger.trace("reading " + file.path);
                 file.content.then((fileContent) => {
                   self.runPlugins(file, fileContent, fileCb);
-                });
+                }).catch(fileCb);
               },
               function (err, contentFiles) {
                 if (err) {

--- a/packages/embark/src/lib/modules/solidity/index.js
+++ b/packages/embark/src/lib/modules/solidity/index.js
@@ -1,6 +1,5 @@
 let async = require('../../utils/async_extend.js');
 let SolcW = require('./solcW.js');
-const remapImports = require('../../utils/solidity/remapImports');
 
 class Solidity {
 
@@ -177,7 +176,7 @@ class Solidity {
 
             originalFilepath[filename] = file.path;
             
-            remapImports.prepareForCompilation(file, options.isCoverage)
+            file.prepareForCompilation(options.isCoverage)
               .then(fileContent => {
                 input[file.path] = {content: fileContent.replace(/\r\n/g, '\n')};
                 fileCb();

--- a/packages/embark/src/lib/modules/solidity/solcP.js
+++ b/packages/embark/src/lib/modules/solidity/solcP.js
@@ -1,8 +1,5 @@
 const fs = require('fs-extra');
-const path = require('path');
 const semver = require('semver');
-const constants = require('../../constants');
-const Utils = require('../../utils/utils');
 const ProcessWrapper = require('../../core/processes/processWrapper');
 const PluginManager = require('live-plugin-manager-git-fix').PluginManager;
 import LongRunningProcessTimer  from '../../utils/longRunningProcessTimer';
@@ -17,18 +14,8 @@ class SolcProcess extends ProcessWrapper {
   }
 
   findImports(filename) {
-    if (filename.startsWith('http') || filename.startsWith('git')) {
-      const fileObj = Utils.getExternalContractUrl(filename, this._providerUrl);
-      filename = fileObj.filePath;
-    }
     if (fs.existsSync(filename)) {
       return {contents: fs.readFileSync(filename).toString()};
-    }
-    if (fs.existsSync(path.join('./node_modules/', filename))) {
-      return {contents: fs.readFileSync(path.join('./node_modules/', filename)).toString()};
-    }
-    if (fs.existsSync(path.join(constants.httpContractsDirectory, filename))) {
-      return {contents: fs.readFileSync(path.join(constants.httpContractsDirectory, filename)).toString()};
     }
     return {error: 'File not found'};
   }

--- a/packages/embark/src/lib/modules/tests/index.js
+++ b/packages/embark/src/lib/modules/tests/index.js
@@ -16,7 +16,6 @@ class TestRunner {
     this.fs = embark.fs;
     this.ipc = options.ipc;
     this.runResults = [];
-    this.embarkjs = null;
 
     this.events.setCommandHandler('tests:run', (options, callback) => {
       this.run(options, callback);
@@ -173,9 +172,6 @@ class TestRunner {
         const Module = require('module');
         const originalRequire = require('module').prototype.require;
         Module.prototype.require = function (requireName) {
-          if (requireName.startsWith('Embark/EmbarkJS')) {
-            return self.embarkjs;
-          }
           if (requireName.startsWith('Embark')) {
             return test.require(...arguments);
           }
@@ -207,13 +203,7 @@ class TestRunner {
               if (global.embark.needConfig) {
                 global.config({});
               }
-              global.embark.onReady((err) => {
-                if(err) return done(err);
-                self.events.request('runcode:eval', 'EmbarkJS', (err, embarkjs) => {
-                  self.embarkjs = embarkjs;
-                  done(err);
-                });
-              });
+              global.embark.onReady(done);
             });
             mocha.run(function (fails) {
               mocha.suite.removeAllListeners();

--- a/packages/embark/src/lib/modules/tests/solc_test.js
+++ b/packages/embark/src/lib/modules/tests/solc_test.js
@@ -120,10 +120,16 @@ class SolcTest extends Test {
                 methodIdentifiers: contract.functionHashes 
               }
             };
-            remixTests.runTest(contract.className, Test.getWeb3Contract(contract, web3), contractDetails, {accounts},
-              self._prettyPrint.bind(self), _callback);
+            this.getWeb3Contract(contract, web3, (err, web3contract) => {
+              if(err) {
+                return _callback(err);
+              }
+              remixTests.runTest(contract.className, web3contract, contractDetails, {accounts},
+                self._prettyPrint.bind(self), _callback);
+            });
           };
           fns.push(fn);
+        
         });
         async.series(fns, next);
       }

--- a/packages/embark/src/lib/modules/tests/solc_test.js
+++ b/packages/embark/src/lib/modules/tests/solc_test.js
@@ -68,7 +68,7 @@ class SolcTest extends Test {
         async.series(fns, next);
       },
       function resetEmbarkJs(file, next) {
-        self.resetEmbarkJS((err) => {
+        self.events.request("runcode:embarkjs:reset", (err) => {
           next(err, file);
         });
       }
@@ -120,11 +120,11 @@ class SolcTest extends Test {
                 methodIdentifiers: contract.functionHashes 
               }
             };
-            this.getWeb3Contract(contract, web3, (err, web3contract) => {
+            this.getEmbarkJSContract(contract, (err, embarkjsContract) => {
               if(err) {
                 return _callback(err);
               }
-              remixTests.runTest(contract.className, web3contract, contractDetails, {accounts},
+              remixTests.runTest(contract.className, embarkjsContract, contractDetails, {accounts},
                 self._prettyPrint.bind(self), _callback);
             });
           };

--- a/packages/embark/src/lib/modules/tests/test.js
+++ b/packages/embark/src/lib/modules/tests/test.js
@@ -2,13 +2,10 @@ import * as utilsContractsConfig from "../../utils/contractsConfig";
 
 const async = require('async');
 const AccountParser = require('../../utils/accountParser');
-const EmbarkJS = require('embarkjs');
 const utils = require('../../utils/utils');
 const constants = require('../../constants');
 const web3Utils = require('web3-utils');
-const VM = require('../../core/modules/coderunner/vm');
-const Web3 = require('web3');
-const IpfsApi = require("ipfs-api");
+const EmbarkJS = require('embarkjs');
 
 const BALANCE_10_ETHER_IN_HEX = '0x8AC7230489E80000';
 
@@ -32,24 +29,26 @@ class Test {
   }
 
   init(callback) {
-    this.gasLimit = constants.tests.gasLimit;
-    this.events.request('deploy:setGasLimit', this.gasLimit);
-    const waitingForReady = setTimeout(() => {
-      this.logger.warn('Waiting for the blockchain connector to be ready...');
-      // TODO add docs link to how to install one
-      this.logger.warn('If you did not install a blockchain connector, stop this process and install one');
-    }, 5000);
-    this.events.request('blockchain:connector:ready', () => {
-      clearTimeout(waitingForReady);
-      if (this.options.node !== 'embark') {
-        this.showNodeHttpWarning();
-        return callback();
-      }
-      if (!this.ipc.connected) {
-        this.logger.error("Could not connect to Embark's IPC. Is embark running?");
-        if (!this.options.inProcess) process.exit(1);
-      }
-      this.connectToIpcNode(callback);
+    this.events.request('runcode:ready', () => {
+      this.gasLimit = constants.tests.gasLimit;
+      this.events.request('deploy:setGasLimit', this.gasLimit);
+      const waitingForReady = setTimeout(() => {
+        this.logger.warn('Waiting for the blockchain connector to be ready...');
+        // TODO add docs link to how to install one
+        this.logger.warn('If you did not install a blockchain connector, stop this process and install one');
+      }, 5000);
+      this.events.request('blockchain:connector:ready', () => {
+        clearTimeout(waitingForReady);
+        if (this.options.node !== 'embark') {
+          this.showNodeHttpWarning();
+          return callback();
+        }
+        if (!this.ipc.connected) {
+          this.logger.error("Could not connect to Embark's IPC. Is embark running?");
+          if (!this.options.inProcess) process.exit(1);
+        }
+        this.connectToIpcNode(callback);
+      });
     });
   }
 
@@ -229,7 +228,6 @@ class Test {
           }
           self.ready = true;
           self.error = false;
-          self.events.emit('tests:ready');
           next(null, accounts);
         });
       },
@@ -243,31 +241,16 @@ class Test {
         // TODO Do not exit in case of not a normal run (eg after a change)
         if (!self.options.inProcess) process.exit(1);
       }
+      self.events.emit('tests:ready');
       callback(null, accounts);
     });
   }
 
   resetEmbarkJS(cb) {
     this.events.request('blockchain:get', (web3) => {
+      // global web3 used in the tests, not in the vm
       global.web3 = web3;
-      this.vm = new VM({
-        sandbox: {
-          EmbarkJS,
-          web3: web3,
-          Web3: Web3,
-          IpfsApi
-        }
-      });
-      this.events.request("code-generator:embarkjs:provider-code", (code) => {
-        this.vm.doEval(code, false, (err, _result) => {
-          if(err) return cb(err);
-          this.events.request("code-generator:embarkjs:init-provider-code", (code) => {
-            this.vm.doEval(code, false, (err, _result) => {
-              cb(err);
-            });
-          });
-        });
-      });
+      this.events.request("runcode:embarkjs:reset", cb);
     });
   }
 
@@ -339,7 +322,14 @@ class Test {
 
             const testContractFactoryPlugin = self.plugins.getPluginsFor('testContractFactory').slice(-1)[0];
 
-            const newContract = testContractFactoryPlugin ? testContractFactoryPlugin.testContractFactory(contract, web3) : Test.getWeb3Contract(contract, web3);
+            if (!testContractFactoryPlugin) {
+              return self.getWeb3Contract(contract, web3, (err, web3Contract) => {
+                Object.setPrototypeOf(self.contracts[contract.className], web3Contract);
+                eachCb();
+              });
+            }
+
+            const newContract = testContractFactoryPlugin.testContractFactory(contract, web3);
             Object.setPrototypeOf(self.contracts[contract.className], newContract);
 
             eachCb();
@@ -359,7 +349,7 @@ class Test {
     });
   }
 
-  static getWeb3Contract(contract, web3) {
+  getWeb3Contract(contract, web3, cb) {
     const newContract = new EmbarkJS.Blockchain.Contract({
       abi: contract.abiDefinition,
       address: contract.deployedAddress,
@@ -378,11 +368,11 @@ class Test {
       newContract.options.gas = constants.tests.gasLimit;
     }
 
-    return newContract;
+    cb(null, newContract);
   }
 
   require(path) {
-    const [contractsPrefix, embarkJSPrefix] = ['Embark/contracts/', 'Embark/EmbarkJS'];
+    const contractsPrefix = 'Embark/contracts/';
 
     // Contract require
     if (path.startsWith(contractsPrefix)) {
@@ -395,11 +385,6 @@ class Test {
       const newContract = {};
       this.contracts[contractName] = newContract;
       return newContract;
-    }
-
-    // EmbarkJS require
-    if (path.startsWith(embarkJSPrefix)) {
-      return EmbarkJS;
     }
 
     throw new Error(__('Unknown module %s', path));

--- a/packages/embark/src/test/code_generator.js
+++ b/packages/embark/src/test/code_generator.js
@@ -29,6 +29,7 @@ describe('embark.CodeGenerator', function() {
       }
     ];
 
+    const currentSolcVersion = require('../../package.json').dependencies.solc;
     const TestEvents = {
       request: (cmd, cb) => {
         cb(currentSolcVersion);

--- a/packages/embark/src/test/config.js
+++ b/packages/embark/src/test/config.js
@@ -191,13 +191,12 @@ describe('embark.Config', function () {
       const expected = [
         {
           "type": "http",
-          "externalUrl": "https://raw.githubusercontent.com/embark-framework/embark/master/test_dapps/packages/test_app/app/contracts/simple_storage.sol",
-          "path": fs.dappPath(".embark/contracts/embark-framework/embark/master/test_dapps/packages/test_app/app/contracts/simple_storage.sol"),
-          "originalPath": ".embark/contracts/embark-framework/embark/master/test_dapps/packages/test_app/app/contracts/simple_storage.sol",
+          "externalUrl": "https://raw.githubusercontent.com/embark-framework/embark/master/test_dapps/test_app/app/contracts/simple_storage.sol",
+          "path": fs.dappPath(".embark/contracts/embark-framework/embark/master/test_dapps/test_app/app/contracts/simple_storage.sol"),
+          "originalPath": ".embark/contracts/embark-framework/embark/master/test_dapps/test_app/app/contracts/simple_storage.sol",
           "pluginPath": '',
           "basedir": "",
           "importRemappings": [],
-          "isPrepared": false,
           "resolver": undefined,
           "storageConfig": undefined,
           "providerUrl": ""
@@ -210,7 +209,6 @@ describe('embark.Config', function () {
           "pluginPath": '',
           "basedir": "",
           "importRemappings": [],
-          "isPrepared": false,
           "resolver": undefined,
           "storageConfig": undefined,
           "providerUrl": ""
@@ -223,7 +221,6 @@ describe('embark.Config', function () {
           "pluginPath": '',
           "basedir": "",
           "importRemappings": [],
-          "isPrepared": false,
           "resolver": undefined,
           "storageConfig": undefined,
           "providerUrl": ""

--- a/packages/embark/src/test/config.js
+++ b/packages/embark/src/test/config.js
@@ -4,6 +4,7 @@ const Plugins = require('../lib/core/plugins.js');
 const assert = require('assert');
 const TestLogger = require('../lib/utils/test_logger');
 const Events = require('../lib/core/events');
+const fs = require('../lib/core/fs');
 
 describe('embark.Config', function () {
   let config = new Config({
@@ -190,12 +191,13 @@ describe('embark.Config', function () {
       const expected = [
         {
           "type": "http",
-          "externalUrl": "https://raw.githubusercontent.com/embark-framework/embark/master/test_dapps/test_app/app/contracts/simple_storage.sol",
-          "path": ".embark/contracts/embark-framework/embark/master/test_dapps/test_app/app/contracts/simple_storage.sol",
-          "originalPath": ".embark/contracts/embark-framework/embark/master/test_dapps/test_app/app/contracts/simple_storage.sol",
+          "externalUrl": "https://raw.githubusercontent.com/embark-framework/embark/master/test_dapps/packages/test_app/app/contracts/simple_storage.sol",
+          "path": fs.dappPath(".embark/contracts/embark-framework/embark/master/test_dapps/packages/test_app/app/contracts/simple_storage.sol"),
+          "originalPath": ".embark/contracts/embark-framework/embark/master/test_dapps/packages/test_app/app/contracts/simple_storage.sol",
           "pluginPath": '',
           "basedir": "",
           "importRemappings": [],
+          "isPrepared": false,
           "resolver": undefined,
           "storageConfig": undefined,
           "providerUrl": ""
@@ -203,23 +205,25 @@ describe('embark.Config', function () {
         {
           "type": "http",
           "externalUrl": "https://raw.githubusercontent.com/status-im/contracts/master/contracts/identity/ERC725.sol",
-          "path": ".embark/contracts/status-im/contracts/master/contracts/identity/ERC725.sol",
+          "path": fs.dappPath(".embark/contracts/status-im/contracts/master/contracts/identity/ERC725.sol"),
           "originalPath": ".embark/contracts/status-im/contracts/master/contracts/identity/ERC725.sol",
           "pluginPath": '',
           "basedir": "",
           "importRemappings": [],
+          "isPrepared": false,
           "resolver": undefined,
           "storageConfig": undefined,
           "providerUrl": ""
         },
         {
           "externalUrl": "https://swarm-gateways.net/bzz:/1ffe993abc835f480f688d07ad75ad1dbdbd1ddb368a08b7ed4d3e400771dd63",
-          "path": ".embark/contracts/bzz:/1ffe993abc835f480f688d07ad75ad1dbdbd1ddb368a08b7ed4d3e400771dd63",
+          "path": fs.dappPath(".embark/contracts/bzz:/1ffe993abc835f480f688d07ad75ad1dbdbd1ddb368a08b7ed4d3e400771dd63"),
           "originalPath": ".embark/contracts/bzz:/1ffe993abc835f480f688d07ad75ad1dbdbd1ddb368a08b7ed4d3e400771dd63",
           "type": "http",
           "pluginPath": '',
           "basedir": "",
           "importRemappings": [],
+          "isPrepared": false,
           "resolver": undefined,
           "storageConfig": undefined,
           "providerUrl": ""

--- a/packages/embark/src/test/console.js
+++ b/packages/embark/src/test/console.js
@@ -7,7 +7,7 @@ let version = require('../../package.json').version;
 
 describe('embark.Console', function() {
   let ipc = new IPC({ipcRole: 'none'});
-  let events = {once: () => {}, setCommandHandler: () => {}, emit: () => {}, on: () => {}};
+  let events = {once: () => {}, setCommandHandler: () => {}, emit: () => {}, on: () => {}, request: () => {}};
   let plugins = new Plugins({plugins: {}, events: events});
   let embarkObject = {
     registerAPICall: () => {},

--- a/packages/embark/src/test/file.js
+++ b/packages/embark/src/test/file.js
@@ -1,0 +1,42 @@
+/*globals describe, it, before*/
+const {File, Types} = require("../lib/core/file");
+const path = require("path");
+const {expect, assert} = require("chai");
+const fs = require("../lib/core/fs");
+const fsNode = require("fs");
+
+describe('embark.File', function () {
+  describe('Read file contents', function () {
+    it('should be able to download a file when type is "http"', async () => {
+      const file = new File({externalUrl: 'https://raw.githubusercontent.com/embark-framework/embark/master/test_apps/test_app/app/contracts/simple_storage.sol', type: Types.http});
+      const content = await file.content;
+
+      const contentFromFileSystem = fsNode.readFileSync(path.join(fs.embarkPath(), "../../", "test_dapps/packages/test_app/app/contracts/simple_storage.sol")).toString();
+      expect(content).to.equal(contentFromFileSystem);
+    });
+
+    it('should be able to read a file when type is "dappFile"', async () => {
+      const file = new File({path: fs.dappPath('contracts/recursive_test_0.sol'), type: Types.dappFile});
+      const content = await file.content;
+
+      const contentFromFileSystem = fs.readFileSync(fs.dappPath("contracts/recursive_test_0.sol")).toString();
+      expect(content).to.equal(contentFromFileSystem);
+    });
+
+    it('should be able to execute a resolver when type is "custom"', async () => {
+      const file = new File({path: fs.dappPath('contracts/recursive_test_0.sol'), type: Types.custom, resolver: (callback) => {
+        callback("test");
+      }});
+      expect(await file.content).to.equal("test");
+    });
+
+    it('should be able to read a file when type is "embarkInternal"', async () => {
+      const file = new File({path: 'test/contracts/recursive_test_0.sol', type: Types.embarkInternal});
+      const content = await file.content;
+
+      const contentFromFileSystem = fs.readFileSync(fs.dappPath("contracts/recursive_test_0.sol")).toString();
+      expect(content).to.equal(contentFromFileSystem);
+    });
+
+  });
+});

--- a/packages/embark/src/test/file.js
+++ b/packages/embark/src/test/file.js
@@ -1,17 +1,17 @@
-/*globals describe, it, before*/
+/*globals describe, it*/
 const {File, Types} = require("../lib/core/file");
 const path = require("path");
-const {expect, assert} = require("chai");
+const {expect} = require("chai");
 const fs = require("../lib/core/fs");
 const fsNode = require("fs");
 
 describe('embark.File', function () {
   describe('Read file contents', function () {
     it('should be able to download a file when type is "http"', async () => {
-      const file = new File({externalUrl: 'https://raw.githubusercontent.com/embark-framework/embark/master/test_apps/test_app/app/contracts/simple_storage.sol', type: Types.http});
+      const file = new File({externalUrl: 'https://raw.githubusercontent.com/embark-framework/embark/master/test_dapps/test_app/app/contracts/simple_storage.sol', type: Types.http});
       const content = await file.content;
 
-      const contentFromFileSystem = fsNode.readFileSync(path.join(fs.embarkPath(), "../../", "test_dapps/packages/test_app/app/contracts/simple_storage.sol")).toString();
+      const contentFromFileSystem = fsNode.readFileSync(path.join(fs.embarkPath(), "../../", "test_dapps/test_app/app/contracts/simple_storage.sol")).toString();
       expect(content).to.equal(contentFromFileSystem);
     });
 

--- a/packages/embark/src/test/modules/solidity/remapImports.js
+++ b/packages/embark/src/test/modules/solidity/remapImports.js
@@ -18,42 +18,42 @@ describe('embark.RemapImports', function () {
     it("should find and add remappings for all recursive imports", (done) => {
       expect(file.importRemappings[0]).to.deep.equal({
         prefix: "./recursive_test_1.sol",
-        target: fs.dappPath(".embark/contracts/recursive_test_1.sol")
+        target: path.normalize(fs.dappPath(".embark/contracts/recursive_test_1.sol"))
       });
       expect(file.importRemappings[1]).to.deep.equal({
         prefix: "./recursive_test_2.sol",
-        target: fs.dappPath(".embark/contracts/recursive_test_2.sol")
+        target: path.normalize(fs.dappPath(".embark/contracts/recursive_test_2.sol"))
       });
       expect(file.importRemappings[2]).to.deep.equal({
         prefix: "embark-test-contract-0/recursive_test_3.sol",
-        target: fs.dappPath(".embark/node_modules/embark-test-contract-0/recursive_test_3.sol")
+        target: path.normalize(fs.dappPath(".embark/node_modules/embark-test-contract-0/recursive_test_3.sol"))
       });
       expect(file.importRemappings[3]).to.deep.equal({
         prefix: "embark-test-contract-1/recursive_test_4.sol",
-        target: fs.dappPath(".embark/node_modules/embark-test-contract-1/recursive_test_4.sol")
+        target: path.normalize(fs.dappPath(".embark/node_modules/embark-test-contract-1/recursive_test_4.sol"))
       });
       done();
     });
 
     it("should update the contract content to use the remapped imports", function (done) {
       expect(content).to.not.contain("./recursive_test_1.sol");
-      expect(content).to.contain(".embark/contracts/recursive_test_1.sol");
+      expect(content).to.contain(path.normalize(".embark/contracts/recursive_test_1.sol").replace(/\\/g, "/"));
 
       let contractFromFilesystem = fsNode.readFileSync(fs.dappPath(".embark/contracts/recursive_test_0.sol")).toString();
       expect(contractFromFilesystem).to.not.contain("./recursive_test_1.sol");
-      expect(contractFromFilesystem).to.contain(".embark/contracts/recursive_test_1.sol");
+      expect(contractFromFilesystem).to.contain(path.normalize(".embark/contracts/recursive_test_1.sol").replace(/\\/g, "/"));
       
       contractFromFilesystem = fsNode.readFileSync(fs.dappPath(".embark/contracts/recursive_test_1.sol")).toString();
       expect(contractFromFilesystem).to.not.contain("./recursive_test_2.sol");
-      expect(contractFromFilesystem).to.contain(".embark/contracts/recursive_test_2.sol");
+      expect(contractFromFilesystem).to.contain(path.normalize(".embark/contracts/recursive_test_2.sol").replace(/\\/g, "/"));
 
       contractFromFilesystem = fsNode.readFileSync(fs.dappPath(".embark/contracts/recursive_test_2.sol")).toString();
       expect(contractFromFilesystem).to.not.contain("import \"embark-test-contract-0/recursive_test_3.sol\"");
-      expect(contractFromFilesystem).to.contain(`import "${fs.dappPath(".embark/node_modules/embark-test-contract-0/recursive_test_3.sol")}"`);
+      expect(contractFromFilesystem).to.contain(`import "${path.normalize(fs.dappPath(".embark/node_modules/embark-test-contract-0/recursive_test_3.sol")).replace(/\\/g, "/")}"`);
       
       contractFromFilesystem = fsNode.readFileSync(fs.dappPath(".embark/node_modules/embark-test-contract-0/recursive_test_3.sol")).toString();
       expect(contractFromFilesystem).to.not.contain("import \"embark-test-contract-1/recursive_test_4.sol\"");
-      expect(contractFromFilesystem).to.contain(`import "${fs.dappPath(".embark/node_modules/embark-test-contract-1/recursive_test_4.sol")}"`);
+      expect(contractFromFilesystem).to.contain(`import "${path.normalize(fs.dappPath(".embark/node_modules/embark-test-contract-1/recursive_test_4.sol")).replace(/\\/g, "/")}"`);
       
       done();
     });
@@ -62,41 +62,41 @@ describe('embark.RemapImports', function () {
 
   describe('Import remappings from external URL', function () {
     before('do the external HTTP contract remappings', async () => {
-      file = new File({externalUrl: 'https://github.com/embark-framework/embark/blob/master/src/test/contracts/recursive_test_0.sol', type: Types.http});
+      file = new File({externalUrl: 'https://github.com/embark-framework/embark/master/packages/embark/src/test/contracts/recursive_test_0.sol', type: Types.http});
       content = await remapImports.prepareForCompilation(file);
     });
 
     it("should find and add remappings for all recursive imports", (done) => {
       expect(file.importRemappings[0]).to.deep.equal({
         prefix: "./recursive_test_1.sol",
-        target: fs.dappPath(".embark/contracts/embark-framework/embark/master/src/test/contracts/recursive_test_1.sol")
+        target: path.normalize(fs.dappPath(".embark/contracts/embark-framework/embark/master/packages/embark/src/test/contracts/recursive_test_1.sol"))
       });
       expect(file.importRemappings[1]).to.deep.equal({
         prefix: "./recursive_test_2.sol",
-        target: fs.dappPath(".embark/contracts/embark-framework/embark/master/src/test/contracts/recursive_test_2.sol")
+        target: path.normalize(fs.dappPath(".embark/contracts/embark-framework/embark/master/packages/embark/src/test/contracts/recursive_test_2.sol"))
       });
       expect(file.importRemappings[2]).to.deep.equal({
         prefix: "embark-test-contract-0/recursive_test_3.sol",
-        target: fs.dappPath(".embark/contracts/embark-framework/embark/master/src/test/contracts/embark-test-contract-0/recursive_test_3.sol")
+        target: path.normalize(fs.dappPath(".embark/contracts/embark-framework/embark/master/packages/embark/src/test/contracts/embark-test-contract-0/recursive_test_3.sol"))
       });
       done();
     });
 
     it("should update the contract content to use the remapped imports", function (done) {
       expect(content).to.not.contain("./recursive_test_1.sol");
-      expect(content).to.contain(".embark/contracts/embark-framework/embark/master/src/test/contracts/recursive_test_1.sol");
+      expect(content).to.contain(path.normalize(".embark/contracts/embark-framework/embark/master/packages/embark/src/test/contracts/recursive_test_1.sol").replace(/\\/g, "/"));
 
-      let contractFromFilesystem = fsNode.readFileSync(fs.dappPath(".embark/contracts/embark-framework/embark/master/src/test/contracts/recursive_test_0.sol")).toString();
+      let contractFromFilesystem = fsNode.readFileSync(fs.dappPath(".embark/contracts/embark-framework/embark/master/packages/embark/src/test/contracts/recursive_test_0.sol")).toString();
       expect(contractFromFilesystem).to.not.contain("./recursive_test_1.sol");
-      expect(contractFromFilesystem).to.contain(".embark/contracts/embark-framework/embark/master/src/test/contracts/recursive_test_1.sol");
+      expect(contractFromFilesystem).to.contain(path.normalize(".embark/contracts/embark-framework/embark/master/packages/embark/src/test/contracts/recursive_test_1.sol").replace(/\\/g, "/"));
       
-      contractFromFilesystem = fsNode.readFileSync(fs.dappPath(".embark/contracts/embark-framework/embark/master/src/test/contracts/recursive_test_1.sol")).toString();
+      contractFromFilesystem = fsNode.readFileSync(fs.dappPath(".embark/contracts/embark-framework/embark/master/packages/embark/src/test/contracts/recursive_test_1.sol")).toString();
       expect(contractFromFilesystem).to.not.contain("./recursive_test_2.sol");
-      expect(contractFromFilesystem).to.contain(".embark/contracts/embark-framework/embark/master/src/test/contracts/recursive_test_2.sol");
+      expect(contractFromFilesystem).to.contain(path.normalize(".embark/contracts/embark-framework/embark/master/packages/embark/src/test/contracts/recursive_test_2.sol").replace(/\\/g, "/"));
 
-      contractFromFilesystem = fsNode.readFileSync(fs.dappPath(".embark/contracts/embark-framework/embark/master/src/test/contracts/recursive_test_2.sol")).toString();
+      contractFromFilesystem = fsNode.readFileSync(fs.dappPath(".embark/contracts/embark-framework/embark/master/packages/embark/src/test/contracts/recursive_test_2.sol")).toString();
       expect(contractFromFilesystem).to.not.contain("import \"embark-test-contract-0/recursive_test_3.sol\"");
-      expect(contractFromFilesystem).to.contain(`import "${fs.dappPath(".embark/contracts/embark-framework/embark/master/src/test/contracts/embark-test-contract-0/recursive_test_3.sol")}"`);
+      expect(contractFromFilesystem).to.contain(`import "${path.normalize(fs.dappPath(".embark/contracts/embark-framework/embark/master/packages/embark/src/test/contracts/embark-test-contract-0/recursive_test_3.sol")).replace(/\\/g, "/")}"`);
 
       done();
     });

--- a/packages/embark/src/test/modules/solidity/remapImports.js
+++ b/packages/embark/src/test/modules/solidity/remapImports.js
@@ -1,0 +1,105 @@
+/*globals describe, it, before*/
+const {File, Types} = require("../../../lib/core/file");
+const path = require("path");
+const remapImports = require("../../../lib/utils/solidity/remapImports");
+const {expect} = require("chai");
+const fs = require("../../../lib/core/fs");
+const fsNode = require("fs");
+
+let file, content;
+
+describe('embark.RemapImports', function () {
+  describe('Import remappings from local file', function () {
+    before('do the remappings', async () => {
+      file = new File({path: 'contracts/recursive_test_0.sol', type: Types.dappFile});
+      content = await remapImports.prepareForCompilation(file);
+    });
+
+    it("should find and add remappings for all recursive imports", (done) => {
+      expect(file.importRemappings[0]).to.deep.equal({
+        prefix: "./recursive_test_1.sol",
+        target: fs.dappPath(".embark/contracts/recursive_test_1.sol")
+      });
+      expect(file.importRemappings[1]).to.deep.equal({
+        prefix: "./recursive_test_2.sol",
+        target: fs.dappPath(".embark/contracts/recursive_test_2.sol")
+      });
+      expect(file.importRemappings[2]).to.deep.equal({
+        prefix: "embark-test-contract-0/recursive_test_3.sol",
+        target: fs.dappPath(".embark/node_modules/embark-test-contract-0/recursive_test_3.sol")
+      });
+      expect(file.importRemappings[3]).to.deep.equal({
+        prefix: "embark-test-contract-1/recursive_test_4.sol",
+        target: fs.dappPath(".embark/node_modules/embark-test-contract-1/recursive_test_4.sol")
+      });
+      done();
+    });
+
+    it("should update the contract content to use the remapped imports", function (done) {
+      expect(content).to.not.contain("./recursive_test_1.sol");
+      expect(content).to.contain(".embark/contracts/recursive_test_1.sol");
+
+      let contractFromFilesystem = fsNode.readFileSync(fs.dappPath(".embark/contracts/recursive_test_0.sol")).toString();
+      expect(contractFromFilesystem).to.not.contain("./recursive_test_1.sol");
+      expect(contractFromFilesystem).to.contain(".embark/contracts/recursive_test_1.sol");
+      
+      contractFromFilesystem = fsNode.readFileSync(fs.dappPath(".embark/contracts/recursive_test_1.sol")).toString();
+      expect(contractFromFilesystem).to.not.contain("./recursive_test_2.sol");
+      expect(contractFromFilesystem).to.contain(".embark/contracts/recursive_test_2.sol");
+
+      contractFromFilesystem = fsNode.readFileSync(fs.dappPath(".embark/contracts/recursive_test_2.sol")).toString();
+      expect(contractFromFilesystem).to.not.contain("import \"embark-test-contract-0/recursive_test_3.sol\"");
+      expect(contractFromFilesystem).to.contain(`import "${fs.dappPath(".embark/node_modules/embark-test-contract-0/recursive_test_3.sol")}"`);
+      
+      contractFromFilesystem = fsNode.readFileSync(fs.dappPath(".embark/node_modules/embark-test-contract-0/recursive_test_3.sol")).toString();
+      expect(contractFromFilesystem).to.not.contain("import \"embark-test-contract-1/recursive_test_4.sol\"");
+      expect(contractFromFilesystem).to.contain(`import "${fs.dappPath(".embark/node_modules/embark-test-contract-1/recursive_test_4.sol")}"`);
+      
+      done();
+    });
+
+  });
+
+  describe('Import remappings from external URL', function () {
+    before('do the external HTTP contract remappings', async () => {
+      file = new File({externalUrl: 'https://github.com/embark-framework/embark/blob/master/src/test/contracts/recursive_test_0.sol', type: Types.http});
+      content = await remapImports.prepareForCompilation(file);
+    });
+
+    it("should find and add remappings for all recursive imports", (done) => {
+      expect(file.importRemappings[0]).to.deep.equal({
+        prefix: "./recursive_test_1.sol",
+        target: fs.dappPath(".embark/contracts/embark-framework/embark/master/src/test/contracts/recursive_test_1.sol")
+      });
+      expect(file.importRemappings[1]).to.deep.equal({
+        prefix: "./recursive_test_2.sol",
+        target: fs.dappPath(".embark/contracts/embark-framework/embark/master/src/test/contracts/recursive_test_2.sol")
+      });
+      expect(file.importRemappings[2]).to.deep.equal({
+        prefix: "embark-test-contract-0/recursive_test_3.sol",
+        target: fs.dappPath(".embark/contracts/embark-framework/embark/master/src/test/contracts/embark-test-contract-0/recursive_test_3.sol")
+      });
+      done();
+    });
+
+    it("should update the contract content to use the remapped imports", function (done) {
+      expect(content).to.not.contain("./recursive_test_1.sol");
+      expect(content).to.contain(".embark/contracts/embark-framework/embark/master/src/test/contracts/recursive_test_1.sol");
+
+      let contractFromFilesystem = fsNode.readFileSync(fs.dappPath(".embark/contracts/embark-framework/embark/master/src/test/contracts/recursive_test_0.sol")).toString();
+      expect(contractFromFilesystem).to.not.contain("./recursive_test_1.sol");
+      expect(contractFromFilesystem).to.contain(".embark/contracts/embark-framework/embark/master/src/test/contracts/recursive_test_1.sol");
+      
+      contractFromFilesystem = fsNode.readFileSync(fs.dappPath(".embark/contracts/embark-framework/embark/master/src/test/contracts/recursive_test_1.sol")).toString();
+      expect(contractFromFilesystem).to.not.contain("./recursive_test_2.sol");
+      expect(contractFromFilesystem).to.contain(".embark/contracts/embark-framework/embark/master/src/test/contracts/recursive_test_2.sol");
+
+      contractFromFilesystem = fsNode.readFileSync(fs.dappPath(".embark/contracts/embark-framework/embark/master/src/test/contracts/recursive_test_2.sol")).toString();
+      expect(contractFromFilesystem).to.not.contain("import \"embark-test-contract-0/recursive_test_3.sol\"");
+      expect(contractFromFilesystem).to.contain(`import "${fs.dappPath(".embark/contracts/embark-framework/embark/master/src/test/contracts/embark-test-contract-0/recursive_test_3.sol")}"`);
+
+      done();
+    });
+  });
+
+});

--- a/packages/embark/src/test/vm.js
+++ b/packages/embark/src/test/vm.js
@@ -1,6 +1,6 @@
 /*globals describe, it*/
 const TestLogger = require('../lib/utils/test_logger');
-const VM = require('../lib/core/modules/coderunner/vm');
+const VM = require('../lib/modules/codeRunner/vm');
 const {expect} = require('chai');
 
 describe('embark.vm', function () {

--- a/packages/embarkjs/src/blockchain.js
+++ b/packages/embarkjs/src/blockchain.js
@@ -47,6 +47,18 @@ Blockchain.connect = function(options, callback) {
   return connect(options);
 };
 
+Blockchain.connectConsole = function(doneCb) {
+  this.doFirst((cb) => {
+    this.blockchainConnector.getAccounts((err, accounts) => {
+      if (accounts) {
+        this.blockchainConnector.setDefaultAccount(accounts[0]);
+      }
+      cb(err);
+      doneCb(err);
+    });
+  });
+};
+
 Blockchain.doFirst = function(todo) {
   todo((err) => {
     this.done = true;

--- a/packages/web3Connector/index.js
+++ b/packages/web3Connector/index.js
@@ -29,12 +29,18 @@ function getWeb3Location(embark) {
 }
 
 module.exports = async (embark) => {
+  let blockchainConnectorReady = false;
   await whenRuncodeReady(embark);
 
   const web3LocationPromise = getWeb3Location(embark);
 
   embark.events.setCommandHandler('blockchain:connector:ready', (cb) => {
+    if (blockchainConnectorReady) {
+      return cb();
+    }
     web3LocationPromise.then((_web3Location) => {
+      blockchainConnectorReady = true;
+      embark.events.emit('blockchain:connector:ready');
       cb();
     });
   });
@@ -54,11 +60,11 @@ module.exports = async (embark) => {
 
   code += "\nEmbarkJS.Blockchain.registerProvider('web3', web3Connector);";
 
-  code += "\nEmbarkJS.Blockchain.setProvider('web3', {});";
+  code += "\nEmbarkJS.Blockchain.setProvider('web3', {web3});";
 
   embark.addCodeToEmbarkJS(code);
 
-  code = "EmbarkJS.Blockchain.setProvider('web3', {});";
+  code = "EmbarkJS.Blockchain.setProvider('web3', {web3});";
 
   const shouldInit = (_config) => {
     return true;

--- a/packages/web3Connector/web3Connector.js
+++ b/packages/web3Connector/web3Connector.js
@@ -2,6 +2,7 @@
 const web3Connector = {};
 
 web3Connector.init = function(_config) {
+  global.web3 = config.web3 || global.web3;
   // Check if the global web3 object uses the old web3 (0.x)
   if (global.web3 && typeof global.web3.version !== 'string') {
     // If so, use a new instance using 1.0, but use its provider

--- a/packages/web3Connector/web3Connector.js
+++ b/packages/web3Connector/web3Connector.js
@@ -1,7 +1,7 @@
 /*global Web3*/
 const web3Connector = {};
 
-web3Connector.init = function(_config) {
+web3Connector.init = function(config) {
   global.web3 = config.web3 || global.web3;
   // Check if the global web3 object uses the old web3 (0.x)
   if (global.web3 && typeof global.web3.version !== 'string') {


### PR DESCRIPTION
## Scope
This PR introduces a large number of changes (for that, I am very sorry). Breaking this up in to smaller PR's was causing tests to fail, and the likelihood of them getting merged diminished. There are a couple of PRs this PR closes, and as such, I have kept the original commits to preserve the history. The first two (of three) commits are the closed PRs, and the last is the glue bringing it all together.

The main goal of this PR is to fix the fragility of the tests with EmbarkJS, however in doing so, a number of recent features have been updated:
#### Remap imports
Remapping of imports still had a few edge cases that needed to be ironed out, as well as have unit tests created for them. More details of the changes an be seen in the closed PR (below).
#### VM2 + console
The main issue with VM2 was running the code generated EmbarkJS code inside the VM, and getting EmbarkJS contracts out of the VM and available to the tests. This fixed issues where ENS may not have been available to the tests. Notable additions include adding `EmbarkJS.Blockchain.connectTests` to the tests lifecycle, and ensuring `EmbarkJS` is only ever required in the console module and not used or passed around elsewhere.
#### Tests in a monorepo context
The main issue with the tests in the context of a monorepo seemed to appear with embark running as module inside the dapp’s `node_modules`, there were issues getting the correct contract state available inside of the tests (as mentioned above). For some reason, this particular case was causing the tests to fail, with ENS never being available (assuming this to be an issue with `EmbarkJS.Blockchain.connect()` never being called). The main fix for this came with passing `web3` as an option in to `EmbarkJS.Blockchain.setProvider()`.

## Events introduced

1. `runcode:ready` - VM is ready to eval commands. This event can be requested to ensure the VM has been setup and can receive code to eval.
2. `console:providers:ready` - console has been fully initialised with blockchain provider (ie `web3`) and `EmbarkJS` and is ready to accept commands. Anything that relies on a blockchain provider (ie `web3` or `EmbarkJS` should wait for this event.
3. `blockchain:ready` - blockchain provider (ie web3) has been initialised with the dapps config. It is available for other commands such as `blockchain:getAccounts` and is available in the console.

## Closes PRs
1. https://github.com/embark-framework/embark/pull/1286
2. https://github.com/embark-framework/embark/pull/1275
Go to bottom for details

## Known issues
There are few known issues with this PR. Instead of trying to fix all of them with this PR, I was hoping to get these issues tackled in separate PRs.
1. `deployIf` directive on contracts defined in the config are not working, however the tests are passing. The issue is that if `ContractA` has a `deployIf` set to `!!ContractB.options.address`, it means that it will not deploy if `ContractB` is not deployed. However, it appears that `ContractA` is attempted to be deployed prior to `ContractB` being deployed, and therefore `ContractA` fails to deploy. Instead, because `ContractA` depends on `ContractB`, `ContractB` should be deployed before `ContractA`.
2. `embark test --node embark` does not seem to be functioning for reasons unknown.
3. Remix tests: Currently there is support for adding contract tests that get process by `remix-tests`, however, there is an error that I believe is not due to embark, but due to the Assert library. For example, if we add a `test/remix_test.sol` to the `test_app` with the following content:
```
pragma solidity ^0.4.24;

import "remix_tests.sol";
import "../app/contracts/simple_storage.sol";

contract SimpleStorageTest {
  SimpleStorage simpleStorage;

  function beforeAll() public {
    simpleStorage = new SimpleStorage(100);
  }

  function initialValueShouldBeCorrect() public {
    return Assert.equal(
      100,
      simpleStorage.storedData,
      "stored data is not what I expected"
    );
  }
}
```
After compilation, we would get the error:
```
remix_test.sol:14:12: TypeError: Member "equal" not found or not visible after argument-dependent lookup in type(library Assert)
    return Assert.equal(
           ^—————^
```

## NBs
This branch is based off of ()`refactor/embarkjs-in-monorepo`)[https://github.com/embark-framework/embark/tree/refactor/embarkjs-in-monorepo], which does not have passing tests due to the `EmbarkJS` ENS issue mentioned above. However, you should (hopefully) see the tests passing in this branch, meaning if both branches are merged, the tests should be passing.
Related PRs: https://github.com/embark-framework/embark-solc/pull/24


## Closed PR details
### [Remap imports updates PR](https://github.com/embark-framework/embark/pull/1286)

#### Scope
Changes include:
1. Add unit tests for recursively remapping imports
2. Handle plugin contracts correctly
3. Allow `prepareForCompilation` to be called from `File`, allowing for external compilers, like `embark-solc` to call this function before compilation.
4. Add flattened remappings to `File` that gets prepared for compilation (ie has it's imports remapped)
5. Return remapped contract content when file type is http. Previously this was broken, as always freshly downloaded (original) content was returned.
6. Handle additional cases for `custom` and http file types.

#### Tested with
This PR was tested with:
- `embark` unit tests
- `embark` test_app
- `embark` test_app with `embark-solc` plugin
- `embark` test_app with `embark-flattener` plugin
- `Giveth/lpp-campaign`

#### Related changes
Related change to get `embark-solc` up-to-date with these changes: https://github.com/embark-framework/embark-solc/pull/24

### [Monorepo tests PR](https://github.com/embark-framework/embark/pull/1275)

#### Scope
When embark was running as module inside the dapp’s `node_modules`, the tests were failing due to several issues:
1. `web3` was not being set in the global namespace of vm2. `EmbarkJS.Blockchain.setProvider` was therefore failing because it relies on `global.web3` to be set. I guess somehow this works when the test app was running in a child tree of the executing program. maybe this is a security feature of vm2, but i’m not sure.
2. `embarkjs` provider code being injected to the vm twice. This really was the initial point of failure, as this piece of code is requiring embarkjs, so i’m assuming, but again not sure, that maybe it was getting a second instance of `EmbarkJS` which did not have it’s providers set up correctly (hence the error with `ENS provider not set`).

Fixes for those issues in this PR:
1. To circumvent the web3 issue, we are now setting `global.web3` for tests only (the global web3 accessible in the tests), and `web3` is now explicitly passed in to `EmbarkJS.Blockchain.setProvider`
2. To fix the `embarkjs` code being called twice, we are not re-injecting this code to the VM during test initialisations