### PR TITLE
fix(@embark/storage): Storage processes race conditions

### DIFF
--- a/packages/embark/src/lib/modules/ipfs/index.js
+++ b/packages/embark/src/lib/modules/ipfs/index.js
@@ -8,7 +8,6 @@ const constants = require('../../constants.json');
 class IPFS {
 
   constructor(embark, options) {
-    const self = this;
     this.logger = embark.logger;
     this.events = embark.events;
     this.buildDir = options.buildDir;
@@ -26,9 +25,10 @@ class IPFS {
       this.registerUploadCommand();
 
       this.events.request("processes:register", "ipfs", (cb) => {
-        self.startProcess(() => {
+        this.startProcess(() => {
           this.addStorageProviderToEmbarkJS();
           this.addObjectToConsole();
+          this.events.emit("ipfs:process:started");
           cb();
         });
       });
@@ -37,7 +37,7 @@ class IPFS {
         if (!err) {
           return;
         }
-        self.logger.info("IPFS node not found, attempting to start own node");
+        this.logger.info("IPFS node not found, attempting to start own node");
         this.listenToCommands();
         this.registerConsoleCommands();
         this.events.request('processes:launch', 'ipfs');

--- a/packages/embark/src/lib/modules/storage/index.js
+++ b/packages/embark/src/lib/modules/storage/index.js
@@ -7,7 +7,9 @@ class Storage {
     if (!this.storageConfig.enabled) return;
 
     this.handleUploadCommand();
-    this.addSetProviders();
+    this.addSetProviders(() => {
+      this.embark.events.setCommandHandler("module:storage:initiated", (cb) => { cb(); });
+    });
   }
 
   handleUploadCommand() {
@@ -26,7 +28,7 @@ class Storage {
     });
   }
 
-  addSetProviders() {
+  addSetProviders(cb) {
     let code = `\nEmbarkJS.Storage.setProviders(${JSON.stringify(this.storageConfig.dappConnection || [])});`;
 
     let shouldInit = (storageConfig) => {
@@ -36,6 +38,7 @@ class Storage {
     this.embark.addProviderInit('storage', code, shouldInit);
     this.embark.events.request("runcode:storage:providerRegistered", () => {
       this.embark.addConsoleProviderInit('storage', code, shouldInit);
+      cb();
     });
   }
 

--- a/packages/embark/src/lib/modules/swarm/index.js
+++ b/packages/embark/src/lib/modules/swarm/index.js
@@ -46,21 +46,21 @@ class Swarm {
     this.swarm = new SwarmAPI({gateway: this.providerUrl});
 
     this.setServiceCheck();
-    this.addProviderToEmbarkJS();
-    this.addObjectToConsole();
     this.registerUploadCommand();
 
     // swarm needs geth to be running first
-    this.events.once(constants.blockchain.blockchainReady, () => {
-      this.swarm.isAvailable((err, isAvailable) => {
-        if (!err || isAvailable) {
-          this.logger.info("Swarm node found, using currently running node");
-          return;
-        }
-        this.logger.info("SWARM: Swarm node not found, attempting to start own node");
-        this.listenToCommands();
-        this.registerConsoleCommands();
-        return this.startProcess(() => {});
+    this.swarm.isAvailable((err, isAvailable) => {
+      if (!err || isAvailable) {
+        this.logger.info("Swarm node found, using currently running node");
+        return;
+      }
+      this.logger.info("SWARM: Swarm node not found, attempting to start own node");
+      this.listenToCommands();
+      this.registerConsoleCommands();
+      return this.startProcess(() => {
+        this.addProviderToEmbarkJS();
+        this.addObjectToConsole();
+        this.events.emit("swarm:process:started");
       });
     });
   }

--- a/packages/embark/src/lib/modules/swarm/process.js
+++ b/packages/embark/src/lib/modules/swarm/process.js
@@ -62,7 +62,7 @@ class SwarmProcess extends ProcessWrapper {
     // Swarm logs appear in stderr somehow
     this.child.stderr.on('data', (data) => {
       data = data.toString();
-      if (!self.readyCalled && data.indexOf('Swarm http proxy started') > -1) {
+      if (!self.readyCalled && (data.includes('Swarm http proxy started') || data.includes('Swarm network started'))) {
         self.readyCalled = true;
         self.send({result: constants.storage.initiated});
       }


### PR DESCRIPTION
Previously, storage providers in embarkjs were not waiting for their respective storage process (ipfs and swarm) to start before running `registerProvider` and `setProvider` in the console.

This PR forces the `registerProvider` and `setProviders` from running in the console until the storage processes have loaded. As a side effect, the code generation of `EmbarkJS` must wait for the storage module ot be fully initiated (ie once the processes have launched and the `registerProvider` and `setProviders` have been run) before generating the code.

This fixes errors pertaining to `Could not connect to a storage provider using any of the dappConnections in the storage config` as these errors were typically caused by `setProviders` being called before the storage processes had fully launched.