### PR TITLE
Fix nav links with children pages and copy-button

### DIFF
--- a/packages/embark-ui/src/components/Converter.js
+++ b/packages/embark-ui/src/components/Converter.js
@@ -1,7 +1,6 @@
 import PropTypes from "prop-types";
 import React from 'react';
 import {
-  InputGroup,
   Card,
   CardBody,
   CardHeader,
@@ -9,7 +8,6 @@ import {
   FormGroup,
   Input,
   Row,
-  InputGroupAddon,
   Label
 } from 'reactstrap';
 import CopyButton from './CopyButton';
@@ -62,12 +60,10 @@ class Converter extends React.Component {
                 this.state.etherConversions.map(unit => (
                   <FormGroup key={unit.key}>
                     <Label htmlFor={unit.name}>{unit.name}</Label>
-                    <InputGroup>
+                    <div className="position-relative">
                       <Input id={unit.name} placeholder={unit.name} value={unit.value} onChange={e => this.handleOnChange(e, unit.key)} />
-                      <InputGroupAddon addonType="append">
-                        <CopyButton text={unit.value} title="Copy value to clipboard" size={2}/>
-                      </InputGroupAddon>
-                    </InputGroup>
+                      <CopyButton text={unit.value} title="Copy value to clipboard" size={2}/>
+                    </div>
                   </FormGroup>
                 ))
               }

--- a/packages/embark-ui/src/components/CopyButton.css
+++ b/packages/embark-ui/src/components/CopyButton.css
@@ -1,7 +1,7 @@
 #root .copy-to-clipboard {
   position: absolute;
-  right: 0;
-  top: 0;
+  right: 1px;
+  top: 0.5px;
   border-top-left-radius: 0;
   border-bottom-right-radius: 0;
   cursor: pointer;

--- a/packages/embark-ui/src/components/Layout.js
+++ b/packages/embark-ui/src/components/Layout.js
@@ -41,9 +41,9 @@ import './Layout.css';
 const HEADER_NAV_ITEMS = [
   {name: "Dashboard", to: "/", icon: 'tachometer'},
   {name: "Deployment", to: "/deployment", icon: "arrow-up"},
-  {name: "Explorer", to: "/explorer/overview", icon: "compass"},
+  {name: "Explorer", to: "/explorer/overview", base: "explorer/", icon: "compass"},
   {name: "Editor", to: "/editor", icon: "codepen"},
-  {name: "Utils", to: "/utilities/converter", icon: "cog"}
+  {name: "Utils", to: "/utilities/converter", base: "utilities/", icon: "cog"}
 ];
 
 const SIDEBAR_NAV_ITEMS = {
@@ -125,6 +125,16 @@ class Layout extends React.Component {
     this.setState({searchError: false});
   }
 
+  isActive = (itemUrl, baseUrl, match, location) => {
+    if (itemUrl === location.pathname) {
+      return true;
+    }
+    if (!baseUrl) {
+      return false;
+    }
+    return location.pathname.indexOf(baseUrl) > -1;
+  };
+
   renderNav() {
     return (
       <React.Fragment>
@@ -132,8 +142,9 @@ class Layout extends React.Component {
           {HEADER_NAV_ITEMS.map((item) => {
             return (
               <NavItem className="px-3" key={item.to}>
-                <NavLink exact activeClassName="active" tag={RNavLink} to={item.to}>
-                  <FontAwesome className="mr-2" name={item.icon} />
+                <NavLink exact activeClassName="active" tag={RNavLink} to={item.to}
+                         isActive={this.isActive.bind(this, item.to, item.base)}>
+                  <FontAwesome className="mr-2" name={item.icon}/>
                   {item.name}
                 </NavLink>
               </NavItem>


### PR DESCRIPTION
- Fixes the Nav links not being highlighted on children pages. 
 - Eg: On Utils/Communication, the Utils link wasn't highlighted

- Also fixes a little style goof on the Converter's page