### PR TITLE
fix(embark-ui): correctly calculate which blocks to display

### DIFF
--- a/packages/embark-ui/src/components/Blocks.js
+++ b/packages/embark-ui/src/components/Blocks.js
@@ -14,6 +14,7 @@ const Blocks = ({blocks, changePage, currentPage, numberOfPages}) => (
           <h2>Blocks</h2>
         </CardHeader>
         <CardBody>
+          {!blocks.length && "No blocks to display"}
           {blocks.map(block => (
             <div className="explorer-row border-top" key={block.number}>
               <CardTitleIdenticon id={block.hash}>Block&nbsp;

--- a/packages/embark-ui/src/components/ExplorerDashboardLayout.js
+++ b/packages/embark-ui/src/components/ExplorerDashboardLayout.js
@@ -22,7 +22,7 @@ const ExplorerDashboardLayout = () => (
       </Row>
       <Row>
         <Col xl={6}>
-          <BlocksContainer overridePageHead={false} />
+          <BlocksContainer numBlocksToDisplay={5} overridePageHead={false} />
         </Col>
         <Col xl={6}>
           <TransactionsContainer overridePageHead={false} />

--- a/packages/embark-ui/src/reducers/selectors.js
+++ b/packages/embark-ui/src/reducers/selectors.js
@@ -249,4 +249,3 @@ export function getPreviewUrl(state) {
 export function getEditorOperationStatus(state) {
   return state.editorOperationStatus;
 }
-


### PR DESCRIPTION
Revise calculations related to block numbers and pagination in the blocks explorer and explorers overview.

Make the number of blocks to display per page configurable and set it to 5 in the explorers overview.

---

Many thanks to @emizzle for his super 🌟 help on putting this together.