### PR TITLE
fix(@embark/core): `web3.eth.getAccounts` returning empty

### DIFF
--- a/packages/embark/src/lib/modules/blockchain_connector/provider.js
+++ b/packages/embark/src/lib/modules/blockchain_connector/provider.js
@@ -129,7 +129,7 @@ class Provider {
               return cb(err);
             }
             if (self.accounts.length) {
-              result.result = self.blockchainAccounts.map(a => a.address);
+              result.result = self.addresses;
             }
             cb(null, result);
           });


### PR DESCRIPTION
`web3.eth.getAccounts` was returning an empty array in the console due to a change, that I’m unsure of what the original intention was for.

@andremedeiros, could you please take a look, and let me know if this breaks the intention of the original changes?