### PR TITLE
fix(cockpit/console): fix cockpit's console outputting "console >"

### DIFF
--- a/packages/embark/src/cmd/cmd_controller.js
+++ b/packages/embark/src/cmd/cmd_controller.js
@@ -346,7 +346,9 @@ class EmbarkController {
         new REPL({
           events: engine.events,
           env: engine.env,
-          ipc: engine.ipc
+          ipc: engine.ipc,
+          useDashboard: false,
+          logger: engine.logger
         }).start(callback);
       }
     ], function (err, _result) {

--- a/packages/embark/src/cmd/dashboard/dashboard.js
+++ b/packages/embark/src/cmd/dashboard/dashboard.js
@@ -25,7 +25,7 @@ class Dashboard {
   start(done) {
     let monitor;
 
-    monitor = new Monitor({env: this.env, events: this.events, version: this.version, ipc: this.ipc});
+    monitor = new Monitor({env: this.env, events: this.events, version: this.version, ipc: this.ipc, logger: this.logger});
     this.logger.logFunction = monitor.logEntry;
     let plugin = this.plugins.createPlugin('dashboard', {});
     plugin.registerAPICall(

--- a/packages/embark/src/cmd/dashboard/monitor.js
+++ b/packages/embark/src/cmd/dashboard/monitor.js
@@ -9,6 +9,7 @@ class Monitor {
     this.env = options.env;
     this.console = options.console;
     this.events = options.events;
+    this.logger = options.logger;
     this.color = options.color || "green";
     this.minimal = options.minimal || false;
     this.ipc = options.ipc;
@@ -56,7 +57,9 @@ class Monitor {
       inputStream: this.terminalReadableStream,
       outputStream: terminalWritableStream,
       logText: this.logText,
-      ipc: this.ipc
+      ipc: this.ipc,
+      useDashboard: true,
+      logger: this.logger
     }).start(() => {
       this.terminal.focus();
     });

--- a/packages/embark/src/cmd/dashboard/repl.js
+++ b/packages/embark/src/cmd/dashboard/repl.js
@@ -9,6 +9,8 @@ class REPL {
     this.outputStream = options.outputStream || process.stdout;
     this.logText = options.logText;
     this.ipc = options.ipc;
+    this.logger = options.logger;
+    this.useDashboard = options.useDashboard;
   }
 
   addHistory(cmd) {
@@ -19,6 +21,9 @@ class REPL {
   }
 
   enhancedEval(cmd, context, filename, callback) {
+    if (this.useDashboard) {
+      this.logger.consoleOnly("console> ".cyan + cmd.white);
+    }
     this.events.request('console:executeCmd', cmd.trim(), function (err, message) {
       if (err) {
         // Do not return as the first param (error), because the dashboard doesn't print errors

--- a/packages/embark/src/lib/core/engine.js
+++ b/packages/embark/src/lib/core/engine.js
@@ -176,8 +176,7 @@ class Engine {
       version: this.version,
       ipc: this.ipc,
       logger: this.logger,
-      config: this.config,
-      useDashboard: this.useDashboard
+      config: this.config
     });
   }
 

--- a/packages/embark/src/lib/core/logger.js
+++ b/packages/embark/src/lib/core/logger.js
@@ -126,6 +126,14 @@ Logger.prototype.info = function () {
   this.writeToFile("[info]: ", ...arguments);
 };
 
+Logger.prototype.consoleOnly = function () {
+  if (!arguments.length || !(this.shouldLog('info'))) {
+    return;
+  }
+  this.logFunction(...Array.from(arguments), 'green');
+  this.writeToFile("[consoleOnly]: ", ...arguments);
+};
+
 Logger.prototype.debug = function () {
   if (!arguments.length || !(this.shouldLog('debug'))) {
     return;

--- a/packages/embark/src/lib/modules/console/index.ts
+++ b/packages/embark/src/lib/modules/console/index.ts
@@ -30,7 +30,6 @@ class Console {
   private cmdHistoryFile: string;
   private suggestions?: Suggestions;
   private providerReady: boolean;
-  private useDashboard: boolean;
 
   constructor(embark: Embark, options: any) {
     this.embark = embark;
@@ -41,7 +40,6 @@ class Console {
     this.fs = embark.fs;
     this.ipc = options.ipc;
     this.config = options.config;
-    this.useDashboard = options.useDashboard;
     this.history = [];
     this.cmdHistoryFile = options.cmdHistoryFile || this.fs.dappPath(".embark", "cmd_history");
     this.providerReady = false;
@@ -153,9 +151,6 @@ class Console {
       return this.ipc.request("console:executeCmd", cmd, callback);
     }
 
-    if (this.useDashboard) {
-      this.logger.info("console > ".cyan + cmd.white);
-    }
     if (!(cmd.split(" ")[0] === "history" || cmd === __("history"))) {
       this.saveHistory(cmd);
     }


### PR DESCRIPTION
When using the dashboard and putting a command in the cockpit's console or the repl, it put `console $gt;` in the cockpit's console.

So I moved the logging of `console>` directly in the repl, since we only want that when using the repl and also created a new logger function called `consoleOnly` (name can be changed), that only logs to the embark console and not to the cockpit.