### PR TITLE
fix(embark/dashboard): fix dashboard not printing repl errors

### DIFF
--- a/packages/embark/src/cmd/dashboard/repl.js
+++ b/packages/embark/src/cmd/dashboard/repl.js
@@ -20,7 +20,11 @@ class REPL {
 
   enhancedEval(cmd, context, filename, callback) {
     this.events.request('console:executeCmd', cmd.trim(), function (err, message) {
-      callback(err, message === undefined ? '' : message); // This way, we don't print undefined
+      if (err) {
+        // Do not return as the first param (error), because the dashboard doesn't print errors
+        return callback(null, err.red);
+      }
+      callback(null, message === undefined ? '' : message); // This way, we don't print undefined
     });
   }
 


### PR DESCRIPTION
Somehow, the dashboard swallowed the errors returned by the repl. So instead, we check for the error and send it as the normal output, but red.