### PR TITLE
feat: add repository.directory field to package.json

### DIFF
--- a/dapps/templates/boilerplate/package.json
+++ b/dapps/templates/boilerplate/package.json
@@ -22,6 +22,11 @@
   "keywords": [],
   "author": "",
   "license": "MIT",
+  "repository": {
+    "directory": "dapps/templates/boilerplate",
+    "type": "git",
+    "url": "https://github.com/embark-framework/embark.git"
+  },
   "devDependencies": {
     "embark": "^4.0.0-beta.0",
     "embark-reset": "^4.0.0-beta.0",

--- a/dapps/templates/demo/package.json
+++ b/dapps/templates/demo/package.json
@@ -22,6 +22,11 @@
   "keywords": [],
   "author": "",
   "license": "MIT",
+  "repository": {
+    "directory": "dapps/templates/demo",
+    "type": "git",
+    "url": "https://github.com/embark-framework/embark.git"
+  },
   "devDependencies": {
     "embark": "^4.0.0-beta.0",
     "embark-reset": "^4.0.0-beta.0",

--- a/dapps/templates/simple/package.json
+++ b/dapps/templates/simple/package.json
@@ -21,6 +21,11 @@
   "keywords": [],
   "author": "",
   "license": "MIT",
+  "repository": {
+    "directory": "dapps/templates/simple",
+    "type": "git",
+    "url": "https://github.com/embark-framework/embark.git"
+  },
   "devDependencies": {
     "embark": "^4.0.0-beta.0",
     "embark-reset": "^4.0.0-beta.0",

--- a/packages/embark-async-wrapper/package.json
+++ b/packages/embark-async-wrapper/package.json
@@ -15,7 +15,11 @@
     "solidity"
   ],
   "license": "MIT",
-  "repository": "github:embark-framework/embark",
+  "repository": {
+    "directory": "packages/embark-async-wrapper",
+    "type": "git",
+    "url": "https://github.com/embark-framework/embark.git"
+  },
   "main": "./dist/index.js",
   "scripts": {
     "build": "cross-env BABEL_ENV=node babel src --extensions \".js,.ts\" --out-dir dist --root-mode upward --source-maps",

--- a/packages/embark-compiler/package.json
+++ b/packages/embark-compiler/package.json
@@ -15,7 +15,11 @@
     "solidity"
   ],
   "license": "MIT",
-  "repository": "github:embark-framework/embark",
+  "repository": {
+    "directory": "packages/embark-compiler",
+    "type": "git",
+    "url": "https://github.com/embark-framework/embark.git"
+  },
   "main": "./dist/index.js",
   "scripts": {
     "build": "cross-env BABEL_ENV=node babel src --extensions \".js,.ts\" --out-dir dist --root-mode upward --source-maps",

--- a/packages/embark-graph/package.json
+++ b/packages/embark-graph/package.json
@@ -18,7 +18,11 @@
     "dist"
   ],
   "license": "MIT",
-  "repository": "github:embark-framework/embark",
+  "repository": {
+    "directory": "packages/embark-graph",
+    "type": "git",
+    "url": "https://github.com/embark-framework/embark.git"
+  },
   "main": "./dist/index.js",
   "scripts": {
     "build": "cross-env BABEL_ENV=node babel src --extensions \".js,.ts\" --out-dir dist --root-mode upward --source-maps",

--- a/packages/embark-reset/package.json
+++ b/packages/embark-reset/package.json
@@ -7,7 +7,11 @@
   "description": "DApp reset utlity for embark",
   "homepage": "https://embark.status.im/",
   "license": "MIT",
-  "repository": "github:embark-framework/embark",
+  "repository": {
+    "directory": "packages/embark-reset",
+    "type": "git",
+    "url": "https://github.com/embark-framework/embark.git"
+  },
   "bin": "./bin.js",
   "main": "index.js",
   "dependencies": {

--- a/packages/embark-typings/package.json
+++ b/packages/embark-typings/package.json
@@ -16,7 +16,11 @@
     "solidity"
   ],
   "license": "MIT",
-  "repository": "github:embark-framework/embark",
+  "repository": {
+    "directory": "packages/embark-typings",
+    "type": "git",
+    "url": "https://github.com/embark-framework/embark.git"
+  },
   "main": "",
   "types": "index",
   "scripts": {

--- a/packages/embark-ui/package.json
+++ b/packages/embark-ui/package.json
@@ -15,7 +15,11 @@
     "solidity"
   ],
   "license": "MIT",
-  "repository": "github:embark-framework/embark",
+  "repository": {
+    "directory": "packages/embark-ui",
+    "type": "git",
+    "url": "https://github.com/embark-framework/embark.git"
+  },
   "scripts": {
     "build": "node scripts/build.js",
     "build-storybook": "build-storybook -s public",

--- a/packages/embark-vyper/package.json
+++ b/packages/embark-vyper/package.json
@@ -15,7 +15,11 @@
     "solidity"
   ],
   "license": "MIT",
-  "repository": "github:embark-framework/embark",
+  "repository": {
+    "directory": "packages/embark-vyper",
+    "type": "git",
+    "url": "https://github.com/embark-framework/embark.git"
+  },
   "main": "./dist/index.js",
   "scripts": {
     "build": "cross-env BABEL_ENV=node babel src --extensions \".js,.ts\" --out-dir dist --root-mode upward --source-maps",

--- a/packages/embark/package.json
+++ b/packages/embark/package.json
@@ -15,7 +15,11 @@
     "solidity"
   ],
   "license": "MIT",
-  "repository": "github:embark-framework/embark",
+  "repository": {
+    "directory": "packages/embark",
+    "type": "git",
+    "url": "https://github.com/embark-framework/embark.git"
+  },
   "bin": {
     "embark": "./bin/embark"
   },

--- a/packages/embark/src/lib/utils/template_generator.js
+++ b/packages/embark/src/lib/utils/template_generator.js
@@ -160,11 +160,18 @@ class TemplateGenerator {
     utils.cd(templatePath);
 
     const pkgJson = fs.readJSONSync('./package.json');
-    pkgJson.name = name;
     if (!(/demo/).test(name)) {
+      delete pkgJson.repository;
       pkgJson.version = '0.0.1';
     }
+    if (pkgJson.devDependencies) {
+      delete pkgJson.devDependencies['embark'];
+      delete pkgJson.devDependencies['embark-reset'];
+      delete pkgJson.devDependencies['npm-run-all'];
+      delete pkgJson.devDependencies['rimraf'];
+    }
     delete pkgJson.files;
+    pkgJson.name = name;
     if (!pkgJson.scripts) pkgJson.scripts = {};
     delete pkgJson.scripts.ci;
     delete pkgJson.scripts.clean;
@@ -172,12 +179,6 @@ class TemplateGenerator {
     delete pkgJson.scripts.qa;
     delete pkgJson.scripts.reset;
     pkgJson.scripts.test = 'embark test';
-    if (pkgJson.devDependencies) {
-      delete pkgJson.devDependencies['embark'];
-      delete pkgJson.devDependencies['embark-reset'];
-      delete pkgJson.devDependencies['npm-run-all'];
-      delete pkgJson.devDependencies['rimraf'];
-    }
     fs.writeFileSync('package.json', JSON.stringify(pkgJson, null, 2));
 
     if (fs.existsSync('dot.gitignore')) {

--- a/packages/embarkjs-connector-web3/package.json
+++ b/packages/embarkjs-connector-web3/package.json
@@ -13,7 +13,11 @@
     "smart-contract"
   ],
   "license": "MIT",
-  "repository": "github:embark-framework/embark",
+  "repository": {
+    "directory": "packages/embarkjs-connector-web3",
+    "type": "git",
+    "url": "https://github.com/embark-framework/embark.git"
+  },
   "main": "index.js",
   "scripts": {
     "ci": "npm run qa",

--- a/packages/embarkjs/package.json
+++ b/packages/embarkjs/package.json
@@ -15,7 +15,11 @@
     "solidity"
   ],
   "license": "MIT",
-  "repository": "github:embark-framework/embark",
+  "repository": {
+    "directory": "packages/embarkjs",
+    "type": "git",
+    "url": "https://github.com/embark-framework/embark.git"
+  },
   "main": "dist/node/index.js",
   "browser": {
     "./dist/node/index.js": "./dist/browser/index.js"


### PR DESCRIPTION
See: https://github.com/npm/rfcs/blob/latest/implemented/0010-monorepo-subdirectory-declaration.md

Make changes by running this command in the root of the monorepo:

```shell
npx lerna exec --concurrency 1 --stream -- \
    'DIRPATH=$(realpath $PWD --relative-to=$LERNA_ROOT_PATH); \
    npx json -I -f package.json -e \
    "this.repository=\
        {\"directory\": \"$DIRPATH\", \
         \"type\": \"git\", \
         \"url\": \"https://github.com/embark-framework/embark.git\"}"'
```

Don't commit changes to private packages, with the exceptions of embark-typings and embark-reset because those may switch from private to public, and also because the latter will be included in `node_modules` of embark even if it is private since embark-reset is presently a bundled dependency of embark.

Don't include the repository field in dapps generated from the template packages, except for the demo.