### PR TITLE
fix(@embark/swarm): Fix swarm not being registered

### DIFF
--- a/packages/embark/src/lib/modules/ipfs/index.js
+++ b/packages/embark/src/lib/modules/ipfs/index.js
@@ -195,8 +195,13 @@ class IPFS {
   }
 
   isIpfsStorageEnabledInTheConfig() {
-    let {enabled, available_providers, dappConnection} = this.storageConfig;
-    return enabled && (available_providers.indexOf('ipfs') > 0 || dappConnection.find(c => c.provider === 'ipfs'));
+    let {enabled, available_providers, dappConnection, upload} = this.storageConfig;
+    return enabled && 
+            available_providers.includes('ipfs') && 
+            (
+              dappConnection.some(c => c.provider === 'ipfs') || 
+              upload.provider === 'ipfs'
+            );
   }
 }
 

--- a/packages/embark/src/lib/modules/swarm/index.js
+++ b/packages/embark/src/lib/modules/swarm/index.js
@@ -26,7 +26,9 @@ class Swarm {
     if(this.isSwarmEnabledInTheConfig() && cantDetermineUrl){
       console.warn('\n===== Swarm module will not be loaded =====');
       console.warn(`Swarm is enabled in the config, however the config is not setup to provide a URL for swarm and therefore the Swarm module will not be loaded. Please either change the ${'config/storage > upload'.bold} setting to Swarm or add the Swarm config to the ${'config/storage > dappConnection'.bold} array. Please see ${'https://embark.status.im/docs/storage_configuration.html'.underline} for more information.\n`);
-    } else {
+      return;
+    }
+    if (!this.isSwarmEnabledInTheConfig()) {
       this.embark.registerConsoleCommand({
         matches: cmd => cmd === "swarm" || cmd.indexOf('swarm ') === 0,
         process: (_cmd, cb) => {
@@ -34,14 +36,12 @@ class Swarm {
           cb();
         }
       });
-
       return;
     }
 
     this.providerUrl = utils.buildUrl(this.storageConfig.upload.protocol, this.storageConfig.upload.host, this.storageConfig.upload.port);
 
     this.getUrl = this.storageConfig.upload.getUrl || this.providerUrl + '/bzz:/';
-
 
     this.swarm = new SwarmAPI({gateway: this.providerUrl});
 
@@ -163,8 +163,13 @@ class Swarm {
   }
 
   isSwarmEnabledInTheConfig() {
-    let {enabled, available_providers, dappConnection} = this.storageConfig;
-    return enabled && (available_providers.indexOf('swarm') > 0 || dappConnection.find(c => c.provider === 'swarm'));
+    let {enabled, available_providers, dappConnection, upload} = this.storageConfig;
+    return enabled && 
+            available_providers.includes('swarm') && 
+            (
+              dappConnection.some(c => c.provider === 'swarm') ||
+              upload.provider === "swarm"
+            );
   }
 
 }


### PR DESCRIPTION
Swarm was not being registered as a service due to a recent change that introduced a bug. The previous change was meant to register “swarm” as a console command to provide output for the `swarm` console command when swarm had not been registered in the VM. The bug, however, returned too early in the cases when swarm was meant to be enabled, thus effectively not registering the entire process.

The fix simply returns only when swarm is in fact, disabled, and also alters slightly the way swarm is determined to be enabled (the changes of which have been copied over to `ipfs`).