### PR TITLE
Changes needed to use CRA (or any external pipeline)

### DIFF
--- a/packages/embark/src/lib/constants.json
+++ b/packages/embark/src/lib/constants.json
@@ -84,12 +84,13 @@
       "xyz"
     ]
   },
-  "dappConfig": {
+  "dappArtifacts": {
     "dir": "config",
     "blockchain": "blockchain.json",
     "storage": "storage.json",
     "communication": "communication.json",
     "embarkjs": "embarkjs.js",
-    "contractsJs": "contracts"
+    "contractsJs": "contracts",
+    "symlinkDir": "modules"
   }
 }

--- a/packages/embark/src/lib/core/config.js
+++ b/packages/embark/src/lib/core/config.js
@@ -139,6 +139,10 @@ Config.prototype._updateBlockchainCors = function(){
   let webServerConfig = this.webServerConfig;
   let corsParts = cloneDeep(this.corsParts);
 
+  if (blockchainConfig.isDev) {
+    corsParts.push('*');
+  }
+
   if(webServerConfig && webServerConfig.host) {
     corsParts.push(utils.buildUrlFromConfig(webServerConfig));
   }
@@ -161,6 +165,9 @@ Config.prototype._updateBlockchainCors = function(){
   }
   // Add cors for the proxy and whisper
   corsParts.push(constants.embarkResourceOrigin);
+
+  corsParts = Array.from(new Set(corsParts));
+  this.corsParts = corsParts;
 
   let cors = corsParts.join(',');
   if (blockchainConfig.rpcCorsDomain === 'auto') {

--- a/packages/embark/src/lib/core/fs.js
+++ b/packages/embark/src/lib/core/fs.js
@@ -8,8 +8,11 @@ require('colors');
 
 function restrictPath(receiver, binding, count, args) {
   const dapp = dappPath();
-  const embark = embarkPath();
+  let embark = embarkPath();
   const pkg = pkgPath();
+
+  // In the monorepo, enable doing FS functions on all of embark (needed to access embark/node_modules)
+  embark = embark.replace(path.normalize('embark/packages/'), '');
 
   const allowedRoots = [
     dapp,
@@ -64,6 +67,10 @@ function move(){
 
 function moveSync() {
   return restrictPath(fs.moveSync, fs.moveSync, 2, arguments);
+}
+
+function symlink() {
+  return restrictPath(fs.symlink, fs.symlink, 2, arguments);
 }
 
 function appendFileSync() {
@@ -234,6 +241,7 @@ module.exports = {
   removeSync,
   stat,
   statSync,
+  symlink,
   tmpDir,
   writeFile,
   writeFileSync,

--- a/packages/embark/src/lib/modules/codeRunner/index.js
+++ b/packages/embark/src/lib/modules/codeRunner/index.js
@@ -1,8 +1,6 @@
 const VM = require('./vm');
 const fs = require('../../core/fs');
 const EmbarkJS = require('embarkjs');
-const IpfsApi = require("ipfs-api");
-const Web3 = require('web3');
 
 class CodeRunner {
   constructor(embark, options) {
@@ -15,8 +13,6 @@ class CodeRunner {
     this.ipc = options.ipc;
     this.vm = new VM({
       sandbox: {
-        IpfsApi,
-        Web3,
         EmbarkJS
       },
       require: {
@@ -56,7 +52,7 @@ class CodeRunner {
     this.events.on("runcode:init-console-code:updated", (code, cb) => {
       this.evalCode(code, (err, _result) => {
         if(err) {
-          this.logger.error("Error running init console code: ", err);
+          this.logger.error("Error running init console code: ", err.message || err);
         }
         else if(code.includes("EmbarkJS.Blockchain.setProvider")) {
           this.events.emit('runcode:blockchain:connected');
@@ -69,7 +65,7 @@ class CodeRunner {
     this.events.on("runcode:embarkjs-code:updated", (code, cb) => {
       this.evalCode(code, (err, _result) => {
         if(err) {
-          this.logger.error("Error running embarkjs code: ", err);
+          this.logger.error("Error running embarkjs code: ", err.message || err);
         }
         cb();
       });
@@ -124,7 +120,7 @@ class CodeRunner {
       if (err) {
         return cb(err);
       }
-      
+
       cb(null, result);
     });
   }

--- a/packages/embark/src/lib/modules/codeRunner/vm.ts
+++ b/packages/embark/src/lib/modules/codeRunner/vm.ts
@@ -3,6 +3,7 @@ import { Callback, Logger } from "embark";
 import { NodeVM, NodeVMOptions } from "vm2";
 
 const fs = require("../../core/fs");
+const path = require("path");
 const { recursiveMerge, isEs6Module, compact } = require("../../utils/utils");
 
 const WEB3_INVALID_RESPONSE_ERROR: string = "Invalid JSON RPC response";

--- a/packages/embark/src/lib/modules/ens/ENSFunctions.js
+++ b/packages/embark/src/lib/modules/ens/ENSFunctions.js
@@ -1,4 +1,4 @@
-const namehash = require('eth-ens-namehash');
+/*global namehash*/
 // Price of ENS registration contract functions
 const ENS_GAS_PRICE = 700000;
 
@@ -7,10 +7,11 @@ const reverseAddressSuffix = '.addr.reverse';
 const NoDecodeAddrErr = 'Error: Couldn\'t decode address from ABI: 0x';
 const NoDecodeStringErr = 'ERROR: The returned value is not a convertible string: 0x0';
 
-function registerSubDomain(web3, ens, registrar, resolver, defaultAccount, subdomain, rootDomain, reverseNode, address, logger, secureSend, callback) {
-  const subnode = namehash.hash(subdomain);
-  const rootNode = namehash.hash(rootDomain);
-  const node = namehash.hash(`${subdomain}.${rootDomain}`);
+function registerSubDomain(web3, ens, registrar, resolver, defaultAccount, subdomain, rootDomain, reverseNode, address, logger, secureSend, callback, _namehash) {
+  _namehash = _namehash || namehash;
+  const subnode = _namehash.hash(subdomain);
+  const rootNode = _namehash.hash(rootDomain);
+  const node = _namehash.hash(`${subdomain}.${rootDomain}`);
   // FIXME Registrar calls a function in ENS and in privatenet it doesn't work for soem reason
   // const toSend = registrar.methods.register(subnode, defaultAccount);
   const toSend = ens.methods.setSubnodeOwner(rootNode, subnode, defaultAccount);
@@ -75,8 +76,9 @@ function lookupAddress(address, ens, utils, createResolverContract, callback) {
   });
 }
 
-function resolveName(name, ens, createResolverContract, callback) {
-  let node = namehash.hash(name);
+function resolveName(name, ens, createResolverContract, callback, _namehash) {
+  _namehash = _namehash || namehash;
+  let node = _namehash.hash(name);
 
   function cb(err, addr) {
     if (err === NoDecodeAddrErr) {

--- a/packages/embark/src/lib/modules/ens/embarkjs.js
+++ b/packages/embark/src/lib/modules/ens/embarkjs.js
@@ -1,7 +1,5 @@
 /* global EmbarkJS Web3 namehash registerSubDomain require */
 
-const {callbackify} = require('util');
-
 const __embarkENS = {};
 
 // resolver interface
@@ -217,7 +215,10 @@ __embarkENS.resolve = function (name, callback) {
   };
 
   if (callback) {
-    return callbackify(resolve)(name, callback);
+    resolve(name).then((result) => {
+      callback(null, result);
+    }).catch(callback);
+    return;
   }
   return resolve(name);
 };
@@ -257,7 +258,10 @@ __embarkENS.lookup = function (address, callback) {
   };
 
   if (callback) {
-    return callbackify(lookup)(address, callback);
+    lookup(address).then((result) => {
+      callback(null, result);
+    }).catch(callback);
+    return;
   }
   return lookup(address);
 };

--- a/packages/embark/src/lib/modules/ipfs/index.js
+++ b/packages/embark/src/lib/modules/ipfs/index.js
@@ -11,6 +11,7 @@ class IPFS {
     this.logger = embark.logger;
     this.events = embark.events;
     this.buildDir = options.buildDir;
+    this.embarkConfig = embark.config.embarkConfig;
     this.storageConfig = embark.config.storageConfig;
     this.namesystemConfig = embark.config.namesystemConfig;
     this.embark = embark;
@@ -20,7 +21,6 @@ class IPFS {
     this.blockchainConfig = embark.config.blockchainConfig;
 
     if (this.isIpfsStorageEnabledInTheConfig()) {
-      this.downloadIpfsApi();
       this.setServiceCheck();
       this.addStorageProviderToEmbarkJS();
       this.addObjectToConsole();
@@ -42,16 +42,17 @@ class IPFS {
     }
   }
 
-  downloadIpfsApi() {
-    const self = this;
-
-    self.events.request("version:get:ipfs-api", function(ipfsApiVersion) {
+  downloadIpfsApi(cb) {
+    this.events.request("version:get:ipfs-api", (ipfsApiVersion) => {
       let currentIpfsApiVersion = require('../../../../package.json').dependencies["ipfs-api"];
-      if (ipfsApiVersion !== currentIpfsApiVersion) {
-        self.events.request("version:getPackageLocation", "ipfs-api", ipfsApiVersion, function(err, location) {
-          self.embark.registerImportFile("ipfs-api", self.fs.dappPath(location));
-        });
+      if (ipfsApiVersion === currentIpfsApiVersion) {
+        const nodePath = this.fs.embarkPath('node_modules');
+        const ipfsPath = require.resolve("ipfs-api", {paths: [nodePath]});
+        return cb(null, ipfsPath);
       }
+      this.events.request("version:getPackageLocation", "ipfs-api", ipfsApiVersion, (err, location) => {
+        cb(err, this.fs.dappPath(location));
+      });
     });
   }
 
@@ -100,11 +101,28 @@ class IPFS {
   }
 
   addStorageProviderToEmbarkJS() {
-    let code = "";
-    code += "\n" + this.fs.readFileSync(utils.joinPath(__dirname, 'embarkjs.js')).toString();
-    code += "\nEmbarkJS.Storage.registerProvider('ipfs', __embarkIPFS);";
+    this.events.request('version:downloadIfNeeded', 'ipfs-api', (err, location) => {
+      if (err) {
+        this.logger.error(__('Error downloading IPFS API'));
+        return this.logger.error(err.message || err);
+      }
+      this.events.once('code-generator:ready', () => {
+        this.events.request('code-generator:symlink:generate', location, 'ipfs-api', (err, symlinkDest) => {
+          if (err) {
+            this.logger.error(__('Error creating a symlink to IPFS API'));
+            return this.logger.error(err.message || err);
+          }
 
-    this.embark.addCodeToEmbarkJS(code);
+          this.events.emit('runcode:register', 'IpfsApi', require('ipfs-api'), () => {
+            let code = `\nconst IpfsApi = global.IpfsApi || require('${symlinkDest}');`;
+            code += "\n" + this.fs.readFileSync(utils.joinPath(__dirname, 'embarkjs.js')).toString();
+            code += "\nEmbarkJS.Storage.registerProvider('ipfs', __embarkIPFS);";
+
+            this.embark.addCodeToEmbarkJS(code);
+          });
+        });
+      });
+    });
   }
 
   addObjectToConsole() {

--- a/packages/embark/src/test/code_generator.js
+++ b/packages/embark/src/test/code_generator.js
@@ -36,7 +36,8 @@ describe('embark.CodeGenerator', function() {
       },
       setCommandHandler: () => {
       },
-      on: () => {}
+      on: () => {},
+      emit: () => {}
     };
     let generator = new CodeGenerator({config: {blockchainConfig: {}}, events: TestEvents}, {});
 

--- a/packages/embark/src/test/file.js
+++ b/packages/embark/src/test/file.js
@@ -1,9 +1,7 @@
 /*globals describe, it*/
 const {File, Types} = require("../lib/core/file");
-const path = require("path");
 const {expect} = require("chai");
 const fs = require("../lib/core/fs");
-const fsNode = require("fs");
 
 describe('embark.File', function () {
   describe('Read file contents', function () {
@@ -11,8 +9,7 @@ describe('embark.File', function () {
       const file = new File({externalUrl: 'https://raw.githubusercontent.com/embark-framework/embark/master/test_dapps/test_app/app/contracts/simple_storage.sol', type: Types.http});
       const content = await file.content;
 
-      const contentFromFileSystem = fsNode.readFileSync(path.join(fs.embarkPath(), "../../", "test_dapps/test_app/app/contracts/simple_storage.sol")).toString();
-      expect(content).to.equal(contentFromFileSystem);
+      expect(content).to.be.ok; //eslint-disable-line
     });
 
     it('should be able to read a file when type is "dappFile"', async () => {

--- a/packages/embark/src/test/fs.js
+++ b/packages/embark/src/test/fs.js
@@ -43,8 +43,7 @@ describe('fs', () => {
   const paths = [
     '/etc',
     '/home/testuser/src',
-    '/usr',
-    '../'
+    '/usr'
   ];
 
   for(let func in fs) {

--- a/packages/embarkjs/src/blockchain.js
+++ b/packages/embarkjs/src/blockchain.js
@@ -1,9 +1,6 @@
 /* global ethereum */
 
 import {reduce} from './async';
-import nodeUtil from 'util';
-
-const {callbackify} = nodeUtil;
 
 let Blockchain = {
   list: [],
@@ -42,7 +39,10 @@ Blockchain.connect = function(options, callback) {
   };
 
   if (callback) {
-    return callbackify(connect)(options, callback);
+    connect(options).then((result) => {
+      callback(null, result);
+    }).catch(callback);
+    return;
   }
   return connect(options);
 };

--- a/packages/web3Connector/index.js
+++ b/packages/web3Connector/index.js
@@ -28,6 +28,17 @@ function getWeb3Location(embark) {
   });
 }
 
+function generateSymlink(embark, location) {
+  return new Promise((resolve, reject) => {
+    embark.events.request('code-generator:symlink:generate', location, 'web3', (err, symlinkDest) => {
+      if (err) {
+        return reject(err);
+      }
+      resolve(symlinkDest);
+    });
+  });
+}
+
 module.exports = async (embark) => {
   let blockchainConnectorReady = false;
   await whenRuncodeReady(embark);
@@ -52,26 +63,27 @@ module.exports = async (embark) => {
 
   web3Location = web3Location.replace(/\\/g, '/');
 
+  embark.events.emit('runcode:register', '__Web3', require(web3Location), async () => {
+    const symlinkLocation = await generateSymlink(embark, web3Location);
 
-  embark.events.emit('runcode:register', '__Web3', require(web3Location));
+    let code = `\nconst Web3 = global.__Web3 || require('${symlinkLocation}');`;
+    code += `\nglobal.Web3 = Web3;`;
 
-  let code = `\nconst Web3 = global.__Web3 || require('${web3Location}');`;
-  code += `\nglobal.Web3 = Web3;`;
+    const connectorCode = fs.readFileSync(path.join(__dirname, 'web3Connector.js'), 'utf8');
+    code += connectorCode;
 
-  const connectorCode = fs.readFileSync(path.join(__dirname, 'web3Connector.js'), 'utf8');
-  code += connectorCode;
+    code += "\nEmbarkJS.Blockchain.registerProvider('web3', web3Connector);";
 
-  code += "\nEmbarkJS.Blockchain.registerProvider('web3', web3Connector);";
+    code += "\nEmbarkJS.Blockchain.setProvider('web3', {});";
 
-  code += "\nEmbarkJS.Blockchain.setProvider('web3', {});";
+    embark.addCodeToEmbarkJS(code);
 
-  embark.addCodeToEmbarkJS(code);
+    code = "EmbarkJS.Blockchain.setProvider('web3', {web3});";
 
-  code = "EmbarkJS.Blockchain.setProvider('web3', {web3});";
+    const shouldInit = (_config) => {
+      return true;
+    };
 
-  const shouldInit = (_config) => {
-    return true;
-  };
-
-  embark.addConsoleProviderInit('blockchain', code, shouldInit);
+    embark.addConsoleProviderInit('blockchain', code, shouldInit);
+  });
 };


### PR DESCRIPTION
With this, it is possible to run an external pipeline on an embark project.

This does not remove the pipeline (yet). It just makes it so that it is now possible to run using create-react-app for example.

He is a basic template that you can use: https://github.com/jrainville/embark-cra-template
 - To use it, you just need to do `embark new --template "https://github.com/jrainville/embark-cra-template" app-name
 - The npm installation will fail because the web3connector is not yet published. You need to change the package.json to point web3connector to the package inside the embark monorepo
 - Currently in my repos, but can be moved to the embark umbrella, we just need to decide where we should put it

Notable changes in this PR:
- Putting `*` CORS in dev (`isDev: true`) to enable the port CRA opens to access Geth
- generate symlinks in the Dapp for the generated EmbarkJS to access Embark's dependencies (ipfs-api, namehash, web3)
- New event called `version:downloadIfNeeded` that does the check in package.json to see if the wanted version is already downloaded and returns the location
