### PR TITLE
fix(@embark/storage): Allow upload when storage disabled

### DIFF
--- a/packages/embark/src/lib/modules/ipfs/index.js
+++ b/packages/embark/src/lib/modules/ipfs/index.js
@@ -3,6 +3,7 @@ const utils = require('../../utils/utils.js');
 const IpfsApi = require('ipfs-api');
 // TODO: not great, breaks module isolation
 const StorageProcessesLauncher = require('../storage/storageProcessesLauncher');
+const constants = require('../../constants.json');
 
 class IPFS {
 
@@ -168,12 +169,12 @@ class IPFS {
   }
 
   listenToCommands() {
-    this.events.setCommandHandler('logs:ipfs:enable',  (cb) => {
+    this.events.setCommandHandler('logs:ipfs:enable', (cb) => {
       this.events.emit('logs:storage:enable');
       return cb(null, 'Enabling IPFS logs');
     });
 
-    this.events.setCommandHandler('logs:ipfs:disable',  (cb) => {
+    this.events.setCommandHandler('logs:ipfs:disable', (cb) => {
       this.events.emit('logs:storage:disable');
       return cb(null, 'Disabling IPFS logs');
     });
@@ -196,12 +197,14 @@ class IPFS {
 
   isIpfsStorageEnabledInTheConfig() {
     let {enabled, available_providers, dappConnection, upload} = this.storageConfig;
-    return enabled && 
-            available_providers.includes('ipfs') && 
-            (
-              dappConnection.some(c => c.provider === 'ipfs') || 
-              upload.provider === 'ipfs'
-            );
+    return (enabled || this.embark.currentContext.includes(constants.contexts.upload)) &&
+      (
+        available_providers.includes('ipfs') &&
+        (
+          dappConnection.some(c => c.provider === 'ipfs') ||
+          upload.provider === 'ipfs'
+        )
+      );
   }
 }
 

--- a/packages/embark/src/lib/modules/swarm/index.js
+++ b/packages/embark/src/lib/modules/swarm/index.js
@@ -23,7 +23,7 @@ class Swarm {
 
     const cantDetermineUrl = this.storageConfig.upload.provider !== 'swarm' && !this.storageConfig.dappConnection.some(connection => connection.provider === 'swarm');
 
-    if(this.isSwarmEnabledInTheConfig() && cantDetermineUrl){
+    if (this.isSwarmEnabledInTheConfig() && cantDetermineUrl) {
       console.warn('\n===== Swarm module will not be loaded =====');
       console.warn(`Swarm is enabled in the config, however the config is not setup to provide a URL for swarm and therefore the Swarm module will not be loaded. Please either change the ${'config/storage > upload'.bold} setting to Swarm or add the Swarm config to the ${'config/storage > dappConnection'.bold} array. Please see ${'https://embark.status.im/docs/storage_configuration.html'.underline} for more information.\n`);
       return;
@@ -136,12 +136,12 @@ class Swarm {
   }
 
   listenToCommands() {
-    this.events.setCommandHandler('logs:swarm:enable',  (cb) => {
+    this.events.setCommandHandler('logs:swarm:enable', (cb) => {
       this.events.emit('logs:storage:enable');
       return cb(null, 'Enabling Swarm logs');
     });
 
-    this.events.setCommandHandler('logs:swarm:disable',  (cb) => {
+    this.events.setCommandHandler('logs:swarm:disable', (cb) => {
       this.events.emit('logs:storage:disable');
       return cb(null, 'Disabling Swarm logs');
     });
@@ -164,12 +164,12 @@ class Swarm {
 
   isSwarmEnabledInTheConfig() {
     let {enabled, available_providers, dappConnection, upload} = this.storageConfig;
-    return enabled && 
-            available_providers.includes('swarm') && 
-            (
-              dappConnection.some(c => c.provider === 'swarm') ||
-              upload.provider === "swarm"
-            );
+    return (enabled || this.embark.currentContext.includes(constants.contexts.upload)) &&
+      available_providers.includes('swarm') &&
+      (
+        dappConnection.some(c => c.provider === 'swarm') ||
+        upload.provider === "swarm"
+      );
   }
 
 }


### PR DESCRIPTION
Allow `embark upload` to upload to IPFS/Swarm even if the storage module is disabled in the storage config.

An easy way to test this is to set `config/storage.js` > `enabled` to `false` in the demo. Then run `embark upload`.