### PR TITLE
Add flag to show tx details in tests

### DIFF
--- a/packages/embark-typings/src/contract.d.ts
+++ b/packages/embark-typings/src/contract.d.ts
@@ -4,4 +4,5 @@ export interface Contract {
   abiDefinition: ABIDefinition[];
   deployedAddress: string;
   className: string;
+  silent?: boolean;
 }

--- a/packages/embark/src/cmd/cmd.js
+++ b/packages/embark/src/cmd/cmd.js
@@ -239,9 +239,10 @@ class Cmd {
               '                       vm - ' + __('start and use an Ethereum simulator (ganache)') + '\n' +
               '                       embark - ' + __('use the node of a running embark process') + '\n' +
               '                       <endpoint> - ' + __('connect to and use the specified node'))
-      .option('-d , --gasDetails', __('print the gas cost for each contract deployment when running the tests'))
+      .option('--gasDetails', __('print the gas cost for each contract deployment when running the tests. Deprecated: Please use --gas-details'))
+      .option('-d , --gas-details', __('print the gas cost for each contract deployment when running the tests'))
+      .option('-t , --tx-details', __('print the details of the transactions that happen during tests'))
       .option('-c , --coverage', __('generate a coverage report after running the tests (vm only)'))
-      .option('--nobrowser', __('do not start browser after coverage report is generated'))
       .option('--locale [locale]', __('language to use (default: en)'))
       .option('--loglevel [loglevel]', __('level of logging to display') + ' ["error", "warn", "info", "debug", "trace"]', /^(error|warn|info|debug|trace)$/i, 'warn')
       .option('--solc', __('run only solidity tests'))
@@ -261,8 +262,16 @@ class Cmd {
           process.exit(1);
         }
         i18n.setOrDetectLocale(options.locale);
-        embark.runTests({file, solc:options.solc, logLevel: options.loglevel, gasDetails: options.gasDetails,
-          node: options.node, coverage: options.coverage, noBrowser: options.nobrowser, env: options.env || 'development'});
+        embark.runTests({
+          file,
+          solc: options.solc,
+          logLevel: options.loglevel,
+          gasDetails: options.gasDetails,
+          txDetails: options.txDetails,
+          node: options.node,
+          coverage: options.coverage,
+          env: options.env || 'development'
+        });
       });
   }
 

