### PR TITLE
fix(@embark/tests): Make `web3` available in test descriptions

### DIFF
--- a/packages/embark/src/lib/modules/tests/index.js
+++ b/packages/embark/src/lib/modules/tests/index.js
@@ -165,7 +165,15 @@ class TestRunner {
         global.contract = function (describeName, callback) {
           return Mocha.describe(describeName, callback);
         };
-        next();
+        self.events.request('blockchain:get', (web3) => {
+          // Global web3 used in the tests, not in the vm.
+          // We need to make this available here so tests can use
+          // web3 in the test description (ie `describe` or `contract`).
+          // NOTE: global.web3 will get overwritten on next test deploy
+          // (triggered in config() function).
+          global.web3 = web3;
+          next();
+        });
       },
       function overrideRequire (next) {
         // Override require to enable `require('Embark/contracts/contractName');`


### PR DESCRIPTION
Previous to this PR, `web3` was only made available to each test case, as it was put in to the global namespace after each test deploy. This was causing issues for tests that use `web3` in the test description (ie in `describe()` or `contract()` functions), as the deploy had not happened yet, and thus `web3` was not yet available. The error encountered in these cases was `web3 is not defined`.

This PR puts `web3` in the global namespace before setting up the tests, making it available to test descriptions.