### PR TITLE
fix: pressing enter on "Display additional results" does the expected thing

### DIFF
--- a/packages/embark-ui/src/components/Console.js
+++ b/packages/embark-ui/src/components/Console.js
@@ -20,10 +20,15 @@ class Console extends Component {
   }
 
   handleSubmit(event) {
+    const instance = this.typeahead.getInstance();
+    if(instance.state.selected.length === 0) {
+      return;
+    }
+
     event.preventDefault();
     this.props.postCommand(this.state.value);
     this.setState({value: ''});
-    this.typeahead.getInstance().clear();
+    instance.clear();
   }
 
   handleChange(value, cb) {


### PR DESCRIPTION
There is still an issue with the library where if you press Enter on
"Display additional results" and don't navigate around the new options,
it won't update the current option in the underlying state.

It's still, however, a small improvement over what we had before.