### PR TITLE
Small fixes to contract configurations

### DIFF
--- a/packages/embark/src/lib/modules/contracts_manager/index.js
+++ b/packages/embark/src/lib/modules/contracts_manager/index.js
@@ -334,6 +334,9 @@ class ContractsManager {
             }
             try {
               self.contracts[className] = JSON.parse(artifactBuf.toString());
+              if (self.contracts[className].deployedAddress) {
+                self.contracts[className].address = self.contracts[className].deployedAddress;
+              }
               eachCb();
             } catch (e) {
               self.logger.error(__('Artifact file does not seem to be valid JSON (%s)', contract.artifact));

--- a/packages/embark/src/lib/modules/contracts_manager/index.js
+++ b/packages/embark/src/lib/modules/contracts_manager/index.js
@@ -458,6 +458,7 @@ class ContractsManager {
           contract.gasEstimates = parentContract.gasEstimates;
           contract.functionHashes = parentContract.functionHashes;
           contract.abiDefinition = parentContract.abiDefinition;
+          contract.linkReferences = parentContract.linkReferences;
 
           contract.gas = contract.gas || parentContract.gas;
           contract.gasPrice = contract.gasPrice || parentContract.gasPrice;

--- a/packages/embark/src/lib/utils/contractsConfig.ts
+++ b/packages/embark/src/lib/utils/contractsConfig.ts
@@ -12,11 +12,11 @@ export function prepare(config: any) {
     const args = config.contracts[contractName].args;
     const onDeploy = config.contracts[contractName].onDeploy;
 
-    if (gas && gas.match(unitRegex)) {
+    if (gas && gas.toString().match(unitRegex)) {
       config.contracts[contractName].gas = utils.getWeiBalanceFromString(gas, web3);
     }
 
-    if (gasPrice && gasPrice.match(unitRegex)) {
+    if (gasPrice && gasPrice.toString().match(unitRegex)) {
       config.contracts[contractName].gasPrice = utils.getWeiBalanceFromString(gasPrice, web3);
     }
 

--- a/test_dapps/test_app/config/contracts.js
+++ b/test_dapps/test_app/config/contracts.js
@@ -60,7 +60,7 @@ module.exports = {
       },
       SomeContract: {
         deployIf: 'await MyToken.methods.isAvailable().call()',
-        onDeploy: ['$MyToken'], // Needed because otherwise Embark doesn't know that we depend on MyToken. Would be cleaner with `dependsOn`
+        deps: ['MyToken'],
         args: [
           ["$MyToken2", "$SimpleStorage"],
           100


### PR DESCRIPTION
- Fix for using artifacts where having an address in the artifact still deployed the contract
- Fix gas and gasPrice to be ints or strings
- Fix contracts that were `instanceOf` another contract that had a library, now linking works