### PR TITLE
fix(@embark/pipeline): Prevent crash when assets not specified

### DIFF
--- a/packages/embark/src/lib/core/config.js
+++ b/packages/embark/src/lib/core/config.js
@@ -561,6 +561,7 @@ Config.prototype.loadPipelineConfigFile = function() {
 };
 
 Config.prototype.loadAssetFiles = function () {
+  if(!this.embarkConfig.app) return;
   Object.keys(this.embarkConfig.app).forEach(targetFile => {
     this.assetFiles[targetFile] = this.loadFiles(this.embarkConfig.app[targetFile]);
   });


### PR DESCRIPTION
Prevent embark from crashing when app assets are not specified in `embark.json`.

Previously, if the `app` property of `embark.json` was missing, embark would crash with the error `TypeError: Cannot convert undefined or null to object`.

With this PR, the missing property is null-checked.