--- a/packages/embark/src/lib/modules/tests/index.js
+++ b/packages/embark/src/lib/modules/tests/index.js
@@ -194,6 +194,7 @@ class TestRunner {
             mocha.reporter(reporter, {
               events: self.events,
               gasDetails: options.gasDetails,
+              txDetails: options.txDetails,
               gasLimit
             });
 

--- a/packages/embark/src/lib/utils/transactionUtils.ts
+++ b/packages/embark/src/lib/utils/transactionUtils.ts
@@ -1,0 +1,73 @@
+import {Contract} from "embark";
+import {ABIDefinition} from "web3/eth/abi";
+
+const utils = require("./utils");
+
+export interface AddressToContract {
+  name: string;
+  functions: { [functionName: string]: FunctionSignature; };
+  silent?: boolean;
+}
+
+export interface AddressToContractArray {
+  [address: string]: AddressToContract;
+}
+
+export interface FunctionSignature {
+  abi: ABIDefinition;
+  functionName?: string;
+  name: string;
+}
+
+export function getAddressToContract(contractsList: Contract[], addressToContract: AddressToContractArray): AddressToContractArray {
+  if (!contractsList) {
+    return addressToContract;
+  }
+  contractsList.forEach((contract: Contract) => {
+    if (!contract.deployedAddress) {
+      return;
+    }
+
+    const address = contract.deployedAddress.toLowerCase();
+    if (addressToContract[address]) {
+      return;
+    }
+    const funcSignatures: { [name: string]: FunctionSignature } = {};
+    contract.abiDefinition
+      .filter((func: ABIDefinition) => func.type === "function")
+      .map((func: ABIDefinition) => {
+        const name = `${func.name}(${func.inputs ? func.inputs.map((input) => input.type).join(",") : ""})`;
+        funcSignatures[utils.sha3(name).substring(0, 10)] = {
+          abi: func,
+          functionName: func.name,
+          name,
+        };
+      });
+
+    addressToContract[address] = {
+      functions: funcSignatures,
+      name: contract.className,
+      silent: contract.silent,
+    };
+  });
+  return addressToContract;
+}
+
+export function getTransactionParams(contract: AddressToContract, transactionInput: string): object {
+  const func = contract.functions[transactionInput.substring(0, 10)];
+  const functionName = func.functionName;
+
+  const decodedParameters = utils.decodeParams(func.abi.inputs, transactionInput.substring(10));
+  let paramString = "";
+  if (func.abi.inputs) {
+    func.abi.inputs.forEach((input) => {
+      const quote = input.type.indexOf("int") === -1 ? '"' : "";
+      paramString += quote + decodedParameters[input.name] + quote + ", ";
+    });
+    paramString = paramString.substring(0, paramString.length - 2);
+  }
+  return {
+    functionName,
+    paramString,
+  };
+}

--- a/packages/embark/src/test/modules/console_listener.js
+++ b/packages/embark/src/test/modules/console_listener.js
@@ -3,6 +3,7 @@ const {expect} = require('chai');
 const sinon = require('sinon');
 const Events = require('../../lib/core/events');
 const Logger = require('../../lib/core/logger');
+const transactionUtils = require('../../lib/utils/transactionUtils');
 const ConsoleListener = require('../../lib/modules/console_listener');
 const IPC = require('../../lib/core/ipc.js');
 require('colors');
@@ -99,8 +100,8 @@ function resetTest() {
     events,
     logger,
     fs: {
-      existsSync: () => { return false },
-      dappPath: () => { return "ok" }
+      existsSync: () => { return false; },
+      dappPath: () => { return "ok"; }
     },
     config: {
       contractsConfig: {}
@@ -128,85 +129,9 @@ describe('Console Listener', function () {
     done();
   });
 
-  describe('#updateContractList', function () {
-    it('should not update contracts list', function (done) {
-      contractsList.deployedAddress = undefined;
-      consoleListener._updateContractList(contractsList);
-
-      expect(consoleListener.addressToContract.length).to.be.equal(0);
-      done();
-    });
-
-    it('should update contracts list', function (done) {
-      consoleListener._updateContractList(contractsList);
-
-      expect(consoleListener.addressToContract["0x12345"]).to.deep.equal({
-        name: "SimpleStorage",
-        functions: {
-          "0x2a1afcd9": {
-            "abi": {
-              "constant": true,
-              "inputs": [],
-              "name": "storedData",
-              "outputs": [
-                {
-                  "name": "",
-                  "type": "uint256"
-                }
-              ],
-              "payable": false,
-              "stateMutability": "view",
-              "type": "function"
-            },
-            "functionName": "storedData",
-            "name": "storedData()"
-          },
-          "0x60fe47b1": {
-            "abi": {
-              "constant": false,
-              "inputs": [
-                {
-                  "name": "x",
-                  "type": "uint256"
-                }
-              ],
-              "name": "set",
-              "outputs": [],
-              "payable": false,
-              "stateMutability": "nonpayable",
-              "type": "function"
-            },
-            "functionName": "set",
-            "name": "set(uint256)"
-          },
-          "0x6d4ce63c": {
-            "abi": {
-              "constant": true,
-              "inputs": [],
-              "name": "get",
-              "outputs": [
-                {
-                  "name": "retVal",
-                  "type": "uint256"
-                }
-              ],
-              "payable": false,
-              "stateMutability": "view",
-              "type": "function"
-            },
-            "functionName": "get",
-            "name": "get()"
-          }
-        },
-        silent: true
-      });
-      done();
-    });
-  });
-
   describe('#listenForLogRequests', function () {
     it('should emit the correct contracts logs', function (done) {
-      consoleListener._updateContractList(contractsList);
+      transactionUtils.getAddressToContract(contractsList, consoleListener.addressToContract);
       consoleListener._onIpcLogRequest(ipcRequest);
 
       const expectedContractLog = {
@@ -249,7 +174,7 @@ describe('Console Listener', function () {
 
     it('should emit a log for a non-contract log', function (done) {
       ipcRequest.type = 'something-other-than-contract-log';
-      consoleListener._updateContractList(contractsList);
+      transactionUtils.getAddressToContract(contractsList, consoleListener.addressToContract);
       consoleListener._onIpcLogRequest(ipcRequest);
 
       expect(loggerInfos[0]).to.be.equal(JSON.stringify(ipcRequest));

--- a/packages/embark/src/test/transactionUtils.js
+++ b/packages/embark/src/test/transactionUtils.js
@@ -1,0 +1,170 @@
+/*globals describe, it, beforeEach*/
+const {expect} = require('chai');
+const transactionUtils = require('../lib/utils/transactionUtils');
+require('colors');
+
+let contractsList;
+
+function resetTest() {
+  contractsList = [
+    {
+      abiDefinition: [
+        {
+          "constant": true,
+          "inputs": [],
+          "name": "storedData",
+          "outputs": [
+            {
+              "name": "",
+              "type": "uint256"
+            }
+          ],
+          "payable": false,
+          "stateMutability": "view",
+          "type": "function"
+        },
+        {
+          "constant": false,
+          "inputs": [
+            {
+              "name": "x",
+              "type": "uint256"
+            }
+          ],
+          "name": "set",
+          "outputs": [],
+          "payable": false,
+          "stateMutability": "nonpayable",
+          "type": "function"
+        },
+        {
+          "constant": true,
+          "inputs": [],
+          "name": "get",
+          "outputs": [
+            {
+              "name": "retVal",
+              "type": "uint256"
+            }
+          ],
+          "payable": false,
+          "stateMutability": "view",
+          "type": "function"
+        },
+        {
+          "inputs": [
+            {
+              "name": "initialValue",
+              "type": "uint256"
+            }
+          ],
+          "payable": false,
+          "stateMutability": "nonpayable",
+          "type": "constructor"
+        }
+      ],
+      deployedAddress: "0x12345",
+      className: "SimpleStorage",
+      silent: true
+    }
+  ];
+}
+
+describe('Transaction Utils', () => {
+  beforeEach(() => {
+    resetTest();
+  });
+
+  describe('#getAddressToContract', () => {
+    it('should not update contracts list when no contracts', () => {
+      contractsList = [];
+      const result = transactionUtils.getAddressToContract(contractsList, {});
+
+      expect(result).to.deep.equal({});
+    });
+
+    it('should not update contracts list when not deployed', () => {
+      contractsList[0].deployedAddress = undefined;
+      const result = transactionUtils.getAddressToContract(contractsList, {});
+
+      expect(result).to.deep.equal({});
+    });
+
+    it('should update contracts list', () => {
+      const result = transactionUtils.getAddressToContract(contractsList, {});
+
+      expect(result).to.deep.equal({
+        "0x12345": {
+          name: "SimpleStorage",
+          functions: {
+            "0x2a1afcd9": {
+              "abi": {
+                "constant": true,
+                "inputs": [],
+                "name": "storedData",
+                "outputs": [
+                  {
+                    "name": "",
+                    "type": "uint256"
+                  }
+                ],
+                "payable": false,
+                "stateMutability": "view",
+                "type": "function"
+              },
+              "functionName": "storedData",
+              "name": "storedData()"
+            },
+            "0x60fe47b1": {
+              "abi": {
+                "constant": false,
+                "inputs": [
+                  {
+                    "name": "x",
+                    "type": "uint256"
+                  }
+                ],
+                "name": "set",
+                "outputs": [],
+                "payable": false,
+                "stateMutability": "nonpayable",
+                "type": "function"
+              },
+              "functionName": "set",
+              "name": "set(uint256)"
+            },
+            "0x6d4ce63c": {
+              "abi": {
+                "constant": true,
+                "inputs": [],
+                "name": "get",
+                "outputs": [
+                  {
+                    "name": "retVal",
+                    "type": "uint256"
+                  }
+                ],
+                "payable": false,
+                "stateMutability": "view",
+                "type": "function"
+              },
+              "functionName": "get",
+              "name": "get()"
+            }
+          },
+          silent: true
+        }
+      });
+    });
+  });
+
+  describe('#getTransactionParams', () => {
+    it('should return the param string and function name', () => {
+      const result = transactionUtils.getAddressToContract(contractsList, {});
+      const {functionName, paramString} = transactionUtils.getTransactionParams(result['0x12345'], '0x60fe47b100000000000000000000000099db99c77ad807f89829f5bda99527438f64a798');
+      expect(functionName).to.equal('set');
+      expect(paramString).to.equal('878372847193751743539905734564138820017777321880');
+
+    });
+  });
+});


### PR DESCRIPTION
Adds a flag to show the tx details just like the tx logger.
Since it uses the same functions as the tx logger, I moved the functions to a utils file and shared them.
![image](https://user-images.githubusercontent.com/11926403/53520108-d68a1f80-3aa2-11e9-8ebd-1fd5809b0836.png)
