### PR TITLE
fix(@embark/solidity): ensure SolidityProcess receives proper Logger …

### DIFF
--- a/packages/embark/src/lib/modules/solidity/solcP.js
+++ b/packages/embark/src/lib/modules/solidity/solcP.js
@@ -80,6 +80,7 @@ class SolcProcess extends ProcessWrapper {
 let solcProcess;
 process.on('message', (msg) => {
   if (msg.action === "init") {
+    msg.options.logger = console;
     solcProcess = new SolcProcess(msg.options);
     return process.send({result: "initiated"});
   }

--- a/packages/embark/src/lib/modules/solidity/solcW.js
+++ b/packages/embark/src/lib/modules/solidity/solcW.js
@@ -69,7 +69,7 @@ class SolcW {
       done();
     });
 
-    this.solcProcess.send({action: "init", options: {logger: self.logger, showSpinner: !self.useDashboard}});
+    this.solcProcess.send({action: "init", options: {showSpinner: !self.useDashboard}});
 
     if (this.ipc.isServer()) {
       this.ipc.on('compile', self.compile.bind(this));

--- a/packages/embark/src/lib/utils/longRunningProcessTimer.ts
+++ b/packages/embark/src/lib/utils/longRunningProcessTimer.ts
@@ -84,7 +84,7 @@ export default class LongRunningProcessTimer {
         }
 
         // log our measurement and make it red if it has taken too long
-        if (!this.options.showSpinner && entry && strDuration && this.options && this.options.longRunningThreshold) {
+        if (!this.options.showSpinner && entry && strDuration !== undefined && this.options && this.options.longRunningThreshold) {
           if (entry.duration > this.options.longRunningThreshold) {
             strDuration = strDuration.red;
           }


### PR DESCRIPTION
…instance

Prior to this commit Embark had a bug where, when running `$ embark run` inside
an Embark project that was freshly cloned or reset, it'd get stuck at loading
the Solidity compiler.

However, this only seemed to happen when Embark was used with its dashboard. When
running

```
$ embark run --nodashboard
```

instead, Embark loaded Solidity successfully and moved on with compilation.

This bug pretty much boiled down to `SolidityProcess` not receiving a valid `Logger`
dependency when instantiated via `SolcW`. The reason this was happening
is that we were sending the needed dependencies via `ProcessLauncher.send()`, which
serializes/deserializes its sent data.

```
solidityProcessLauncher.send({action: 'init', options: { logger: this.logger }});
```

And inside `SolidityProcess`

```
process.on('message', (msg) => {
  if (msg.action === "init") {
    solcProcess = new SolcProcess(msg.options);
  }
  ...
}
```

`SolcProcess` passes its `logger` instance down to `longRunningProcessTimer` which
uses methods on `Logger`.

However, since the data had been serialized, all prototype methods on the data is
gone, resulting in an error, which made Embark stop.

**Why was this only a problem when using the dashboard?**

Turns out we've only relied on `Logger.info()` in case the dashboard is used.