### PR TITLE
fix: limit cockpit editor file size

### DIFF
--- a/packages/embark-ui/src/services/storage.js
+++ b/packages/embark-ui/src/services/storage.js
@@ -2,6 +2,14 @@
 
 export async function addEditorTabs({file}) {
   const editorTabs = findOrCreateEditorTabs();
+
+  // Avoid files bigger than 1MB. Browsers limit heavily
+  // how much local storage we can actually use.
+  if(file.content.length > 1024 * 1024) {
+    alert('File is too big');
+    return {response: {data: editorTabs}};
+  }
+
   editorTabs.forEach(f => f.active = false);
   const alreadyAddedFile = editorTabs.find(f => f.name === file.name);
   if (alreadyAddedFile) {


### PR DESCRIPTION
LocalStorage has severe limits that we weren't taking under account. For instance, Safari has a limit, per domain, of 2.5MB, whereas Chrome has a limit of 5MB.

On top of this being a JS editor, and very slow with bigger files, we should limit how big the files we edit can be to prevent filling up local storage.