### PR TITLE
fix: use our global Web3 and not Metamask's

### DIFF
--- a/packages/web3Connector/index.js
+++ b/packages/web3Connector/index.js
@@ -44,9 +44,9 @@ module.exports = async (embark) => {
   web3Location = web3Location.replace(/\\/g, '/');
 
 
-  embark.events.emit('runcode:register', 'Web3', require(web3Location), false);
+  embark.events.emit('runcode:register', '__Web3', require(web3Location), false);
 
-  let code = `\nconst Web3 = global.Web3 || require('${web3Location}');`;
+  let code = `\nconst Web3 = global.__Web3 || require('${web3Location}');`;
   code += `\nglobal.Web3 = Web3;`;
 
   const connectorCode = fs.readFileSync(path.join(__dirname, 'web3Connector.js'), 'utf8');


### PR DESCRIPTION
This is a problem that's caused because we can't require stuff inside the console, so the connector needs to try the global object that was registered for the console, and then in the Dapp, that won't be available and it will require the code.
