### PR TITLE
fix(@embark/core): Re-enable regular txs commands/api

### DIFF
--- a/packages/embark/src/lib/modules/blockchain_listener/index.js
+++ b/packages/embark/src/lib/modules/blockchain_listener/index.js
@@ -26,10 +26,12 @@ class BlockchainListener {
     this.ipc.server.once('connect', () => {
       this.processLogsApi = new ProcessLogsApi({embark: this.embark, processName: PROCESS_NAME, silent: true});
       this._listenToBlockchainLogs();
+    });
+    if (this.ipc.isServer()) {
       this._listenToCommands();
       this._registerConsoleCommands();
       this._registerApiEndpoint();
-    });
+    }
   }
 
   /**


### PR DESCRIPTION
https://github.com/embark-framework/embark/pull/1367 introduced a change that prevented the `blockchain_listener` from listening to logs until the IPC server connected. However, the restriction went too far, and included restricting registration of console commands and API endpoints for the regular transactions feature.

This fix reverts the changes that affect registration of regular txs endpoints and console commands.