### PR TITLE
fix(@embark/cockpit): Fix whisper messages not being received

### DIFF
--- a/packages/embark/src/lib/modules/whisper/index.js
+++ b/packages/embark/src/lib/modules/whisper/index.js
@@ -18,6 +18,7 @@ class Whisper {
     this.web3 = new Web3();
     this.embark = embark;
     this.web3Ready = false;
+    this.webSocketsChannels = {};
 
     if (embark.currentContext.includes('test') && options.node &&options.node === 'vm') {
       this.logger.info(__('Whisper disabled in the tests'));


### PR DESCRIPTION
Cockpit whisper messages were not being subscribed to due to a inocuous bug that would swallow errors and ultimately not be subscribed to the `rxjs` observer.