### PR TITLE
fix(@embark/cockpit): Fix decode transaction error

### DIFF
--- a/packages/embark-ui/src/actions/index.js
+++ b/packages/embark-ui/src/actions/index.js
@@ -1,6 +1,3 @@
-import {EMBARK_PROCESS_NAME} from '../constants';
-import {ansiToHtml} from '../utils/utils';
-
 export const REQUEST = 'REQUEST';
 export const SUCCESS = 'SUCCESS';
 export const FAILURE = 'FAILURE';

--- a/packages/embark-ui/src/components/ContractsDeployment.js
+++ b/packages/embark-ui/src/components/ContractsDeployment.js
@@ -54,8 +54,8 @@ const LayoutContract = ({contract, children, cardTitle}) => (
 
 LayoutContract.propTypes = {
   contract: PropTypes.object,
-  children: PropTypes.array,
-  cardTitle: PropTypes.object
+  children: PropTypes.any,
+  cardTitle: PropTypes.any
 };
 
 const DeploymentResult = ({deployment}) => {

--- a/packages/embark-ui/src/services/web3.js
+++ b/packages/embark-ui/src/services/web3.js
@@ -21,13 +21,12 @@ export function estimateGas({web3, contract, args}) {
 
 export function deploy({web3, contract, args}) {
   return new Promise((resolve, reject) => {
-    const cleanup = () => { promiEvent.removeAllListeners(); };
-    const promiEvent = new web3.eth.Contract(contract.abiDefinition)
+    new web3.eth.Contract(contract.abiDefinition)
       .deploy({data: `0x${contract.code}`, arguments: args})
       .send({from: web3.eth.defaultAccount})
       .on('error', reject)
-      .on('receipt', resolve)
-      .then(cleanup)
-      .catch(cleanup);
-  });
+      .once('receipt', resolve)
+      .catch(reject)
+      .then(() => {});
+    });
 }

--- a/packages/embark/src/lib/modules/blockchain_connector/index.js
+++ b/packages/embark/src/lib/modules/blockchain_connector/index.js
@@ -419,7 +419,7 @@ class BlockchainConnector {
       'get',
       '/embark-api/blockchain/transactions/:hash',
       (req, res) => {
-        self.getTransactionByRawTransactionHash(req.params.hash, (err, transaction) => {
+        self.getTransactionByHash(req.params.hash, (err, transaction) => {
           if (err) {
             self.logger.error(err);
           }


### PR DESCRIPTION
Reproduce:
1. Go to cockpit > transactions
2. Click a transaction
3. There will be a flicker of an error, then the decoded tx displays OK. Inspecting the network requests, there is a 500 error with a response of
```
AssertionError [ERR_ASSERTION]: invalid remainder
```
This error is also printed in the console.

The issue is that the transaction is not a raw transaction, so instead of trying to decode the non-raw transaction, the transaction can be decoded by web3.