### PR TITLE
fix(cockpit/sidebar): fix closed sidebar in the dark-theme

### DIFF
--- a/packages/embark-ui/src/scss/coreui-dark.scss
+++ b/packages/embark-ui/src/scss/coreui-dark.scss
@@ -62,3 +62,4 @@
 }
 
 @import "SearchBar";
+@import "sidebar";


### PR DESCRIPTION
was caused by the dark-theme class not being high level enough