### PR TITLE
fix(@embark/embarkjs): Fix potential race condition

### DIFF
--- a/packages/embarkjs/src/blockchain.js
+++ b/packages/embarkjs/src/blockchain.js
@@ -49,12 +49,18 @@ Blockchain.connect = function(options, callback) {
 
 Blockchain.connectConsole = function(doneCb) {
   this.doFirst((cb) => {
-    this.blockchainConnector.getAccounts((err, accounts) => {
+    this.blockchainConnector.getAccounts(async (err, accounts) => {
       if (accounts) {
         this.blockchainConnector.setDefaultAccount(accounts[0]);
       }
-      cb(err);
-      doneCb(err);
+      let _err = err;
+      try {
+        await cb(_err);
+      } catch (e) {
+        _err = e;
+      } finally {
+        doneCb(_err);
+      }
     });
   });
 };


### PR DESCRIPTION
`EmbarkJS.Blockchain.connectConsole` has a potential race condition with both `cb` and `doneCb` firing at the end of the method.

This PR is an attempt to fix that by first awaiting the `cb`, then finally calling `doneCb`, as suggested by @michaelsbradleyjr in https://github.com/embark-framework/embark/pull/1319#discussion_r256850820

Please wait for @michaelsbradleyjr's approval before merging.