### PR TITLE
refactor(embark): do not wrap mocha in a child process

### DIFF
--- a/packages/embark/package.json
+++ b/packages/embark/package.json
@@ -32,7 +32,7 @@
     "qa": "npm-run-all lint typecheck build test package",
     "reset": "npx rimraf .nyc_output coverage dist embark-*.tgz package",
     "start": "npm run watch",
-    "test": "node scripts/test.js",
+    "test": "nyc --reporter=html mocha \"dist/test/**/*.js\" --exit --no-timeouts --require ./scripts/test.js --require source-map-support/register",
     "typecheck": "tsc",
     "watch": "run-p watch:*",
     "watch:build": "npm run build -- --verbose --watch",

--- a/packages/embark/scripts/test.js
+++ b/packages/embark/scripts/test.js
@@ -1,20 +1,9 @@
 /* global __dirname process require */
 
-const {execSync} = require('child_process');
 const fs = require('fs-extra');
 const os = require('os');
 const path = require('path');
 
 process.env.DAPP_PATH = fs.mkdtempSync(path.join(os.tmpdir(), 'embark-test-'));
-fs.copySync(path.join(__dirname, '../dist/test'), process.env.DAPP_PATH);
 
-execSync(
-  [`nyc`,
-   `--reporter=html`,
-   `mocha`,
-   `"dist/test/**/*.js"`,
-   `--exit`,
-   `--no-timeouts`,
-   `--require source-map-support/register`].join(' '),
-  {cwd: path.join(__dirname, '..'), stdio: 'inherit'}
-);
+fs.copySync(path.join(__dirname, '../dist/test'), process.env.DAPP_PATH);


### PR DESCRIPTION
It's possible to pass a `--require` option to mocha to load a script that sets up `process.env.DAPP_PATH` as needed for embark's tests; that approach is preferable to running mocha in a child process because when running in a child process there seemed to be problems with sources maps and with VS Code's debugger.

After the changes in this PR, the following works as expected, i.e. when there are runtime errors line/col numbers are reported per the files in `src/`:

```
$ yarn build:no-ui
$ cd packages/embark
$ npx mocha "dist/test/**/*.js" \
            --exit \
            --no-timeouts \
            --require ./scripts/test.js \
            --require source-map-support/register
```

And the following VS Code launch config works well for me:

```json
{
  "type": "node",
  "request": "launch",
  "name": "test - packages/embark",
  "cwd": "${workspaceFolder}/packages/embark",
  "program": "${workspaceFolder}/node_modules/mocha/bin/_mocha",
  "args": [
    "'dist/test/**/*.js'",
    "--exit",
    "--no-timeouts",
    "--require",
    "./scripts/test.js",
    "--require",
    "source-map-support/register"
  ],
  "autoAttachChildProcesses": true,
  "sourceMaps": true
}
```

NOTE for VS Code users: I found it's important to specify `"'dist/test/**/*.js'"` in the launch config instead of `"\"dist/test/**/*.js\""`, and that it's important to specify `"program": "${workspaceFolder}/node_modules/mocha/bin/_mocha"` vs. `"program": "${workspaceFolder}/packages/embark/node_modules/.bin/mocha"`.

KNOWN ISSUES: when there are runtime errors during `yarn test` in `packages/embark`, line/col numbers reflect the sources in `package/embark/dist` because `nyc` isn't setup correctly to use the source-maps generated by babel. A solution has not yet been found.