### PR TITLE
fix(console): fix ENS tests not working with embark side by side

### DIFF
--- a/packages/embark-typings/src/embark.d.ts
+++ b/packages/embark-typings/src/embark.d.ts
@@ -31,5 +31,6 @@ export interface Embark {
   logger: Logger;
   fs: any;
   config: Config;
+  currentContext: string[];
   registerActionForEvent(name: string, action: (callback: () => void) => void): void;
 }

--- a/packages/embark-ui/src/actions/index.js
+++ b/packages/embark-ui/src/actions/index.js
@@ -1,3 +1,6 @@
+import {EMBARK_PROCESS_NAME} from '../constants';
+import {ansiToHtml} from '../utils/utils';
+
 export const REQUEST = 'REQUEST';
 export const SUCCESS = 'SUCCESS';
 export const FAILURE = 'FAILURE';
@@ -118,7 +121,17 @@ export const COMMANDS = createRequestTypes('COMMANDS');
 export const commands = {
   post: (command) => action(COMMANDS[REQUEST], {command}),
   success: (command, payload) => {
-    return action(COMMANDS[SUCCESS], {});
+    return action(COMMANDS[SUCCESS], {
+      processLogs: [
+        {
+          timestamp: new Date().getTime(),
+          name: EMBARK_PROCESS_NAME,
+          msg: `${ansiToHtml(command.result || '')}`,
+          command: `console> ${payload.command}<br>`,
+          result: command.result
+        }
+      ]
+    });
   },
   failure: (error) => action(COMMANDS[FAILURE], {error})
 };

--- a/packages/embark/src/cmd/cmd_controller.js
+++ b/packages/embark/src/cmd/cmd_controller.js
@@ -346,8 +346,7 @@ class EmbarkController {
         new REPL({
           events: engine.events,
           env: engine.env,
-          ipc: engine.ipc,
-          logger: engine.logger
+          ipc: engine.ipc
         }).start(callback);
       }
     ], function (err, _result) {

--- a/packages/embark/src/cmd/dashboard/dashboard.js
+++ b/packages/embark/src/cmd/dashboard/dashboard.js
@@ -25,7 +25,7 @@ class Dashboard {
   start(done) {
     let monitor;
 
-    monitor = new Monitor({env: this.env, events: this.events, version: this.version, ipc: this.ipc, logger: this.logger});
+    monitor = new Monitor({env: this.env, events: this.events, version: this.version, ipc: this.ipc});
     this.logger.logFunction = monitor.logEntry;
     let plugin = this.plugins.createPlugin('dashboard', {});
     plugin.registerAPICall(

--- a/packages/embark/src/cmd/dashboard/monitor.js
+++ b/packages/embark/src/cmd/dashboard/monitor.js
@@ -11,7 +11,6 @@ class Monitor {
     this.color = options.color || "green";
     this.minimal = options.minimal || false;
     this.ipc = options.ipc;
-    this.logger = options.logger;
 
     this.screen = blessed.screen({
       smartCSR: true,
@@ -53,7 +52,6 @@ class Monitor {
     this.repl = new REPL({
       events: this.events,
       env: this.env,
-      logger: this.logger,
       inputStream: this.terminalReadableStream,
       outputStream: terminalWritableStream,
       logText: this.logText,

--- a/packages/embark/src/cmd/dashboard/repl.js
+++ b/packages/embark/src/cmd/dashboard/repl.js
@@ -9,7 +9,6 @@ class REPL {
     this.outputStream = options.outputStream || process.stdout;
     this.logText = options.logText;
     this.ipc = options.ipc;
-    this.logger = options.logger;
   }
 
   addHistory(cmd) {
@@ -19,9 +18,9 @@ class REPL {
     }
   }
 
-  enhancedEval(cmd, _context, _filename, _callback) {
-    this.events.request('console:executeCmd', cmd.trim(), (err, message) => {
-      this.logger.info(message === undefined ? '' : message);
+  enhancedEval(cmd, context, filename, callback) {
+    this.events.request('console:executeCmd', cmd.trim(), function (err, message) {
+      callback(err, message === undefined ? '' : message); // This way, we don't print undefined
     });
   }
 

--- a/packages/embark/src/lib/core/logger.js
+++ b/packages/embark/src/lib/core/logger.js
@@ -17,7 +17,7 @@ class Logger {
       const args = Array.from(arguments);
       const color = args[args.length - 1];
       args.splice(args.length - 1, 1);
-      this._logFunction(...args.map(arg => {
+      this._logFunction(...args.filter(arg => arg !== undefined && arg !== null).map(arg => {
         if (color) {
           return typeof arg === 'object' ? util.inspect(arg, 2)[color] : arg[color];
         }

--- a/packages/embark/src/lib/modules/console/index.ts
+++ b/packages/embark/src/lib/modules/console/index.ts
@@ -3,6 +3,7 @@ const env = require("../../core/env");
 const utils = require("../../utils/utils");
 const escapeHtml = require("../../utils/escapeHtml");
 import { Callback } from "embark";
+import constants from "../../constants.json";
 const stringify = require("json-stringify-safe");
 import { waterfall } from "async";
 import { Embark, Events } from "embark";
@@ -85,7 +86,7 @@ class Console {
   }
 
   private get isEmbarkConsole() {
-    return this.ipc.connected && this.ipc.isClient();
+    return this.ipc.connected && this.ipc.isClient() && this.embark.currentContext && this.embark.currentContext.includes(constants.contexts.console);
   }
 
   private cmdHistorySize() {

--- a/packages/embark/src/lib/modules/console/index.ts
+++ b/packages/embark/src/lib/modules/console/index.ts
@@ -96,7 +96,6 @@ class Console {
   private registerApi() {
     const plugin = this.plugins.createPlugin("consoleApi", {});
     plugin.registerAPICall("post", "/embark-api/command", (req: any, res: any) => {
-      this.logger.info(`Cockpit> ${req.body.command}`.cyan);
       this.executeCmd(req.body.command, (err: any, result: any) => {
         if (err) {
           return res.send({ result: err.message || err });
@@ -104,10 +103,8 @@ class Console {
         let response = result;
         if (typeof result !== "string") {
           response = stringify(result, utils.jsonFunctionReplacer, 2);
-          this.logger.info(response);
         } else {
           // Avoid HTML injection in the Cockpit
-          this.logger.info(response);
           response = escapeHtml(response);
         }
         return res.send({ result: response });

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,6 +7,7 @@
     "noEmit": true,
     "noImplicitThis": false,
     "strict": true,
-    "target": "ES2017"
+    "target": "ES2017",
+    "resolveJsonModule": true
   }
 }


### PR DESCRIPTION
I'd like @emizzle to confirm I didn't do something wrong, but long story short, when the console is a client in terms of IPC, it didn't do the EmbarkJS `connectConsole` so ENS tests were bound to fail. 

I think we could actually remove the `isEmbarkConsole` condition altogether for the register, but maybe it slows things down a bit or we make it so that we eval only through the console? Because there's a weird gap between runCode and console, but they still need one another