### PR TITLE
fix(@embark/cockpit): Fix cockpit not suggesting console commands

### DIFF
--- a/packages/embark-typings/src/embark.d.ts
+++ b/packages/embark-typings/src/embark.d.ts
@@ -1,4 +1,5 @@
 import { Logger } from "./logger";
+import { Plugins } from "./plugins";
 
 export interface Events {
   on: any;
@@ -19,6 +20,7 @@ export interface Config {
       solc: string;
     }
   };
+  plugins: Plugins;
   reloadConfig(): void;
 }
 

--- a/packages/embark/src/lib/modules/debugger/index.ts
+++ b/packages/embark/src/lib/modules/debugger/index.ts
@@ -250,7 +250,7 @@ class TransactionDebugger {
         const filename: string = this.txTracker[this.lastTx].contract.filename;
         startDebug(txHash, filename, callback);
       },
-      usage: "debug <txHash>",
+      usage: "debug [txHash]",
     });
 
     this.embark.registerConsoleCommand({

--- a/packages/embark/src/lib/modules/ens/index.js
+++ b/packages/embark/src/lib/modules/ens/index.js
@@ -92,7 +92,7 @@ class ENS {
 
   registerConsoleCommands() {
     this.embark.registerConsoleCommand({
-      usage: 'resolve <name>',
+      usage: 'resolve [name]',
       description: __('Resolves an ENS name'),
       matches: (cmd) => {
         let [cmdName] = cmd.split(' ');
@@ -105,7 +105,7 @@ class ENS {
     });
 
     this.embark.registerConsoleCommand({
-      usage: 'lookup <address>',
+      usage: 'lookup [address]',
       description: __('Lookup an ENS address'),
       matches: (cmd) => {
         let [cmdName] = cmd.split(' ');
@@ -119,7 +119,7 @@ class ENS {
 
 
     this.embark.registerConsoleCommand({
-      usage: 'registerSubDomain <subDomain> <address>',
+      usage: 'registerSubDomain [subDomain] [address]',
       description: __('Register an ENS sub-domain'),
       matches: (cmd) => {
         let [cmdName] = cmd.split(' ');

--- a/packages/embark/src/lib/modules/plugin_cmd/index.js
+++ b/packages/embark/src/lib/modules/plugin_cmd/index.js
@@ -13,7 +13,7 @@ class PluginCommand {
   registerCommand() {
     this.embark.registerConsoleCommand({
       description: "Installs a plugin in the Dapp. eg: plugin install embark-solc",
-      usage: "plugin install <package>",
+      usage: "plugin install [package]",
       matches: (cmd) => {
         const [cmdName] = cmd.split(' ');
         return cmdName === 'plugin';

--- a/packages/embark/src/lib/modules/profiler/index.js
+++ b/packages/embark/src/lib/modules/profiler/index.js
@@ -71,7 +71,7 @@ class Profiler {
   registerConsoleCommand() {
     this.embark.registerConsoleCommand({
       description: "Outputs the function profile of a contract",
-      usage: "profile <contractName>",
+      usage: "profile [contractName]",
       matches: (cmd) => {
         const [cmdName] = cmd.split(' ');
         return cmdName === 'profile';


### PR DESCRIPTION
## NOTE 
This is a recreation of https://github.com/embark-framework/embark/pull/1346, as somehow this commit got eliminated in a merge, and ultimately, never applied to master.

## Fixes
This PR fixes a number of issues relating to the cockpit console.

#### Console commands display in cockpit console
Fix cockpit console not displaying console usage commands that included “<usage option>”. For example “resolve <name>” would not display the “<name>” part, as it was attempting to write this in as HTML (ansi-to-html conversion).

This was fixed by replacing any instances of “<usage>” with “[usage]”. Please note that future usage strings should not contain text wrapped in “<>”.

#### Autosuggestions for “web.eth.” not appearing
Fix “web3.eth.” not suggesting members of `web3.eth`. This was due to a `Object.keys(web3.eth)` throwing `'getOwnPropertyDescriptor' on proxy: trap returned descriptor for property 'defaultAccount' that is incompatible with the existing property in the proxy target` in the console. Changing `Object.keys` to `Object.getOwnPropertyDescriptor` solved the problem.

#### Fix autosuggestion of known console commands (ie from plugins)
Fix known console commands (ie from  plugins) not being autosuggested. For example, typing “web”, should autosuggest `webserver start/stop`,  `log webserver on`, and `log webserver off`.

This PR adds in support for registered console commands (from plugins).