### PR TITLE
fix(@embark/console): Fix console not working with VM2/monorepo

### DIFF
--- a/packages/embark/src/lib/core/engine.js
+++ b/packages/embark/src/lib/core/engine.js
@@ -169,15 +169,14 @@ class Engine {
     this.registerModule('plugin_cmd', {embarkConfigFile: this.embarkConfig, embarkConfig: this.config.embarkConfig, packageFile: 'package.json'});
   }
 
-  console(options) {
+  console(_options) {
     this.registerModule('console', {
       events: this.events,
       plugins: this.plugins,
       version: this.version,
       ipc: this.ipc,
       logger: this.logger,
-      config: this.config,
-      forceRegister: options.forceRegister
+      config: this.config
     });
   }
 

--- a/packages/embark/src/lib/modules/blockchain_connector/index.js
+++ b/packages/embark/src/lib/modules/blockchain_connector/index.js
@@ -192,8 +192,8 @@ class BlockchainConnector {
   }
 
   _emitWeb3Ready() {
-    this.isWeb3Ready = true;
     this.registerWeb3Object(() => {
+      this.isWeb3Ready = true;
       this.events.emit(WEB3_READY);
     });
     this.subscribeToPendingTransactions();
@@ -695,7 +695,7 @@ class BlockchainConnector {
   registerWeb3Object(cb = () => {}) {
     // doesn't feel quite right, should be a cmd or plugin method
     // can just be a command without a callback
-    this.events.emit("runcode:register", "web3", this.web3, false, cb);
+    this.events.emit("runcode:register", "web3", this.web3, cb);
   }
 
   subscribeToPendingTransactions() {

--- a/packages/embark/src/lib/modules/codeRunner/vm.ts
+++ b/packages/embark/src/lib/modules/codeRunner/vm.ts
@@ -40,6 +40,8 @@ class VM {
         "@babel/runtime-corejs2/core-js/object/assign",
         "eth-ens-namehash",
         "swarm-api",
+        "rxjs",
+        "rxjs/operators",
       ],
     },
     sandbox: { __dirname: fs.dappPath() },
@@ -102,7 +104,9 @@ class VM {
       if (error.message && error.message.indexOf(WEB3_INVALID_RESPONSE_ERROR) !== -1) {
         error.message += ". Are you connected to an Ethereum node?";
       }
-
+      if (typeof error === "string") {
+        error = new Error(error);
+      }
       return cb(error);
     }
     return cb(null, result);
@@ -150,27 +154,6 @@ class VM {
   private setupNodeVm(cb: Callback<null>) {
     this.vm = new NodeVM(this.options);
     cb();
-  }
-
-  /**
-   * Gets the registered @type {Web3} object, and returns an @type {object} with it's
-   * defaultAccount and provider URL.
-   * @typedef {getWeb3Config}
-   * @property {string} defaultAccount
-   * @property {string} providerUrl
-   * @returns {getWeb3Config} The configured values of the web3 object registered to this
-   *  VM instance.
-   */
-  public getWeb3Config() {
-    const Web3 = require("web3");
-    const provider = this.options.sandbox.web3.currentProvider;
-    let providerUrl;
-    if (provider instanceof Web3.providers.HttpProvider) {
-      providerUrl = provider.host;
-    } else if (provider instanceof Web3.providers.WebsocketProvider) {
-      providerUrl = provider.connection._url;
-    }
-    return { defaultAccount: this.options.sandbox.web3.eth.defaultAccount, providerUrl };
   }
 }
 

--- a/packages/embark/src/lib/modules/console/suggestions.ts
+++ b/packages/embark/src/lib/modules/console/suggestions.ts
@@ -92,7 +92,7 @@ export default class Suggestions {
         }
 
         return cb(this.searchSuggestions(cmd, suggestions));
-      }, false, true);
+      }, true);
     } catch (e) {
     }
 

--- a/packages/embark/src/lib/modules/deployment/contract_deployer.js
+++ b/packages/embark/src/lib/modules/deployment/contract_deployer.js
@@ -211,8 +211,7 @@ class ContractDeployer {
     self.events.emit("deploy:contract:deployed", contract);
 
     self.events.request('code-generator:contract:custom', contract, (contractCode) => {
-      self.events.request('runcode:eval', contractCode, () => {}, true);
-      return callback();
+      self.events.request('runcode:eval', contractCode, callback);
     });
   }
 
