### PR TITLE
fix(@embark/core): Metamask + geth warning to enable regular txs

### DIFF
--- a/packages/embark-ui/src/actions/index.js
+++ b/packages/embark-ui/src/actions/index.js
@@ -420,6 +420,13 @@ export const initRegularTxs = {
   failure: () => action(INIT_REGULAR_TXS[FAILURE])
 };
 
+export const STOP_REGULAR_TXS = createRequestTypes('STOP_REGULAR_TXS');
+export const stopRegularTxs = {
+  request: () => action(STOP_REGULAR_TXS[REQUEST], {mode: 'off'}),
+  success: () => action(STOP_REGULAR_TXS[SUCCESS]),
+  failure: () => action(STOP_REGULAR_TXS[FAILURE])
+};
+
 // Web Socket
 export const WATCH_NEW_PROCESS_LOGS = 'WATCH_NEW_PROCESS_LOGS';
 export const STOP_NEW_PROCESS_LOGS = 'STOP_NEW_PROCESS_LOGS';

--- a/packages/embark-ui/src/containers/AppContainer.js
+++ b/packages/embark-ui/src/containers/AppContainer.js
@@ -17,6 +17,7 @@ import {
   listenToServices as listenToServicesAction,
   listenToContracts as listenToContractsAction,
   initRegularTxs as initRegularTxsAction,
+  stopRegularTxs as stopRegularTxsAction,
   changeTheme, fetchTheme
 } from '../actions';
 
@@ -71,7 +72,7 @@ class AppContainer extends Component {
       this.doAuthenticate();
     }
 
