### PR TITLE
fix(@embark/cockpit): Fix cockpit not suggesting console commands

### DIFF
--- a/packages/embark-typings/src/embark.d.ts
+++ b/packages/embark-typings/src/embark.d.ts
@@ -1,4 +1,5 @@
 import { Logger } from "./logger";
+import { Plugins } from "./plugins";
 
 export interface Events {
   on: any;
@@ -25,6 +26,7 @@ export interface Embark {
         solc: string;
       }
     };
+    plugins: Plugins;
     reloadConfig(): void;
   };
   registerActionForEvent(name: string, action: (callback: () => void) => void): void;

--- a/packages/embark/src/lib/modules/console/index.ts
+++ b/packages/embark/src/lib/modules/console/index.ts
@@ -118,7 +118,7 @@ class Console {
         "swarm".cyan + " - " + __("instantiated swarm-api object configured to the current environment (available if swarm is enabled)"),
         "web3".cyan + " - " + __("instantiated web3.js object configured to the current environment"),
         "EmbarkJS".cyan + " - " + __("EmbarkJS static functions for Storage, Messages, Names, etc."),
-        "log <process> on/off".cyan + " - " + __("Activate or deactivate the logs of a sub-process. Options: blockchain, ipfs, webserver"),
+        "log [process] on/off".cyan + " - " + __("Activate or deactivate the logs of a sub-process. Options: blockchain, ipfs, webserver"),
       ];
       helpDescriptions.forEach((helpDescription) => {
         let matches = [] as string[];
@@ -139,6 +139,12 @@ class Console {
   }
 
   private executeCmd(cmd: string, callback: any) {
+    // if this is the embark console process, send the command to the process
+    // running all the needed services (ie the process running `embark run`)
+    if (this.isEmbarkConsole) {
+      return this.ipc.request("console:executeCmd", cmd, callback);
+    }
+
     if (!(cmd.split(" ")[0] === "history" || cmd === __("history"))) {
       this.saveHistory(cmd);
     }
@@ -178,12 +184,6 @@ class Console {
     const output = this.processEmbarkCmd(cmd, helpDescriptions);
     if (output) {
       return callback(null, output);
-    }
-
-    // if this is the embark console process, send the command to the process
-    // running all the needed services (ie the process running `embark run`)
-    if (this.isEmbarkConsole) {
-      return this.ipc.request("console:executeCmd", cmd, callback);
     }
 
     this.events.request("runcode:eval", cmd, (err: Error, result: any) => {
@@ -242,7 +242,7 @@ class Console {
         const [_cmdName, length] = cmd.split(" ");
         this.getHistory(length, callback);
       },
-      usage: "history <optionalLength>",
+      usage: "history [optionalLength]",
     });
   }
 

--- a/packages/embark/src/lib/modules/debugger/index.ts
+++ b/packages/embark/src/lib/modules/debugger/index.ts
@@ -250,7 +250,7 @@ class TransactionDebugger {
         const filename: string = this.txTracker[this.lastTx].contract.filename;
         startDebug(txHash, filename, callback);
       },
-      usage: "debug <txHash>",
+      usage: "debug [txHash]",
     });
 
     this.embark.registerConsoleCommand({

--- a/packages/embark/src/lib/modules/ens/index.js
+++ b/packages/embark/src/lib/modules/ens/index.js
@@ -91,7 +91,7 @@ class ENS {
 
   registerConsoleCommands() {
     this.embark.registerConsoleCommand({
-      usage: 'resolve <name>',
+      usage: 'resolve [name]',
       description: __('Resolves an ENS name'),
       matches: (cmd) => {
         let [cmdName] = cmd.split(' ');
@@ -104,7 +104,7 @@ class ENS {
     });
 
     this.embark.registerConsoleCommand({
-      usage: 'lookup <address>',
+      usage: 'lookup [address]',
       description: __('Lookup an ENS address'),
       matches: (cmd) => {
         let [cmdName] = cmd.split(' ');
@@ -118,7 +118,7 @@ class ENS {
 
 
     this.embark.registerConsoleCommand({
-      usage: 'registerSubDomain <subDomain> <address>',
+      usage: 'registerSubDomain [subDomain] [address]',
       description: __('Register an ENS sub-domain'),
       matches: (cmd) => {
         let [cmdName] = cmd.split(' ');

--- a/packages/embark/src/lib/modules/plugin_cmd/index.js
+++ b/packages/embark/src/lib/modules/plugin_cmd/index.js
@@ -13,7 +13,7 @@ class PluginCommand {
   registerCommand() {
     this.embark.registerConsoleCommand({
       description: "Installs a plugin in the Dapp. eg: plugin install embark-solc",
-      usage: "plugin install <package>",
+      usage: "plugin install [package]",
       matches: (cmd) => {
         const [cmdName] = cmd.split(' ');
         return cmdName === 'plugin';

--- a/packages/embark/src/lib/modules/profiler/index.js
+++ b/packages/embark/src/lib/modules/profiler/index.js
@@ -71,7 +71,7 @@ class Profiler {
   registerConsoleCommand() {
     this.embark.registerConsoleCommand({
       description: "Outputs the function profile of a contract",
-      usage: "profile <contractName>",
+      usage: "profile [contractName]",
       matches: (cmd) => {
         const [cmdName] = cmd.split(' ');
         return cmdName === 'profile';


### PR DESCRIPTION
This PR fixes a number of issues relating to the cockpit console.

#### Console commands display in cockpit console
Fix cockpit console not displaying console usage commands that included “<usage option>”. For example “resolve <name>” would not display the “<name>” part, as it was attempting to write this in as HTML (ansi-to-html conversion).

This was fixed by replacing any instances of “<usage>” with “[usage]”. Please note that future usage strings should not contain text wrapped in “<>”.

#### Autosuggestions for “web.eth.” not appearing
Fix “web3.eth.” not suggesting members of `web3.eth`. This was due to a `Object.keys(web3.eth)` throwing `'getOwnPropertyDescriptor' on proxy: trap returned descriptor for property 'defaultAccount' that is incompatible with the existing property in the proxy target` in the console. Changing `Object.keys` to `Object.getOwnPropertyDescriptor` solved the problem.

#### Fix autosuggestion of known console commands (ie from plugins)
Fix known console commands (ie from  plugins) not being autosuggested. For example, typing “web”, should autosuggest `webserver start/stop`,  `log webserver on`, and `log webserver off`.

This PR adds in support for registered console commands (from plugins).

## Blocking PRs
Please note, this PR is based off of #1337 which in turn is based off of #1340. These two PRs need to be merged before this one can be merged.