### PR TITLE
fix(cockpit/dashboard): fix logs not in  cockpit with dashboard

### DIFF
--- a/packages/embark/src/cmd/cmd_controller.js
+++ b/packages/embark/src/cmd/cmd_controller.js
@@ -102,8 +102,8 @@ class EmbarkController {
     async.waterfall([
       function initEngine(callback) {
         engine.init({}, () => {
+          engine.startService("embarkListener");
           if (!options.useDashboard) {
-            engine.startService("embarkListener");
             engine.logger.info('========================'.bold.green);
             engine.logger.info((__('Welcome to Embark') + ' ' + engine.version).yellow.bold);
             engine.logger.info('========================'.bold.green);


### PR DESCRIPTION
They weren't in the cockpit because the listener wasn't started. I know it was removed by @emizzle before, so gonna wait on his input before merging.