-    const enableRegularTxs = !!getQueryParam(this.props.location, ENABLE_REGULAR_TXS);
+    const enableRegularTxs = getQueryParam(this.props.location, ENABLE_REGULAR_TXS);
 
     if (getQueryToken(this.props.location) && 
         (!this.props.credentials.authenticating || 
@@ -85,8 +86,11 @@ class AppContainer extends Component {
       this.props.listenToServices();
       this.props.fetchPlugins();
       this.props.listenToContracts();
-      if (enableRegularTxs) {
+      if (enableRegularTxs === "true") {
         this.props.initRegularTxs();
+        this.props.history.replace(stripQueryParam(this.props.location, ENABLE_REGULAR_TXS));
+      } else if (enableRegularTxs === "false") {
+        this.props.stopRegularTxs();
         this.props.history.replace(stripQueryParam(this.props.location, ENABLE_REGULAR_TXS));
       }
     }
@@ -158,7 +162,8 @@ AppContainer.propTypes = {
   history: PropTypes.object,
   listenToServices: PropTypes.func,
   listenToContracts: PropTypes.func,
-  initRegularTxs: PropTypes.func
+  initRegularTxs: PropTypes.func,
+  stopRegularTxs: PropTypes.func
 };
 
 function mapStateToProps(state) {
@@ -184,6 +189,7 @@ export default withRouter(connect(
     changeTheme: changeTheme.request,
     fetchTheme: fetchTheme.request,
     listenToContracts: listenToContractsAction,
-    initRegularTxs: initRegularTxsAction.request
+    initRegularTxs: initRegularTxsAction.request,
+    stopRegularTxs: stopRegularTxsAction.request
   },
 )(AppContainer));

--- a/packages/embark-ui/src/sagas/index.js
+++ b/packages/embark-ui/src/sagas/index.js
@@ -79,7 +79,8 @@ export const debugStepIntoForward = doRequest.bind(null, actions.debugStepIntoFo
 export const debugStepIntoBackward = doRequest.bind(null, actions.debugStepIntoBackward, api.debugStepIntoBackward);
 export const toggleBreakpoint = doRequest.bind(null, actions.toggleBreakpoint, api.toggleBreakpoint);
 export const authenticate = doRequest.bind(null, actions.authenticate, api.authenticate);
-export const initRegularTxs = doRequest.bind(null, actions.initRegularTxs, api.initRegularTxs);
+export const initRegularTxs = doRequest.bind(null, actions.initRegularTxs, api.regularTxs);
+export const stopRegularTxs = doRequest.bind(null, actions.stopRegularTxs, api.regularTxs);
 
 export const fetchCredentials = doRequest.bind(null, actions.fetchCredentials, storage.fetchCredentials);
 export const saveCredentials = doRequest.bind(null, actions.saveCredentials, storage.saveCredentials);
@@ -348,6 +349,10 @@ export function *watchInitRegularTxs() {
   yield takeEvery(actions.INIT_REGULAR_TXS[actions.REQUEST], initRegularTxs);
 }
 
+export function *watchStopRegularTxs() {
+  yield takeEvery(actions.STOP_REGULAR_TXS[actions.REQUEST], stopRegularTxs);
+}
+
 function createChannel(socket) {
   return eventChannel(emit => {
     socket.onmessage = ((message) => {
@@ -591,6 +596,7 @@ export default function *root() {
     fork(watchPostFileSuccess),
     fork(watchPostFolderSuccess),
     fork(watchListenContracts),
-    fork(watchInitRegularTxs)
+    fork(watchInitRegularTxs),
+    fork(watchStopRegularTxs)
   ]);
 }

--- a/packages/embark-ui/src/services/api.js
+++ b/packages/embark-ui/src/services/api.js
@@ -228,7 +228,7 @@ export function toggleBreakpoint(payload) {
   return post('/debugger/breakpoint', {params: payload, credentials: payload.credentials});
 }
 
-export function initRegularTxs(payload) {
+export function regularTxs(payload) {
   return get('/regular-txs', {params: payload, credentials: payload.credentials});
 }
 

--- a/packages/embark/src/lib/modules/blockchain_listener/index.js
+++ b/packages/embark/src/lib/modules/blockchain_listener/index.js
@@ -60,8 +60,16 @@ class BlockchainListener {
     this.embark.registerAPICall(
       'get',
       '/embark-api/regular-txs',
-      (req, _res) => {
-        this.events.request(`regularTxs:${req.query.mode === 'on' ? 'start' : 'stop'}`);
+      (req, res) => {
+        if(!req.query.mode || !['on', 'off'].includes(req.query.mode)) {
+          return res.status(400).send("Invalid parameter 'mode' provided. Must be one of: ['on', 'off']");
+        }
+        this.events.request(`regularTxs:${req.query.mode === 'on' ? 'start' : 'stop'}`, (err, result) => {
+          if(err) {
+            return res.send({ error: err.message });
+          }
+          res.send(result);
+        });
       }
     );
   }

--- a/packages/embarkjs/src/blockchain.js
+++ b/packages/embarkjs/src/blockchain.js
@@ -13,7 +13,7 @@ Blockchain.connect = function(options, callback) {
   const connect = ({
     dappConnection,
     dappAutoEnable = true,
-    warnAboutMetamask,
+    warnIfMetamask,
     blockchainClient = ''
   }) => {
     return new Promise((resolve, reject) => {
@@ -21,8 +21,8 @@ Blockchain.connect = function(options, callback) {
         this.doFirst((done) => {
           this.autoEnable = dappAutoEnable;
           this.doConnect(dappConnection, {
-            warnAboutMetamask: warnAboutMetamask,
-            blockchainClient: blockchainClient
+            warnAboutMetamask: warnIfMetamask,
+            blockchainClient
           }, async (err) => {
             let _err = err;
             try {


### PR DESCRIPTION
A console warning is meant to appear in the browser console when the dapp is connecting to web3 using metamask and the blockchain client is geth. The warning displays information telling the user they should enable regular transactions to prevent known issues regarding transactions getting stuck.

The issue fixed here pertained to `warnAboutMetamask` vs `warnIfMetamask` - maybe there was a change that introduced this issue upstream.

Additionally, enabling and disabling of regular transactions via an API endpoint did not