### PR TITLE
fix: use right accounts for contract deployment

### DIFF
--- a/packages/embark/src/lib/modules/blockchain_connector/index.js
+++ b/packages/embark/src/lib/modules/blockchain_connector/index.js
@@ -165,7 +165,8 @@ class BlockchainConnector {
       logger: this.logger,
       isDev: this.isDev,
       type: type,
-      web3Endpoint: self.web3Endpoint
+      web3Endpoint: self.web3Endpoint,
+      events: this.events
     };
     this.provider = new Provider(providerOptions);
 

--- a/packages/embark/src/lib/modules/blockchain_connector/provider.js
+++ b/packages/embark/src/lib/modules/blockchain_connector/provider.js
@@ -14,7 +14,13 @@ class Provider {
     this.web3Endpoint = options.web3Endpoint;
     this.logger = options.logger;
     this.isDev = options.isDev;
+    this.events = options.events;
     this.nonceCache = {};
+
+    this.events.setCommandHandler("blockchain:provider:contract:accounts:get", cb => {
+      const accounts = this.accounts.map(a => a.address);
+      cb(accounts);
+    });
   }
 
   getNonce(address, callback) {
@@ -123,7 +129,7 @@ class Provider {
               return cb(err);
             }
             if (self.accounts.length) {
-              result.result = self.addresses; // Send our addresses
+              result.result = self.blockchainAccounts.map(a => a.address);
             }
             cb(null, result);
           });

--- a/packages/embark/src/lib/modules/deployment/contract_deployer.js
+++ b/packages/embark/src/lib/modules/deployment/contract_deployer.js
@@ -113,10 +113,7 @@ class ContractDeployer {
       // TODO: can potentially go to a beforeDeploy plugin
       function getAccounts(next) {
         deploymentAccount = self.blockchain.defaultAccount();
-        self.blockchain.getAccounts(function (err, _accounts) {
-          if (err) {
-            return next(new Error(err));
-          }
+        self.events.request('blockchain:provider:contract:accounts:get', _accounts => {
           accounts = _accounts;
 
           // applying deployer account configuration, if any

--- a/packages/embark/src/lib/modules/tests/test.js
+++ b/packages/embark/src/lib/modules/tests/test.js
@@ -26,6 +26,10 @@ class Test {
     this.provider = null;
     this.accounts = [];
     this.embarkjs = {};
+
+    this.events.setCommandHandler("blockchain:provider:contract:accounts:get", cb => {
+      cb(this.accounts);
+    });
   }
 
   init(callback) {
@@ -321,7 +325,7 @@ class Test {
               }
               Object.setPrototypeOf(self.contracts[contract.className], vmContract || null);
               eachCb();
-            });            
+            });
           }, (err) => {
             next(err, accounts);
           });
@@ -366,7 +370,7 @@ class Test {
         newContract.options.gas = "${constants.tests.gasLimit}";
       }
       return newContract;`;
-    this.events.request("runcode:eval", codeToRun, cb, false, true); 
+    this.events.request("runcode:eval", codeToRun, cb, false, true);
   }
 
   require(path) {
@@ -384,7 +388,7 @@ class Test {
       this.contracts[contractName] = newContract;
       return newContract;
     }
-    
+
     // EmbarkJS require
     if (path.startsWith(embarkJSPrefix)) {
       return this.embarkjs;

--- a/packages/embark/src/lib/utils/accountParser.js
+++ b/packages/embark/src/lib/utils/accountParser.js
@@ -65,10 +65,12 @@ class AccountParser {
         logger.warn(`Private key ending with ${accountConfig.privateKey.substr(accountConfig.privateKey.length - 5)} is not a HEX string`);
         return null;
       }
+
+      const key = Buffer.from(accountConfig.privateKey.substr(2), 'hex');
       if (returnAddress) {
-        return ethereumjsWallet.fromPrivateKey(accountConfig.privateKey).getChecksumAddressString();
+        return ethereumjsWallet.fromPrivateKey(key).getChecksumAddressString();
       }
-      return Object.assign(web3.eth.accounts.privateKeyToAccount(accountConfig.privateKey), {hexBalance});
+      return Object.assign(web3.eth.accounts.privateKeyToAccount(key), {hexBalance});
     }
 
     if (accountConfig.privateKeyFile) {
@@ -103,6 +105,9 @@ class AccountParser {
           logger.warn(`Private key is not a HEX string in file ${accountConfig.privateKeyFile} at index ${index}`);
           return null;
         }
+
+        key = Buffer.from(key.substr(2), 'hex');
+
         if (returnAddress) {
           return ethereumjsWallet.fromPrivateKey(key).getChecksumAddressString();
         }

--- a/packages/embark/src/test/accountParser.js
+++ b/packages/embark/src/test/accountParser.js
@@ -38,7 +38,7 @@ describe('embark.AccountParser', function () {
         privateKey: 'myKey'
       }, web3, testLogger);
 
-      assert.deepEqual(account, {key: '0xmyKey', hexBalance: null});
+      assert.deepEqual(account, {key: Buffer.from('myKey', 'hex'), hexBalance: null});
     });
 
     it('should return two accounts from the keys in the file', function () {
@@ -47,8 +47,8 @@ describe('embark.AccountParser', function () {
       }, web3, testLogger);
 
       assert.deepEqual(account, [
-        {key: '0xkey1', hexBalance: null},
-        {key: '0xkey2', hexBalance: null}
+        {key: Buffer.from('key1', 'hex'), hexBalance: null},
+        {key: Buffer.from('key2', 'hex'), hexBalance: null}
       ]);
     });
 


### PR DESCRIPTION
Also pass `privateKey` values in a way that ethereum wallet likes.