### PR TITLE
build(embarkjs): clean script should invoke 'npx rimraf'

### DIFF
--- a/packages/embarkjs/package.json
+++ b/packages/embarkjs/package.json
@@ -35,7 +35,7 @@
     "build:node:async": "cross-env BABEL_ENV=node:async babel src/node --out-dir dist --root-mode upward --source-maps",
     "build:node:test": "cross-env BABEL_ENV=node:test babel test --out-dir build-test --root-mode upward --source-maps",
     "ci": "npm run qa",
-    "clean": "rimraf build-test dist embarkjs-*.tgz package",
+    "clean": "npx rimraf build-test dist embarkjs-*.tgz package",
     "package": "npm pack",
     "qa": "npm-run-all build test package",
     "reset": "npm run clean && npx rimraf node_modules",
@@ -57,7 +57,7 @@
     "lodash.clonedeep": "4.5.0",
     "mocha": "5.2.0",
     "npm-run-all": "4.1.5",
-    "rimraf": "2.6.2",
+    "rimraf": "2.6.3",
     "source-map-support": "0.5.9",
     "web3": "1.0.0-beta.37"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -18790,7 +18790,7 @@ right-align@^0.1.1:
   dependencies:
     align-text "^0.1.1"
 
-rimraf@2, rimraf@2.6.2, rimraf@^2.2.8, rimraf@^2.5.4, rimraf@^2.6.1, rimraf@^2.6.2, rimraf@~2.6.2:
+rimraf@2, rimraf@^2.2.8, rimraf@^2.5.4, rimraf@^2.6.1, rimraf@^2.6.2, rimraf@~2.6.2:
   version "2.6.2"
   resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-2.6.2.tgz#2ed8150d24a16ea8651e6d6ef0f47c4158ce7a36"
   integrity sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==


### PR DESCRIPTION
Packages' `"clean"` scripts should run regardless of whether `node_modules` is in place at the root and/or package levels, but the `embarkjs` package was missing a needed `npx` in front of `rimraf` in its script.

Also, bump its devDeps version of rimraf to be in line with the rest of `packages/*` and `test_dapps/*`.