### PR TITLE
Fix bug in firefox with services, contracts, etc.

### DIFF
--- a/packages/embark-ui/src/reducers/index.js
+++ b/packages/embark-ui/src/reducers/index.js
@@ -88,7 +88,7 @@ const sorter = {
   },
 };
 
-const filtrer = {
+const filters = {
   processes: function(process, index, self) {
     if (["embark", "blockchain"].indexOf(process.name) === -1) return false;
     return index === self.findIndex((t) => t.name === process.name);
@@ -151,8 +151,8 @@ function entities(state = entitiesDefaultState, action) {
     return {...state, files: action.files};
   }
   for (let name of Object.keys(state)) {
-    let filter = filtrer[name] || (() => true);
-    let sort = sorter[name] || (() => true);
+    let filter = filters[name] || (() => true);
+    let sort = sorter[name] || (() => 0);
     if (action[name] && action[name].length > 1) {
       return {...state, [name]: [...action[name], ...state[name]].sort(sort).filter(filter)};
     }
@@ -160,8 +160,8 @@ function entities(state = entitiesDefaultState, action) {
       let entity = action[name][0];
       let nested = Object.keys(state).reduce((acc, entityName) => {
         if (entity && entity[entityName] && entity[entityName].length > 0) {
-          let entityFilter = filtrer[entityName] || (() => true);
-          let entitySort = sorter[entityName] || (() => true);
+          let entityFilter = filters[entityName] || (() => true);
+          let entitySort = sorter[entityName] || (() => 0);
           acc[entityName] = [...entity[entityName], ...state[entityName]].sort(entitySort).filter(entityFilter);
         }
         return acc;

--- a/packages/embark/src/lib/core/services_monitor.js
+++ b/packages/embark/src/lib/core/services_monitor.js
@@ -1,4 +1,5 @@
-let async = require('../utils/async_extend.js');
+const async = require('../utils/async_extend.js');
+const deepEqual = require('deep-equal');
 
 class ServicesMonitor {
   constructor(options) {
@@ -32,9 +33,12 @@ ServicesMonitor.prototype.initCheck = function (checkName) {
     if (check && check.status === 'on' && obj.status === 'off') {
       self.events.emit('check:wentOffline:' + checkName);
     }
-    self.checkState[checkName] = {name: obj.name, status: obj.status, serviceName: checkName};
     check.status = obj.status;
-    self.events.emit("servicesState", self.checkState);
+    const newState = {name: obj.name, status: obj.status, serviceName: checkName};
+    if (!deepEqual(newState, self.checkState[checkName])) {
+      self.checkState[checkName] = {name: obj.name, status: obj.status, serviceName: checkName};
+      self.events.emit("servicesState", self.checkState);
+    }
   });
 
   if (check.interval !== 0) {


### PR DESCRIPTION
This is a weird bug, because it only hapenned in Firefox and only certain entities. 
The problem is we used a "bad" default sorter. When you don't want to change the order, you need to send `0`, but we sent `true`, which firefox handles weirdly.

Also, I made it so that we send an update on the services only when the services actually changed