### PR TITLE
Connect the Dapp automatically for users

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,8 +60,8 @@
       "embark/embark-test-contract-1",
       "test_app/embark-service",
       "test_app/zeppelin-solidity",
-      "test_app/web3connector",
-      "contracts_app/web3connector"
+      "test_app/embarkjs-web3-connector",
+      "contracts_app/embarkjs-web3-connector"
     ]
   }
 }

--- a/package.json
+++ b/package.json
@@ -60,8 +60,8 @@
       "embark/embark-test-contract-1",
       "test_app/embark-service",
       "test_app/zeppelin-solidity",
-      "test_app/embarkjs-web3-connector",
-      "contracts_app/embarkjs-web3-connector"
+      "test_app/embarkjs-connector-web3",
+      "contracts_app/embarkjs-connector-web3"
     ]
   }
 }

--- a/packages/embark/src/lib/core/plugin.js
+++ b/packages/embark/src/lib/core/plugin.js
@@ -45,6 +45,7 @@ var Plugin = function(options) {
   this.currentContext = options.context;
   this.acceptedContext = options.pluginConfig.context || [constants.contexts.any];
   this.version = options.version;
+  this.constants = constants;
 
   if (!Array.isArray(this.currentContext)) {
     this.currentContext = [this.currentContext];
@@ -96,7 +97,9 @@ Plugin.prototype.loadPlugin = function() {
     this.setUpLogger();
   }
   if (utils.isEs6Module(this.pluginModule)) {
-    this.pluginModule = this.pluginModule.default;
+    if (this.pluginModule.default) {
+      this.pluginModule = this.pluginModule.default;
+    }
     return new this.pluginModule(this);
   }
   this.pluginModule.call(this, this);

--- a/packages/embark/src/lib/core/plugins.js
+++ b/packages/embark/src/lib/core/plugins.js
@@ -88,8 +88,12 @@ Plugins.prototype.loadInternalPlugin = function(pluginName, pluginConfig, isPack
 };
 
 Plugins.prototype.loadPlugin = function(pluginName, pluginConfig) {
-  var pluginPath = this.fs.dappPath('node_modules', pluginName);
-  var plugin = require(pluginPath);
+  let pluginPath = this.fs.dappPath('node_modules', pluginName);
+  let plugin = require(pluginPath);
+
+  if (plugin.default) {
+    plugin = plugin.default;
+  }
 
   var pluginWrapper = new Plugin({
     name: pluginName,

--- a/packages/embark/src/lib/modules/codeRunner/vm.ts
+++ b/packages/embark/src/lib/modules/codeRunner/vm.ts
@@ -127,7 +127,7 @@ class VM {
     if (code === eval || code === require) { return; }
 
     // handle ES6 modules
-    if (isEs6Module(code)) {
+    if (isEs6Module(code) && code.default) {
       code = code.default;
     }
 

--- a/packages/embark/src/lib/utils/utils.js
+++ b/packages/embark/src/lib/utils/utils.js
@@ -623,8 +623,12 @@ function toposort(graph) {
   return toposortGraph(graph);
 }
 
+function isConstructor(obj) {
+  return !!obj.prototype && !!obj.prototype.constructor.name;
+}
+
 function isEs6Module(module) {
-  return typeof module === 'object' && typeof module.default === 'function' && module.__esModule;
+  return (typeof module === 'function' && isConstructor(module)) || (typeof module === 'object' && typeof module.default === 'function' && module.__esModule);
 }
 
 function urlJoin(url, path) {

--- a/packages/embark/templates/boilerplate/app/js/index.js
+++ b/packages/embark/templates/boilerplate/app/js/index.js
@@ -1,11 +1,10 @@
 import EmbarkJS from 'Embark/EmbarkJS';
-import config from '../../embarkArtifacts/config/blockchain.json';
 
 // import your contracts
 // e.g if you have a contract named SimpleStorage:
 //import SimpleStorage from 'Embark/contracts/SimpleStorage';
 
 
-EmbarkJS.Blockchain.connect(config, (err) => {
+EmbarkJS.onReady((err) => {
   // You can execute contract calls after the connection
 });

--- a/packages/embark/templates/boilerplate/embark.json
+++ b/packages/embark/templates/boilerplate/embark.json
@@ -14,7 +14,7 @@
     "ipfs-api": "17.2.4"
   },
   "plugins": {
-    "embarkjs-web3-connector": {}
+    "embarkjs-connector-web3": {}
   },
   "options": {
     "solc": {

--- a/packages/embark/templates/boilerplate/embark.json
+++ b/packages/embark/templates/boilerplate/embark.json
@@ -14,7 +14,7 @@
     "ipfs-api": "17.2.4"
   },
   "plugins": {
-    "web3connector": {}
+    "embarkjs-web3-connector": {}
   },
   "options": {
     "solc": {

--- a/packages/embark/templates/boilerplate/package.json
+++ b/packages/embark/templates/boilerplate/package.json
@@ -9,6 +9,6 @@
   "author": "",
   "license": "MIT",
   "dependencies": {
-    "embarkjs-web3-connector": "4.0.0-beta.0"
+    "embarkjs-connector-web3": "4.0.0-beta.0"
   }
 }

--- a/packages/embark/templates/boilerplate/package.json
+++ b/packages/embark/templates/boilerplate/package.json
@@ -9,6 +9,6 @@
   "author": "",
   "license": "MIT",
   "dependencies": {
-    "web3connector": "4.0.0-beta.0"
+    "embarkjs-web3-connector": "4.0.0-beta.0"
   }
 }

--- a/packages/embark/templates/demo/app/dapp.js
+++ b/packages/embark/templates/demo/app/dapp.js
@@ -7,7 +7,6 @@ import Blockchain from './components/blockchain';
 import Whisper from './components/whisper';
 import Storage from './components/storage';
 import ENS from './components/ens';
-import config from '../embarkArtifacts/config/blockchain';
 
 import './dapp.css';
 
@@ -28,7 +27,7 @@ class App extends React.Component {
   }
 
   componentDidMount() {
-    EmbarkJS.Blockchain.connect(config, (err) => {
+    EmbarkJS.onReady((err) => {
       this.setState({blockchainEnabled: true});
       if (err) {
         // If err is not null then it means something went wrong connecting to ethereum

--- a/packages/embark/templates/demo/embark.json
+++ b/packages/embark/templates/demo/embark.json
@@ -13,7 +13,7 @@
     "ipfs-api": "17.2.4"
   },
   "plugins": {
-    "web3connector": {}
+    "embarkjs-web3-connector": {}
   },
   "options": {
     "solc": {

--- a/packages/embark/templates/demo/embark.json
+++ b/packages/embark/templates/demo/embark.json
@@ -13,7 +13,7 @@
     "ipfs-api": "17.2.4"
   },
   "plugins": {
-    "embarkjs-web3-connector": {}
+    "embarkjs-connector-web3": {}
   },
   "options": {
     "solc": {

--- a/packages/embark/templates/demo/package.json
+++ b/packages/embark/templates/demo/package.json
@@ -14,6 +14,6 @@
     "react-dom": "16.7.0"
   },
   "dependencies": {
-    "embarkjs-web3-connector": "4.0.0-beta.0"
+    "embarkjs-connector-web3": "4.0.0-beta.0"
   }
 }

--- a/packages/embark/templates/demo/package.json
+++ b/packages/embark/templates/demo/package.json
@@ -14,6 +14,6 @@
     "react-dom": "16.7.0"
   },
   "dependencies": {
-    "web3connector": "4.0.0-beta.0"
+    "embarkjs-web3-connector": "4.0.0-beta.0"
   }
 }

--- a/packages/embark/templates/simple/embark.json
+++ b/packages/embark/templates/simple/embark.json
@@ -13,7 +13,7 @@
     "solc": "0.5.0"
   },
   "plugins": {
-    "embarkjs-web3-connector": {}
+    "embarkjs-connector-web3": {}
   },
   "options": {
     "solc": {

--- a/packages/embark/templates/simple/embark.json
+++ b/packages/embark/templates/simple/embark.json
@@ -13,7 +13,7 @@
     "solc": "0.5.0"
   },
   "plugins": {
-    "web3connector": {}
+    "embarkjs-web3-connector": {}
   },
   "options": {
     "solc": {

--- a/packages/embark/templates/simple/package.json
+++ b/packages/embark/templates/simple/package.json
@@ -9,6 +9,6 @@
   "author": "",
   "license": "MIT",
   "dependencies": {
-    "embarkjs-web3-connector": "4.0.0-beta.0"
+    "embarkjs-connector-web3": "4.0.0-beta.0"
   }
 }

--- a/packages/embark/templates/simple/package.json
+++ b/packages/embark/templates/simple/package.json
@@ -9,6 +9,6 @@
   "author": "",
   "license": "MIT",
   "dependencies": {
-    "web3connector": "4.0.0-beta.0"
+    "embarkjs-web3-connector": "4.0.0-beta.0"
   }
 }

--- a/packages/embarkjs-connector-web3/embarkJSConnectorWeb3.js
+++ b/packages/embarkjs-connector-web3/embarkJSConnectorWeb3.js
@@ -1,7 +1,7 @@
 /*global Web3*/
-const embarkJSWeb3Connector = {};
+const embarkJSConnectorWeb3 = {};
 
-embarkJSWeb3Connector.init = function(config) {
+embarkJSConnectorWeb3.init = function(config) {
   global.web3 = config.web3 || global.web3;
   // Check if the global web3 object uses the old web3 (0.x)
   if (global.web3 && typeof global.web3.version !== 'string') {
@@ -13,46 +13,46 @@ embarkJSWeb3Connector.init = function(config) {
   global.web3 = this.web3;
 };
 
-embarkJSWeb3Connector.getInstance = function () {
+embarkJSConnectorWeb3.getInstance = function () {
   return this.web3;
 };
 
-embarkJSWeb3Connector.getAccounts = function () {
+embarkJSConnectorWeb3.getAccounts = function () {
   return this.web3.eth.getAccounts(...arguments);
 };
 
-embarkJSWeb3Connector.getNewProvider = function (providerName, ...args) {
+embarkJSConnectorWeb3.getNewProvider = function (providerName, ...args) {
   return new Web3.providers[providerName](...args);
 };
 
-embarkJSWeb3Connector.setProvider = function (provider) {
+embarkJSConnectorWeb3.setProvider = function (provider) {
   return this.web3.setProvider(provider);
 };
 
-embarkJSWeb3Connector.getCurrentProvider = function () {
+embarkJSConnectorWeb3.getCurrentProvider = function () {
   return this.web3.currentProvider;
 };
 
-embarkJSWeb3Connector.getDefaultAccount = function () {
+embarkJSConnectorWeb3.getDefaultAccount = function () {
   return this.web3.eth.defaultAccount;
 };
 
-embarkJSWeb3Connector.setDefaultAccount = function (account) {
+embarkJSConnectorWeb3.setDefaultAccount = function (account) {
   this.web3.eth.defaultAccount = account;
 };
 
-embarkJSWeb3Connector.newContract = function (options) {
+embarkJSConnectorWeb3.newContract = function (options) {
   return new this.web3.eth.Contract(options.abi, options.address);
 };
 
-embarkJSWeb3Connector.send = function () {
+embarkJSConnectorWeb3.send = function () {
   return this.web3.eth.sendTransaction(...arguments);
 };
 
-embarkJSWeb3Connector.toWei = function () {
+embarkJSConnectorWeb3.toWei = function () {
   return this.web3.toWei(...arguments);
 };
 
-embarkJSWeb3Connector.getNetworkId = function () {
+embarkJSConnectorWeb3.getNetworkId = function () {
   return this.web3.eth.net.getId();
 };

--- a/packages/embarkjs-connector-web3/index.js
+++ b/packages/embarkjs-connector-web3/index.js
@@ -1,6 +1,6 @@
 const path = require('path');
 
-class EmbarkJSWeb3Connector {
+class EmbarkJSConnectorWeb3 {
   constructor(embark, _options) {
     this.embark = embark;
     this.events = embark.events;
@@ -40,10 +40,10 @@ class EmbarkJSWeb3Connector {
     let code = `\nconst Web3 = global.__Web3 || require('${symlinkLocation}');`;
     code += `\nglobal.Web3 = Web3;`;
 
-    const connectorCode = this.fs.readFileSync(path.join(__dirname, 'embarkJSWeb3Connector.js'), 'utf8');
+    const connectorCode = this.fs.readFileSync(path.join(__dirname, 'embarkJSConnectorWeb3.js'), 'utf8');
     code += connectorCode;
 
-    code += "\nEmbarkJS.Blockchain.registerProvider('web3', embarkJSWeb3Connector);";
+    code += "\nEmbarkJS.Blockchain.registerProvider('web3', embarkJSConnectorWeb3);";
     code += "\nEmbarkJS.Blockchain.setProvider('web3', {});";
 
     const configPath = this.fs.dappPath(this.config.embarkConfig.generationDir, this.constants.dappArtifacts.dir, this.constants.dappArtifacts.blockchain).replace(/\\/g, '/');
@@ -111,4 +111,4 @@ class EmbarkJSWeb3Connector {
   }
 }
 
-module.exports = EmbarkJSWeb3Connector;
+module.exports = EmbarkJSConnectorWeb3;

--- a/packages/embarkjs-connector-web3/package.json
+++ b/packages/embarkjs-connector-web3/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "embarkjs-web3-connector",
+  "name": "embarkjs-connector-web3",
   "version": "4.0.0-beta.0",
   "description": "Web3.js Connector for EmbarkJS",
   "main": "index.js",
@@ -8,7 +8,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "embark/packages/embarkjs-web3-connector"
+    "url": "embark/packages/embarkjs-connector-web3"
   },
   "keywords": [
     "embark",

--- a/packages/embarkjs-web3-connector/embarkJSWeb3Connector.js
+++ b/packages/embarkjs-web3-connector/embarkJSWeb3Connector.js
@@ -1,7 +1,7 @@
 /*global Web3*/
-const web3Connector = {};
+const embarkJSWeb3Connector = {};
 
-web3Connector.init = function(config) {
+embarkJSWeb3Connector.init = function(config) {
   global.web3 = config.web3 || global.web3;
   // Check if the global web3 object uses the old web3 (0.x)
   if (global.web3 && typeof global.web3.version !== 'string') {
@@ -13,46 +13,46 @@ web3Connector.init = function(config) {
   global.web3 = this.web3;
 };
 
-web3Connector.getInstance = function () {
+embarkJSWeb3Connector.getInstance = function () {
   return this.web3;
 };
 
-web3Connector.getAccounts = function () {
+embarkJSWeb3Connector.getAccounts = function () {
   return this.web3.eth.getAccounts(...arguments);
 };
 
-web3Connector.getNewProvider = function (providerName, ...args) {
+embarkJSWeb3Connector.getNewProvider = function (providerName, ...args) {
   return new Web3.providers[providerName](...args);
 };
 
-web3Connector.setProvider = function (provider) {
+embarkJSWeb3Connector.setProvider = function (provider) {
   return this.web3.setProvider(provider);
 };
 
-web3Connector.getCurrentProvider = function () {
+embarkJSWeb3Connector.getCurrentProvider = function () {
   return this.web3.currentProvider;
 };
 
-web3Connector.getDefaultAccount = function () {
+embarkJSWeb3Connector.getDefaultAccount = function () {
   return this.web3.eth.defaultAccount;
 };
 
-web3Connector.setDefaultAccount = function (account) {
+embarkJSWeb3Connector.setDefaultAccount = function (account) {
   this.web3.eth.defaultAccount = account;
 };
 
-web3Connector.newContract = function (options) {
+embarkJSWeb3Connector.newContract = function (options) {
   return new this.web3.eth.Contract(options.abi, options.address);
 };
 
-web3Connector.send = function () {
+embarkJSWeb3Connector.send = function () {
   return this.web3.eth.sendTransaction(...arguments);
 };
 
-web3Connector.toWei = function () {
+embarkJSWeb3Connector.toWei = function () {
   return this.web3.toWei(...arguments);
 };
 
-web3Connector.getNetworkId = function () {
+embarkJSWeb3Connector.getNetworkId = function () {
   return this.web3.eth.net.getId();
 };

--- a/packages/embarkjs-web3-connector/index.js
+++ b/packages/embarkjs-web3-connector/index.js
@@ -69,10 +69,10 @@ module.exports = async (embark) => {
     let code = `\nconst Web3 = global.__Web3 || require('${symlinkLocation}');`;
     code += `\nglobal.Web3 = Web3;`;
 
-    const connectorCode = fs.readFileSync(path.join(__dirname, 'web3Connector.js'), 'utf8');
+    const connectorCode = fs.readFileSync(path.join(__dirname, 'embarkJSWeb3Connector.js'), 'utf8');
     code += connectorCode;
 
-    code += "\nEmbarkJS.Blockchain.registerProvider('web3', web3Connector);";
+    code += "\nEmbarkJS.Blockchain.registerProvider('web3', embarkJSWeb3Connector);";
 
     code += "\nEmbarkJS.Blockchain.setProvider('web3', {});";
 

--- a/packages/embarkjs-web3-connector/index.js
+++ b/packages/embarkjs-web3-connector/index.js
@@ -1,82 +1,59 @@
 const path = require('path');
-const fs = require('fs');
 
-function whenRuncodeReady(embark) {
-  return new Promise((resolve) => {
-    embark.events.on('runcode:ready', () => {
-      resolve();
-    });
-  });
-}
+class EmbarkJSWeb3Connector {
+  constructor(embark, _options) {
+    this.embark = embark;
+    this.events = embark.events;
+    this.fs = embark.fs;
+    this.config = embark.config;
+    this.constants = embark.constants;
+    this.registerProvider();
+  }
 
-function getWeb3Location(embark) {
-  return new Promise((resolve, reject) => {
-    embark.events.request("version:get:web3", (web3Version) => {
-      if (web3Version === "1.0.0-beta") {
-        const nodePath = embark.embarkPath('node_modules');
-        const web3Path = require.resolve("web3", {paths: [nodePath]});
-        return resolve(web3Path);
+  async registerProvider() {
+    let blockchainConnectorReady = false;
+    await this.whenRuncodeReady();
+
+    const web3LocationPromise = this.getWeb3Location();
+
+    this.events.setCommandHandler('blockchain:connector:ready', (cb) => {
+      if (blockchainConnectorReady) {
+        return cb();
       }
-      embark.events.request("version:getPackageLocation", "web3", web3Version, (err, location) => {
-        if (err) {
-          return reject(err);
-        }
-        const locationPath = embark.embarkPath(location);
-        resolve(locationPath);
+      this.events.once("blockchain:connector:ready", () => {
+        cb();
       });
     });
-  });
-}
 
-function generateSymlink(embark, location) {
-  return new Promise((resolve, reject) => {
-    embark.events.request('code-generator:symlink:generate', location, 'web3', (err, symlinkDest) => {
-      if (err) {
-        return reject(err);
-      }
-      resolve(symlinkDest);
+    web3LocationPromise.then((_web3Location) => {
+      blockchainConnectorReady = true;
+      this.events.emit('blockchain:connector:ready');
     });
-  });
-}
 
-module.exports = async (embark) => {
-  let blockchainConnectorReady = false;
-  await whenRuncodeReady(embark);
+    let web3Location = await web3LocationPromise;
+    web3Location = web3Location.replace(/\\/g, '/');
 
-  const web3LocationPromise = getWeb3Location(embark);
+    await this.registerVar('__Web3', require(web3Location));
 
-  embark.events.setCommandHandler('blockchain:connector:ready', (cb) => {
-    if (blockchainConnectorReady) {
-      return cb();
-    }
-    embark.events.once("blockchain:connector:ready", () => {
-      cb();
-    });
-  });
-
-  web3LocationPromise.then((_web3Location) => {
-    blockchainConnectorReady = true;
-    embark.events.emit('blockchain:connector:ready');
-  });
-
-  let web3Location = await web3LocationPromise;
-
-  web3Location = web3Location.replace(/\\/g, '/');
-
-  embark.events.emit('runcode:register', '__Web3', require(web3Location), async () => {
-    const symlinkLocation = await generateSymlink(embark, web3Location);
+    const symlinkLocation = await this.generateSymlink(web3Location);
 
     let code = `\nconst Web3 = global.__Web3 || require('${symlinkLocation}');`;
     code += `\nglobal.Web3 = Web3;`;
 
-    const connectorCode = fs.readFileSync(path.join(__dirname, 'embarkJSWeb3Connector.js'), 'utf8');
+    const connectorCode = this.fs.readFileSync(path.join(__dirname, 'embarkJSWeb3Connector.js'), 'utf8');
     code += connectorCode;
 
     code += "\nEmbarkJS.Blockchain.registerProvider('web3', embarkJSWeb3Connector);";
-
     code += "\nEmbarkJS.Blockchain.setProvider('web3', {});";
 
-    embark.addCodeToEmbarkJS(code);
+    const configPath = this.fs.dappPath(this.config.embarkConfig.generationDir, this.constants.dappArtifacts.dir, this.constants.dappArtifacts.blockchain).replace(/\\/g, '/');
+
+    code += `\nif (!global.__Web3) {`; // Only connect when in the Dapp
+    code += `\n  const web3ConnectionConfig = require('${configPath}');`;
+    code += `\n  EmbarkJS.Blockchain.connect(web3ConnectionConfig, (err) => {if (err) { console.error(err); } });`;
+    code += `\n}`;
+
+    this.embark.addCodeToEmbarkJS(code);
 
     code = "EmbarkJS.Blockchain.setProvider('web3', {web3});";
 
@@ -84,6 +61,54 @@ module.exports = async (embark) => {
       return true;
     };
 
-    embark.addConsoleProviderInit('blockchain', code, shouldInit);
-  });
-};
+    this.embark.addConsoleProviderInit('blockchain', code, shouldInit);
+  }
+
+  whenRuncodeReady() {
+    return new Promise((resolve) => {
+      this.events.on('runcode:ready', () => {
+        resolve();
+      });
+    });
+  }
+
+  getWeb3Location() {
+    return new Promise((resolve, reject) => {
+      this.events.request("version:get:web3", (web3Version) => {
+        if (web3Version === "1.0.0-beta") {
+          const nodePath = this.fs.embarkPath('node_modules');
+          const web3Path = require.resolve("web3", {paths: [nodePath]});
+          return resolve(web3Path);
+        }
+        this.events.request("version:getPackageLocation", "web3", web3Version, (err, location) => {
+          if (err) {
+            return reject(err);
+          }
+          const locationPath = this.fs.embarkPath(location);
+          resolve(locationPath);
+        });
+      });
+    });
+  }
+
+  generateSymlink(location) {
+    return new Promise((resolve, reject) => {
+      this.events.request('code-generator:symlink:generate', location, 'web3', (err, symlinkDest) => {
+        if (err) {
+          return reject(err);
+        }
+        resolve(symlinkDest);
+      });
+    });
+  }
+
+  registerVar(name, code) {
+    return new Promise((resolve) => {
+      this.events.emit('runcode:register', name, code, () => {
+        resolve();
+      });
+    });
+  }
+}
+
+module.exports = EmbarkJSWeb3Connector;

--- a/packages/embarkjs-web3-connector/package.json
+++ b/packages/embarkjs-web3-connector/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "web3connector",
+  "name": "embarkjs-web3-connector",
   "version": "4.0.0-beta.0",
   "description": "Web3.js Connector for EmbarkJS",
   "main": "index.js",
@@ -8,7 +8,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "embark/packages/Web3Connector"
+    "url": "embark/packages/embarkjs-web3-connector"
   },
   "keywords": [
     "embark",

--- a/packages/embarkjs/src/blockchain.js
+++ b/packages/embarkjs/src/blockchain.js
@@ -192,7 +192,8 @@ Blockchain.doConnect = function(connectionList, opts, doneCb) {
         // embark will only do this if geth is our client and we are in
         // dev mode
         if (opts.blockchainClient === 'geth') {
-          console.warn("%cNote: There is a known issue with Geth that may cause transactions to get stuck when using Metamask. Please log in to the cockpit (http://localhost:8000/embark?enableRegularTxs=true) to enable a workaround. Once logged in, the workaround will automatically be enabled.", "font-size: 2em");
+          // TODO find a way to share the port number
+          console.warn("%cNote: There is a known issue with Geth that may cause transactions to get stuck when using Metamask. Please log in to the cockpit (http://localhost:55555/embark?enableRegularTxs=true) to enable a workaround. Once logged in, the workaround will automatically be enabled.", "font-size: 2em");
         }
         if (opts.blockchainClient === 'parity') {
           console.warn("%cNote: Parity blocks the connection from browser extensions like Metamask. To resolve this problem, go to https://embark.status.im/docs/blockchain_configuration.html#Using-Parity-and-Metamask", "font-size: 2em");

--- a/test_dapps/contracts_app/embark.json
+++ b/test_dapps/contracts_app/embark.json
@@ -16,6 +16,6 @@
     "solc": "0.4.24"
   },
   "plugins": {
-    "web3connector": {}
+    "embarkjs-web3-connector": {}
   }
 }

--- a/test_dapps/contracts_app/embark.json
+++ b/test_dapps/contracts_app/embark.json
@@ -16,6 +16,6 @@
     "solc": "0.4.24"
   },
   "plugins": {
-    "embarkjs-web3-connector": {}
+    "embarkjs-connector-web3": {}
   }
 }

--- a/test_dapps/contracts_app/package.json
+++ b/test_dapps/contracts_app/package.json
@@ -4,7 +4,7 @@
     "rimraf": "2.6.3"
   },
   "dependencies": {
-    "web3connector": "4.0.0-beta.0"
+    "embarkjs-web3-connector": "4.0.0-beta.0"
   },
   "name": "contracts_app",
   "private": true,

--- a/test_dapps/contracts_app/package.json
+++ b/test_dapps/contracts_app/package.json
@@ -4,7 +4,7 @@
     "rimraf": "2.6.3"
   },
   "dependencies": {
-    "embarkjs-web3-connector": "4.0.0-beta.0"
+    "embarkjs-connector-web3": "4.0.0-beta.0"
   },
   "name": "contracts_app",
   "private": true,

--- a/test_dapps/test_app/app/js/index.js
+++ b/test_dapps/test_app/app/js/index.js
@@ -2,7 +2,6 @@
 import React  from 'react';
 import EmbarkJS from 'Embark/EmbarkJS';
 import {SimpleStorage, Test, SimpleStorageTest} from '../../embarkArtifacts/contracts';
-import config from '../../embarkArtifacts/config/blockchain';
 
 window.SimpleStorageTest = SimpleStorageTest;
 
@@ -34,7 +33,7 @@ var addToLog = function(id, txt) {
 // Blockchain example
 // ===========================
 $(document).ready(function() {
-  EmbarkJS.Blockchain.connect(config, (err) => {
+  EmbarkJS.onReady((err) => {
     if (err) {
       console.error(err);
     }

--- a/test_dapps/test_app/embark.json
+++ b/test_dapps/test_app/embark.json
@@ -21,7 +21,7 @@
   },
   "plugins": {
     "embark-service": {},
-    "embarkjs-web3-connector": {}
+    "embarkjs-connector-web3": {}
   },
   "options": {
     "solc": {

--- a/test_dapps/test_app/embark.json
+++ b/test_dapps/test_app/embark.json
@@ -21,7 +21,7 @@
   },
   "plugins": {
     "embark-service": {},
-    "web3connector": {}
+    "embarkjs-web3-connector": {}
   },
   "options": {
     "solc": {

--- a/test_dapps/test_app/package.json
+++ b/test_dapps/test_app/package.json
@@ -14,7 +14,7 @@
     "zeppelin-solidity": "1.12.0"
   },
   "dependencies": {
-    "embarkjs-web3-connector": "4.0.0-beta.0"
+    "embarkjs-connector-web3": "4.0.0-beta.0"
   },
   "name": "test_app",
   "private": true,

--- a/test_dapps/test_app/package.json
+++ b/test_dapps/test_app/package.json
@@ -14,7 +14,7 @@
     "zeppelin-solidity": "1.12.0"
   },
   "dependencies": {
-    "web3connector": "4.0.0-beta.0"
+    "embarkjs-web3-connector": "4.0.0-beta.0"
   },
   "name": "test_app",
   "private": true,


### PR DESCRIPTION
- Renames the connector to `embarkjs-web3-connector`
- Enables the use of Classes for external plugins
- Only calls doFirst once when connecting in EmbarkJS.Blockchain.connect (otherwise, onReady was called twice)
- Automatically connects for the user in the Dapp
- Converts web3-connector to a class
- Replace the BLockhain.connects by onReady