### PR TITLE
fix: blockchain logs show in cockpit

### DIFF
--- a/packages/embark/src/lib/core/ipc.js
+++ b/packages/embark/src/lib/core/ipc.js
@@ -118,6 +118,7 @@ class IPC {
       cb = cb || (() => {});
       return cb();
     }
+
     if (cb) {
       this.once(action, cb);
     }

--- a/packages/embark/src/lib/modules/blockchain_listener/index.js
+++ b/packages/embark/src/lib/modules/blockchain_listener/index.js
@@ -6,7 +6,7 @@ const PROCESS_NAME = 'blockchain';
  * BlockchainListener has two functions:
  * 1. Register API endpoints (HTTP GET and WS) to retrieve blockchain logs
  *    when in standalone mode (ie `embark blockchain`).
- * 2. Listen to log events from the IPC connection (to `embark blockchain`) 
+ * 2. Listen to log events from the IPC connection (to `embark blockchain`)
  *    and ensure they are processed through the LogHandler.
  */
 class BlockchainListener {
@@ -22,20 +22,20 @@ class BlockchainListener {
     this.events = embark.events;
     this.logger = embark.logger;
     this.ipc = ipc;
-    this.processLogsApi = new ProcessLogsApi({embark: this.embark, processName: PROCESS_NAME, silent: true});
 
-    if (this.ipc.isServer()) {
+    this.ipc.server.once('connect', () => {
+      this.processLogsApi = new ProcessLogsApi({embark: this.embark, processName: PROCESS_NAME, silent: true});
       this._listenToBlockchainLogs();
       this._listenToCommands();
       this._registerConsoleCommands();
       this._registerApiEndpoint();
-    }
+    });
   }
 
   /**
    * Listens to log events emitted by the standalone blockchain and ensures
    * they are processed through the LogHandler.
-   * 
+   *
    * @return {void}
    */
   _listenToBlockchainLogs() {


### PR DESCRIPTION
There are two ways to launch the blockchain process with Embark: standalone, by running `embark blockchain`, or with the dashboard, by running `embark run`.

When Embark runs, it also starts an IPC server that is used, amongst other things, to receive logs from potentially the standalone process. The problem is that the log listener for the standalone blockchain process starts independently of the blockchain process launcher, which will try to start a blockchain process even if one is already running. Each of these also registers an API endpoint which is supposed to serve logs. As the API endpoint is the same for both, one overwrites the other, and in this case `BlockchainListener` always won.

This PR sets things up in a way that `BlockchainListener` will only register its API endpoint if, and only if, an IPC connection occurs. The standalone blockchain process has a retry loop that will attempt to connect to IPC every so often, so once it connects, it will now send the logs that IPC missed plus any future logs.

You suck, @emizzle