### PR TITLE
fix(@embark/core): Fix contract accounts request handler

### DIFF
--- a/packages/embark/src/lib/modules/blockchain_connector/provider.js
+++ b/packages/embark/src/lib/modules/blockchain_connector/provider.js
@@ -18,7 +18,7 @@ class Provider {
     this.nonceCache = {};
 
     this.events.setCommandHandler("blockchain:provider:contract:accounts:get", cb => {
-      const accounts = this.accounts.map(a => a.address);
+      const accounts = this.accounts.map(a => a.address || a);
       cb(accounts);
     });
   }


### PR DESCRIPTION
Change the handler to get contract accounts to be able to grab the address from a contract object or a string.

Previously, this was causing the demo to hang as it was returning an array of `undefined`s.