### PR TITLE
Fixes for the tests

### DIFF
--- a/packages/embark/src/lib/modules/console/index.ts
+++ b/packages/embark/src/lib/modules/console/index.ts
@@ -61,7 +61,7 @@ class Console {
     this.events.setCommandHandler("console:executeCmd", this.executeCmd.bind(this));
     this.events.setCommandHandler("console:history", (cb: any) => this.getHistory(this.cmdHistorySize(), cb));
     this.events.setCommandHandler("console:provider:ready", (cb: any) => {
-      if (this.providerReady) {
+      if (this.providerReady || this.isEmbarkConsole) {
         return cb();
       }
       this.events.once("console:provider:done", cb);

--- a/packages/embark/src/lib/modules/ens/index.js
+++ b/packages/embark/src/lib/modules/ens/index.js
@@ -543,7 +543,6 @@ class ENS {
       }
     ], (err) => {
       self.configured = true;
-      console.log('all done');
       if (err && err !== NO_REGISTRATION) {
         self.logger.error('Error while deploying ENS contracts');
         self.logger.error(err.message || err);

--- a/packages/embark/src/lib/modules/solidity/index.js
+++ b/packages/embark/src/lib/modules/solidity/index.js
@@ -162,7 +162,7 @@ class Solidity {
     let self = this;
     let input = {};
     let originalFilepath = {};
-    
+
     async.waterfall([
       function prepareInput(callback) {
         async.each(contractFiles,
@@ -170,12 +170,13 @@ class Solidity {
             let filename = file.path;
 
             for (let directory of self.embark.config.contractDirectories) {
+              directory = directory.replace(/\\/g, '/');
               let match = new RegExp("^" + directory);
               filename = filename.replace(match, '');
             }
 
             originalFilepath[filename] = file.path;
-            
+
             file.prepareForCompilation(options.isCoverage)
               .then(fileContent => {
                 input[file.path] = {content: fileContent.replace(/\r\n/g, '\n')};


### PR DESCRIPTION
- Fix embark test getting stuck when `embark run` in running next to it (even without `--node`
- Fix ENS transactions getting stuck when using `--node ws:...`
- Fix the regex used by coverage on Windows (backslahes)