### PR TITLE
build: specify a high network timeout in root .yarnc

### DIFF
--- a/.yarnrc
+++ b/.yarnrc
@@ -1,2 +1,3 @@
 --*.scripts-prepend-node-path true
 --install.check-files true
+--install.network-timeout 600000


### PR DESCRIPTION
Yarn can be sensitive to timeouts when downloading large-ish packages that aren't in its cache, e.g. `@reactivex/rxjs`. Specify a high-timeout in the root `.yarnrc` to workaround `yarn install` hanging indefinitely and reporting network connection errors, which seems to be experienced more frequently on Windows than on Linux or macOS. Note: this is probably buggy behavior on yarn's part.