@@ -344,7 +343,7 @@ class ContractDeployer {
               self.plugins.runActionsForEvent('deploy:contract:deployed', {contract: contract}, () => {
                 return next(null, receipt);
               });
-            }, true);
+            });
           });
         }, hash => {
           self.logFunction(contract)(__("deploying") + " " + contract.className.bold.cyan + " " + __("with").green + " " + contract.gas + " " + __("gas at the price of").green + " " + contract.gasPrice + " " + __("Wei, estimated cost:").green + " " + estimatedCost + " Wei".green + " (txHash: " + hash.bold.cyan + ")");

--- a/packages/embark/src/lib/modules/tests/test.js
+++ b/packages/embark/src/lib/modules/tests/test.js
@@ -34,20 +34,6 @@ class Test {
         this.events.request('runcode:ready', next);
       },
       (next) => {
-        this.initWeb3Provider(next);
-      },
-      (next) => {
-        const waitingForReady = setTimeout(() => {
-          this.logger.warn('Waiting for the blockchain connector to be ready...');
-          // TODO add docs link to how to install one
-          this.logger.warn('If you did not install a blockchain connector, stop this process and install one');
-        }, 5000);
-        this.events.request('blockchain:connector:ready', () => {
-          clearTimeout(waitingForReady);
-          next();
-        });
-      },
-      (next) => {
         this.gasLimit = constants.tests.gasLimit;
         this.events.request('deploy:setGasLimit', this.gasLimit);
         if (this.options.node !== 'embark') {
@@ -185,7 +171,9 @@ class Test {
           return callback(err);
         }
         self.firstRunConfig = false;
-        self.events.request("runcode:embarkjs:reset", callback);
+        self.events.request("blockchain:ready", () => {
+          self.events.request("runcode:embarkjs:reset", callback);
+        });
       });
     });
   }
@@ -346,7 +334,7 @@ class Test {
             Object.setPrototypeOf(self.embarkjs, embarkjs);
           }
           next(err, accounts);
