### PR TITLE
fix: format \n as <br> in cockpit console

### DIFF
--- a/packages/embark-ui/src/components/Console.js
+++ b/packages/embark-ui/src/components/Console.js
@@ -11,7 +11,7 @@ import Logs from "./Logs";
 import "./Console.css";
 import {EMBARK_PROCESS_NAME} from '../constants';
 
-const convert = new Convert();
+const convert = new Convert({newline: true, escapeXML: true});
 
 class Console extends Component {
   constructor(props) {


### PR DESCRIPTION
This fixes cases where commands return results with `\n` characters that weren't reflected in the console, such as the `help` command.

[Documentation for these options.](https://www.npmjs.com/package/ansi-to-html#default-options)