### PR TITLE
Remove contract profiling for contract interactions

### DIFF
--- a/packages/embark-ui/src/components/ContractOverview.js
+++ b/packages/embark-ui/src/components/ContractOverview.js
@@ -32,7 +32,7 @@ class ContractFunction extends Component {
   }
 
   static isPureCall(method) {
-    return (method.mutability === 'view' || method.mutability === 'pure');
+    return (method.stateMutability === 'view' || method.stateMutability === 'pure');
   }
 
   static isEvent(method) {
@@ -70,7 +70,7 @@ class ContractFunction extends Component {
 
   handleCall(e) {
     e.preventDefault();
-    this.props.postContractFunction(this.props.contractProfile.name, this.props.method.name, this.inputsAsArray(), this.state.inputs.gasPrice * 1000000000);
+    this.props.postContractFunction(this.props.contractName, this.props.method.name, this.inputsAsArray(), this.state.inputs.gasPrice * 1000000000);
   }
 
   callDisabled() {
@@ -189,7 +189,7 @@ class ContractFunction extends Component {
 }
 
 ContractFunction.propTypes = {
-  contractProfile: PropTypes.object,
+  contractName: PropTypes.string,
   method: PropTypes.object,
   contractFunctions: PropTypes.arrayOf(PropTypes.object),
   postContractFunction: PropTypes.func
@@ -202,7 +202,7 @@ const filterContractFunctions = (contractFunctions, contractName, method) => {
 };
 
 const ContractOverview = (props) => {
-  const {contractProfile, contract} = props;
+  const {contract} = props;
   const contractDisplay = formatContractForDisplay(contract);
   if (!contractDisplay) {
     return '';
@@ -213,14 +213,13 @@ const ContractOverview = (props) => {
       {(contractDisplay.state === 'Deployed') && <div>Deployed at {contractDisplay.address}</div>}
       {(contractDisplay.state !== 'Deployed') && <div>{contractDisplay.address}</div>}
       <br/>
-      {contractProfile.methods
+      {contract.abiDefinition
         .filter((method) => {
           return props.onlyConstructor ? method.type === 'constructor' : method.type !== 'constructor';
         })
-        .map(method => <ContractFunction key={method.name}
+        .map(method => <ContractFunction key={method.name} contractName={contract.className}
                                          method={method}
-                                         contractFunctions={filterContractFunctions(props.contractFunctions, contractProfile.name, method.name)}
-                                         contractProfile={contractProfile}
+                                         contractFunctions={filterContractFunctions(props.contractFunctions, contract.className, method.name)}
                                          postContractFunction={props.postContractFunction}/>)}
     </div>
   );
@@ -229,7 +228,6 @@ const ContractOverview = (props) => {
 ContractOverview.propTypes = {
   contract: PropTypes.object,
   onlyConstructor: PropTypes.bool,
-  contractProfile: PropTypes.object,
   contractFunctions: PropTypes.arrayOf(PropTypes.object),
   postContractFunction: PropTypes.func
 };

--- a/packages/embark-ui/src/containers/ContractOverviewContainer.js
+++ b/packages/embark-ui/src/containers/ContractOverviewContainer.js
@@ -2,23 +2,18 @@ import React, {Component} from 'react';
 import {connect} from 'react-redux';
 import PropTypes from 'prop-types';
 
-import {contractProfile as contractProfileAction, contractFunction as contractFunctionAction} from '../actions';
+import {contractFunction as contractFunctionAction} from '../actions';
 import ContractOverview from '../components/ContractOverview';
 import DataWrapper from "../components/DataWrapper";
-import {getContractProfile, getContractFunctions} from "../reducers/selectors";
+import {getContractFunctions} from "../reducers/selectors";
 
 class ContractOverviewContainer extends Component {
-  componentDidMount() {
-    this.props.fetchContractProfile(this.props.contract.className);
-  }
-
   render() {
     return (
-      <DataWrapper shouldRender={this.props.contractProfile !== undefined}
+      <DataWrapper shouldRender={this.props.contractFunctions !== undefined}
                    {...this.props}
-                   render={({contractProfile, contractFunctions, postContractFunction}) => (
-                     <ContractOverview contractProfile={contractProfile}
-                                       contractFunctions={contractFunctions}
+                   render={({contractFunctions, postContractFunction}) => (
+                     <ContractOverview contractFunctions={contractFunctions}
                                        contract={this.props.contract}
                                        postContractFunction={postContractFunction}/>
                    )}/>
@@ -28,7 +23,6 @@ class ContractOverviewContainer extends Component {
 
 function mapStateToProps(state, props) {
   return {
-    contractProfile: getContractProfile(state, props.contract.className),
     contractFunctions: getContractFunctions(state, props.contract.className),
     error: state.errorMessage,
     loading: state.loading
@@ -37,17 +31,14 @@ function mapStateToProps(state, props) {
 
 ContractOverviewContainer.propTypes = {
   contract: PropTypes.object,
-  contractProfile: PropTypes.object,
   contractFunctions: PropTypes.arrayOf(PropTypes.object),
   postContractFunction: PropTypes.func,
-  fetchContractProfile: PropTypes.func,
   error: PropTypes.string
 };
 
 export default connect(
   mapStateToProps,
   {
-    fetchContractProfile: contractProfileAction.request,
     postContractFunction: contractFunctionAction.post
   }
 )(ContractOverviewContainer);


### PR DESCRIPTION
We profiled the contracts for the contract overview (the interact tab) in order to list the function, but that is unecessary, as we already have all the information in the ABI.