-        }, true);
+        });
       }
     ], function (err, accounts) {
       if (err) {

--- a/packages/embark/src/test/events.js
+++ b/packages/embark/src/test/events.js
@@ -1,0 +1,120 @@
+/*globals describe, it, before, beforeEach*/
+const {File, Types} = require("../lib/core/file");
+const Assert = require("assert");
+const {expect} = require("chai");
+const fs = require("../lib/core/fs");
+const Events = require("../lib/core/events");
+
+let events;
+const testEventName = "testevent";
+
+describe('embark.Events', function () {
+  this.timeout(10000);
+  before(() => {
+    events = new Events();
+  });
+
+  beforeEach(() => {
+    events.removeAllListeners(testEventName);
+    events.removeAllListeners(`request:${testEventName}`);
+  });
+
+  describe('Set event listeners', function () {
+    it('should be able to listen to an event emission', (done) => {
+      events.on(testEventName, ({isTest}) => {
+        expect(isTest).to.be.true;
+        done();
+      });
+      events.emit(testEventName, { isTest: true });
+    });
+
+    it('should be able to listen to an event emission once', (done) => {
+      events.once(testEventName, ({isTest}) => {
+        expect(isTest).to.be.true;
+        done();
+      });
+      events.emit(testEventName, { isTest: true });
+    });
+  });
+  describe('Set command handlers', function() {
+    it('should be able to set a command handler and request the event', (done) => {
+      events.setCommandHandler(testEventName, () => {
+        Assert.ok(true);
+        done();
+      });
+      events.request(testEventName);
+    });
+
+    it('should be able to set a command handler with data and request the event', (done) => {
+      events.setCommandHandler(testEventName, (options, cb) => {
+        expect(options.isTest).to.be.true;
+        cb(options);
+      });
+      events.request(testEventName, { isTest: true }, (data) => {
+        expect(data.isTest).to.be.true;
+        done();
+      });
+    });
+
+    it('should be able to set a command handler with data and request the event once', (done) => {
+      events.setCommandHandlerOnce(testEventName, (options, cb) => {
+        expect(options.isTest).to.be.true;
+        cb(options);
+      });
+      events.request(testEventName, { isTest: true }, (data) => {
+        expect(data.isTest).to.be.true;
+        events.request(testEventName, { isTest: true }, (data) => {
+          Assert.fail("Should not call the requested event again, as it was set with once only");
+        });
+        done();
+      });
+    });
+
+    it('should be able to request an event before a command handler has been set', (done) => {
+      let testData = { isTest: true, manipulatedCount: 0 };
+      events.request(testEventName, testData, (dataFirst) => {
+        expect(dataFirst.isTest).to.be.true;
+        expect(dataFirst.manipulatedCount).to.equal(1);
+        expect(dataFirst.isAnotherTest).to.be.undefined;
+      });
+      events.request(testEventName, testData, (dataSecond) => {
+        expect(dataSecond.isTest).to.be.true;
+        expect(dataSecond.manipulatedCount).to.equal(2);
+        expect(dataSecond.isAnotherTest).to.be.undefined;
+
+        dataSecond.isAnotherTest = true;
+        events.request(testEventName, dataSecond, (dataThird) => {
+          expect(dataThird.isTest).to.be.true;
+          expect(dataThird.manipulatedCount).to.equal(3);
+          expect(dataThird.isAnotherTest).to.be.true;
+          done();
+        });
+      });
+      events.setCommandHandler(testEventName, (options, cb) => {
+        expect(options.isTest).to.be.true;
+        options.manipulatedCount++;
+        cb(options);
+      });
+    });
+
+    it('should be able to request an event before a command handler has been set once', (done) => {
+      let testData = { isTest: true, manipulatedCount: 0 };
+      events.request(testEventName, testData, (data) => {
+        expect(data.isTest).to.be.true;
+        expect(data.manipulatedCount).to.equal(1);
+        expect(data.isAnotherTest).to.be.undefined;
+        events.request(testEventName, data, (_dataSecondRun) => {
+          Assert.fail("Should not call the requested event again, as it was set with once only");
+        });
+      });
+      events.request(testEventName, testData, (_dataThirdRun) => {
+        done();
+      });
+      events.setCommandHandlerOnce(testEventName, (options, cb) => {
+        expect(options.isTest).to.be.true;
+        options.manipulatedCount = options.manipulatedCount + 1;
+        cb(options);
+      });
+    });
+  });
+});

--- a/packages/web3Connector/index.js
+++ b/packages/web3Connector/index.js
@@ -38,11 +38,14 @@ module.exports = async (embark) => {
     if (blockchainConnectorReady) {
       return cb();
     }
-    web3LocationPromise.then((_web3Location) => {
-      blockchainConnectorReady = true;
-      embark.events.emit('blockchain:connector:ready');
+    embark.events.once("blockchain:connector:ready", () => {
       cb();
     });
+  });
+
+  web3LocationPromise.then((_web3Location) => {
+    blockchainConnectorReady = true;
+    embark.events.emit('blockchain:connector:ready');
   });
 
   let web3Location = await web3LocationPromise;
@@ -50,7 +53,7 @@ module.exports = async (embark) => {
   web3Location = web3Location.replace(/\\/g, '/');
 
 
-  embark.events.emit('runcode:register', '__Web3', require(web3Location), false);
+  embark.events.emit('runcode:register', '__Web3', require(web3Location));
 
   let code = `\nconst Web3 = global.__Web3 || require('${web3Location}');`;
   code += `\nglobal.Web3 = Web3;`;
@@ -60,7 +63,7 @@ module.exports = async (embark) => {
 
   code += "\nEmbarkJS.Blockchain.registerProvider('web3', web3Connector);";
 
-  code += "\nEmbarkJS.Blockchain.setProvider('web3', {web3});";
+  code += "\nEmbarkJS.Blockchain.setProvider('web3', {});";
 
   embark.addCodeToEmbarkJS(code);
 


### PR DESCRIPTION
The console was not working correctly with the latest VM2/monorepo updates. This PR addresses namely fixes this problem, but also adds a few more notable changes:

* SIGNIFICANT improvement in loading time for `embark console` with an already running `embark run`. This is due to removing unneeded services starting, and instead forwarding user input to the main `embark run` process.
* All user input commands are now forwarded to the `embark run` process via IPC insteaad of evaluating the command in the `embark console` process.
* Removed IPC console history as it's no longer needed due to the above. Side effects:
  * The signature of the `runcode:eval` and `runcode:register` events was changed to remove the `toRecord` parameter.
```
// Old runcode:eval signature: 
events.request("runcode:eval", "code to be evaluated", (err, result) => {}, isNotUserInput, tolerateError);

// New runcode:eval signature: 
events.request("runcode:eval", "code to be evaluated", (err, result) => {}, tolerateError)
 
//Old runcode:register signature: 
events.request("runcode:register", "varName", variableValue, toRecord, (err, result) => {});

// New runcode:register signature: 
events.request("runcode:register", "varName", variableValue, (err, result) => {});
```
* Removed unneeded `forceRegister` flag.
* Removed the `VM.getWeb3Config` method as it's no longer being used (EmbarkJS contracts are pulled out from the VM instead).
* Updated `web3Connector` `blockchain:connector:ready` to allow for event requests or event emissions.
* In the tests, removed the initial `initWeb3Provider` in the `init` as it was being called twice.
* In the tests, removed the `web3Connector` check message as the tests are now using the Console, and the console does this check. This was causing duplicate messages to be displayed in the output.