### PR TITLE
fix(ens/logger): add ens contracts to contract manager before deploy

### DIFF
--- a/packages/embark-ui/src/components/ContractOverview.js
+++ b/packages/embark-ui/src/components/ContractOverview.js
@@ -203,6 +203,9 @@ const filterContractFunctions = (contractFunctions, contractName, method) => {
 const ContractOverview = (props) => {
   const {contractProfile, contract} = props;
   const contractDisplay = formatContractForDisplay(contract);
+  if (!contractDisplay) {
+    return '';
+  }
 
   return (
     <div>

--- a/packages/embark-ui/src/components/Contracts.js
+++ b/packages/embark-ui/src/components/Contracts.js
@@ -17,6 +17,9 @@ const Contracts = ({contracts, title = "Contracts"}) => (
           {
             contracts.map(contract => {
               const contractDisplay = formatContractForDisplay(contract);
+              if (!contractDisplay) {
+                return '';
+              }
 
               return (
                 <div className="explorer-row border-top" key={contract.address}>
@@ -31,7 +34,7 @@ const Contracts = ({contracts, title = "Contracts"}) => (
                     <Col>
                       <strong>State</strong>
                       <div className={contractDisplay.stateColor}>
-                        {formatContractForDisplay(contract).state}
+                        {contractDisplay.state}
                       </div>
                     </Col>
                   </Row>

--- a/packages/embark-ui/src/components/ContractsList.js
+++ b/packages/embark-ui/src/components/ContractsList.js
@@ -17,6 +17,9 @@ const ContractsList = ({contracts}) => (
       {
         contracts.map((contract) => {
           const contractDisplay = formatContractForDisplay(contract);
+          if (!contractDisplay) {
+            return '';
+          }
           return (
             <tr key={contract.className} className={contractDisplay.stateColor}>
               <td><Link to={`/explorer/contracts/${contract.className}`}>{contract.className}</Link></td>

--- a/packages/embark-ui/src/utils/presentation.js
+++ b/packages/embark-ui/src/utils/presentation.js
@@ -1,4 +1,7 @@
 export function formatContractForDisplay(contract) {
+  if (contract.silent) {
+    return;
+  }
   let address = (contract.address || contract.deployedAddress);
   let state = 'Deployed';
   let stateColor = 'success';

--- a/packages/embark/src/lib/modules/contracts_manager/index.js
+++ b/packages/embark/src/lib/modules/contracts_manager/index.js
@@ -24,6 +24,10 @@ class ContractsManager {
       cb(self.compileError, self.listContracts());
     });
 
+    self.events.setCommandHandler('contracts:add', (contract) => {
+      this.contracts[contract.className] = contract;
+    });
+
     self.events.setCommandHandler('contracts:all', (cb) => {
       cb(self.compileError, self.contracts);
     });

--- a/packages/embark/src/lib/modules/ens/index.js
+++ b/packages/embark/src/lib/modules/ens/index.js
@@ -419,12 +419,14 @@ class ENS {
         });
       },
       function registry(next) {
+        self.events.request('contracts:add', self.ensConfig.ENSRegistry);
         self.events.request('deploy:contract', self.ensConfig.ENSRegistry, (err, _receipt) => {
           return next(err);
         });
       },
       function resolver(next) {
         self.ensConfig.Resolver.args = [self.ensConfig.ENSRegistry.deployedAddress];
+        self.events.request('contracts:add', self.ensConfig.Resolver);
         self.events.request('deploy:contract', self.ensConfig.Resolver, (err, _receipt) => {
           return next(err);
         });
@@ -446,6 +448,7 @@ class ENS {
         const contract = self.ensConfig.FIFSRegistrar;
         contract.args = [registryAddress, rootNode];
 
+        self.events.request('contracts:add', contract);
         self.events.request('deploy:contract', contract, (err, _receipt) => {
           return next(err);
         });


### PR DESCRIPTION
Fixes the problem with `Contract log for unknown contract: {"type":"contract-`, because ENS contracts were not part of the contract manager.