### PR TITLE
feat(@embark/pipeline): Add `enabled` property to pipeline config

### DIFF
--- a/dapps/templates/boilerplate/config/pipeline.js
+++ b/dapps/templates/boilerplate/config/pipeline.js
@@ -9,7 +9,7 @@
 //   embark new --template flow
 
 module.exports = {
-  typescript: false
+  typescript: false,
   // Setting `typescript: true` in this config will disable Flow support in
   // Embark's default webpack config and enable TypeScript support: .ts and
   // .tsx sources will automatically be transpiled into JavaScript without any
@@ -20,4 +20,8 @@ module.exports = {
   //   https://github.com/embark-framework/embark-typescript-template
   // A new DApp can be created from that template with:
   //   embark new --template typescript
+  enabled: true 
+  // Setting `enabled: false` in this config will disable Embark's built-in Webpack
+  // pipeline. The developer will need to use a different frontend build tool, such as 
+  // `create-react-app` or Angular CLI to build their dapp
 };

--- a/dapps/templates/demo/config/pipeline.js
+++ b/dapps/templates/demo/config/pipeline.js
@@ -9,7 +9,7 @@
 //   embark new --template flow
 
 module.exports = {
-  typescript: false
+  typescript: false,
   // Setting `typescript: true` in this config will disable Flow support in
   // Embark's default webpack config and enable TypeScript support: .ts and
   // .tsx sources will automatically be transpiled into JavaScript without any
@@ -20,4 +20,8 @@ module.exports = {
   //   https://github.com/embark-framework/embark-typescript-template
   // A new DApp can be created from that template with:
   //   embark new --template typescript
+  enabled: true 
+  // Setting `enabled: false` in this config will disable Embark's built-in Webpack
+  // pipeline. The developer will need to use a different frontend build tool, such as 
+  // `create-react-app` or Angular CLI to build their dapp
 };

--- a/packages/embark/src/lib/core/config.js
+++ b/packages/embark/src/lib/core/config.js
@@ -533,7 +533,8 @@ Config.prototype.loadEmbarkConfigFile = function() {
 Config.prototype.loadPipelineConfigFile = function() {
 
   const defaultPipelineConfig = {
-    typescript: false
+    typescript: false,
+    enabled: true
   };
 
   let pipelineConfigPath = this._getFileOrObject(this.configDir, 'pipeline', 'pipeline');
@@ -558,6 +559,7 @@ Config.prototype.loadPipelineConfigFile = function() {
   }
 
   this.pipelineConfig = pipelineConfig;
+  this.events.emit('config:load:pipeline', this.pipelineConfig);
 };
 
 Config.prototype.loadAssetFiles = function () {

--- a/packages/embark/src/lib/core/fs.js
+++ b/packages/embark/src/lib/core/fs.js
@@ -144,6 +144,7 @@ function removeSync() {
 }
 
 function anchoredPath(anchor, ...args) {
+  args = args.map(path => path.replace(dappPath(), ""));
   return utils.joinPath(env.anchoredValue(anchor), ...args);
 }
 

--- a/packages/embark/src/lib/modules/pipeline/index.js
+++ b/packages/embark/src/lib/modules/pipeline/index.js
@@ -24,7 +24,15 @@ class Pipeline {
     this.isFirstBuild = true;
     this.useDashboard = options.useDashboard;
 
-    this.events.setCommandHandler('pipeline:build', (options, callback) => this.build(options, callback));
+    // track changes to the pipeline config in the filesystem
+    this.events.on('config:load:pipeline', (pipelineConfig) => {
+      this.pipelineConfig = pipelineConfig;
+    });
+
+    this.events.setCommandHandler('pipeline:build', (options, callback) => {
+      if(!this.pipelineConfig.enabled) return callback();
+      this.build(options, callback);
+    });
     this.events.setCommandHandler('pipeline:build:contracts', callback => this.buildContracts([], callback));
     this.fs.removeSync(this.buildDir);
 


### PR DESCRIPTION
Add an `enabled` property to the pipeline config. This lets developers disable the pipeline using the config file.

Updates to the enabled property will be reflected while embark is running. For example if embark is running with the pipeline, setting `enabled: false` in the pipeline config will build/deploy the contracts but not run the pipeline. Conversely, if embark is running with the pipeline disabled, enabling the pipeline in the config will build/deploy the contracts then build the dapp.