### PR TITLE
fix(@embark/cockpit): Switching between tabs resets logs

### DIFF
--- a/packages/embark-ui/src/reducers/index.js
+++ b/packages/embark-ui/src/reducers/index.js
@@ -7,6 +7,12 @@ import {EMBARK_PROCESS_NAME, DARK_THEME, DEPLOYMENT_PIPELINES, DEFAULT_HOST, ELE
 
 const BN_FACTOR = 10000;
 const VOID_ADDRESS = '0x0000000000000000000000000000000000000000';
+// This is set so that the total number of logs allowed in the entities state is ELEMENTS_LIMIT
+// multipled by the number of services we are monitoring for logs. As it stands currently, we
+// are monitoring only "embark" and "blockchain" logs, hence we are allowing ELEMENTS_LIMIT * 2.
+// TODO: If we update the number of services to show process logs, we need to update this number
+// to reflect the new number of services.
+const PROCESS_LOGS_LIMIT = ELEMENTS_LIMIT * 2;
 
 const entitiesDefaultState = {
   accounts: [],
@@ -91,7 +97,7 @@ const filtrer = {
   },
   processLogs: function(processLog, index, self) {
     if (processLog.id !== undefined) {
-      return index === self.findIndex((p) => p.id === processLog.id) && index <= ELEMENTS_LIMIT;
+      return index === self.findIndex((p) => p.id === processLog.id && p.name === processLog.name) && index <= PROCESS_LOGS_LIMIT;
     }
     return true;
   },

--- a/packages/embark/src/cmd/cmd_controller.js
+++ b/packages/embark/src/cmd/cmd_controller.js
@@ -103,6 +103,7 @@ class EmbarkController {
       function initEngine(callback) {
         engine.init({}, () => {
           if (!options.useDashboard) {
+            engine.startService("embarkListener");
             engine.logger.info('========================'.bold.green);
             engine.logger.info((__('Welcome to Embark') + ' ' + engine.version).yellow.bold);
             engine.logger.info('========================'.bold.green);
@@ -118,7 +119,6 @@ class EmbarkController {
 
         engine.startService("processManager");
         engine.startService("coreProcess");
-        engine.startService("embarkListener");
         engine.startService("blockchainListener");
         engine.startService("serviceMonitor");
         engine.startService("libraryManager");


### PR DESCRIPTION
Switching between the two tabs shown on the Dashboard for the cockpit was removing some of the logs that were previously displayed. This was due to an overlap in `id`’s being assigned to the logs from different processes.

To alleviate this, the reducers has been updated to not only check `id` but also `process.name`.

Additionally, the reducer was updated so that the number of logs for **each process** is set to `ELEMENTS_LIMIT`. For example, our `ELEMENT_LIMIT` is currently set to `200` and it would have meant that the total number of process logs across all processes would have been capped at 200. The current changes in this PR allow for 400 total logs, given that we have two processes being monitored for logs.