### PR TITLE
fix: cockpit search with tx hash shows tx page

### DIFF
--- a/packages/embark-ui/src/sagas/searchSaga.js
+++ b/packages/embark-ui/src/sagas/searchSaga.js
@@ -47,9 +47,8 @@ export function *searchExplorer(entity, payload) {
   // Blocks
   yield fetchBlocks({limit: ELEMENTS_LIMIT});
   const blocks = yield select(getBlocks);
-  const intSearchValue = parseInt(searchValue, 10);
   result = blocks.find(block => {
-    return block.hash === searchValue || block.number === intSearchValue;
+    return block.hash === searchValue || block.number.toString() === searchValue;
   });
 
   if (result) {


### PR DESCRIPTION
This issue was caused by a string to integer conversion. In JavaScript,
when converting a string that starts with `0` (which is the case for tx
hashes) to an integer using `parseInt` it will always yield 0. That,
combined with a block with number 0 would always return a block result
instead of the transaction.

```
> parseInt("0xluri", 10)
0
```

This PR checks if the resulting number equals the string that was
provided on top of checking for the block number.