### PR TITLE
Fix <br> in console

### DIFF
--- a/packages/embark-ui/src/actions/index.js
+++ b/packages/embark-ui/src/actions/index.js
@@ -127,7 +127,7 @@ export const commands = {
           timestamp: new Date().getTime(),
           name: EMBARK_PROCESS_NAME,
           msg: `${ansiToHtml(command.result || '')}`,
-          command: `console> ${payload.command}<br>`,
+          command: `console> ${payload.command}\n`,
           result: command.result
         }
       ]


### PR DESCRIPTION
Replaced them with `\n`. Problem was we prevent injections so tags are not rendered.