### PR TITLE
fix(embark/storage): fix hang when storage is disabled

### DIFF
--- a/packages/embark/src/lib/core/engine.js
+++ b/packages/embark/src/lib/core/engine.js
@@ -193,7 +193,7 @@ class Engine {
     this.registerModule('code_generator', {plugins: self.plugins, env: self.env});
 
     const generateCode = function (modifiedAssets) {
-      self.events.request("module:storage:initiated", () => {
+      self.events.request("module:storage:onReady", () => {
         self.events.request("code-generator:embarkjs:build", () => {
           self.events.emit('code-generator-ready', modifiedAssets);
         });
@@ -279,15 +279,15 @@ class Engine {
         if (!this.config.storageConfig.available_providers.includes("ipfs")) {
           return next();
         }
-        this.registerModule('ipfs');
         this.events.on("ipfs:process:started", next);
+        this.registerModule('ipfs');
       },
       (next) => {
         if (!this.config.storageConfig.available_providers.includes("swarm")) {
           return next();
         }
-        this.registerModule('swarm');
         this.events.on("swarm:process:started", next);
+        this.registerModule('swarm');
       }
     ], (err) => {
       if(err) {

--- a/packages/embark/src/lib/modules/ipfs/index.js
+++ b/packages/embark/src/lib/modules/ipfs/index.js
@@ -20,29 +20,31 @@ class IPFS {
     this.webServerConfig = embark.config.webServerConfig;
     this.blockchainConfig = embark.config.blockchainConfig;
 
-    if (this.isIpfsStorageEnabledInTheConfig()) {
-      this.setServiceCheck();
-      this.registerUploadCommand();
-
-      this.events.request("processes:register", "ipfs", (cb) => {
-        this.startProcess(() => {
-          this.addStorageProviderToEmbarkJS();
-          this.addObjectToConsole();
-          this.events.emit("ipfs:process:started");
-          cb();
-        });
-      });
-
-      this._checkService((err) => {
-        if (!err) {
-          return;
-        }
-        this.logger.info("IPFS node not found, attempting to start own node");
-        this.listenToCommands();
-        this.registerConsoleCommands();
-        this.events.request('processes:launch', 'ipfs');
-      });
+    if (!this.isIpfsStorageEnabledInTheConfig()) {
+      return this.events.emit("ipfs:process:started", false);
     }
+
+    this.setServiceCheck();
+    this.registerUploadCommand();
+
+    this.events.request("processes:register", "ipfs", (cb) => {
+      this.startProcess(() => {
+        this.addStorageProviderToEmbarkJS();
+        this.addObjectToConsole();
+        this.events.emit("ipfs:process:started");
+        cb();
+      });
+    });
+
+    this._checkService((err) => {
+      if (!err) {
+        return;
+      }
+      this.logger.info("IPFS node not found, attempting to start own node");
+      this.listenToCommands();
+      this.registerConsoleCommands();
+      this.events.request('processes:launch', 'ipfs');
+    });
   }
 
   downloadIpfsApi(cb) {

--- a/packages/embark/src/lib/modules/storage/index.js
+++ b/packages/embark/src/lib/modules/storage/index.js
@@ -3,12 +3,24 @@ class Storage {
     this.embark = embark;
     this.storageConfig = embark.config.storageConfig;
     this.plugins = options.plugins;
+    this.ready = false;
 
-    if (!this.storageConfig.enabled) return;
+    this.embark.events.setCommandHandler("module:storage:onReady", (cb) => {
+      if (this.ready) {
+        return cb();
+      }
+      this.embark.events.once("module:storage:ready", cb);
+    });
+
+    if (!this.storageConfig.enabled) {
+      this.ready = true;
+      return;
+    }
 
     this.handleUploadCommand();
     this.addSetProviders(() => {
-      this.embark.events.setCommandHandler("module:storage:initiated", (cb) => { cb(); });
+      this.ready = true;
+      this.embark.events.emit("module:storage:ready");
     });
   }
 

--- a/packages/embark/src/lib/modules/swarm/index.js
+++ b/packages/embark/src/lib/modules/swarm/index.js
@@ -26,7 +26,7 @@ class Swarm {
     if (this.isSwarmEnabledInTheConfig() && cantDetermineUrl) {
       console.warn('\n===== Swarm module will not be loaded =====');
       console.warn(`Swarm is enabled in the config, however the config is not setup to provide a URL for swarm and therefore the Swarm module will not be loaded. Please either change the ${'config/storage > upload'.bold} setting to Swarm or add the Swarm config to the ${'config/storage > dappConnection'.bold} array. Please see ${'https://embark.status.im/docs/storage_configuration.html'.underline} for more information.\n`);
-      return;
+      return this.events.emit("swarm:process:started", false);
     }
     if (!this.isSwarmEnabledInTheConfig()) {
       this.embark.registerConsoleCommand({
@@ -36,7 +36,7 @@ class Swarm {
           cb();
         }
       });
-      return;
+      return this.events.emit("swarm:process:started", false);
     }
 
     this.providerUrl = utils.buildUrl(this.storageConfig.upload.protocol, this.storageConfig.upload.host, this.storageConfig.upload.port);


### PR DESCRIPTION
This was caused by the race condition fix that went in earlier. If storage was disabled or the storage process died, it hung because we wait for the storage to be ready to build the files.

We still will have the hang if IPFS or swarm crashes, should we still build if it crashes, or add a better message or something else?