### PR TITLE
fix(embark/solidity): fix getting the original filename of contracts

### DIFF
--- a/packages/embark/src/lib/modules/solidity/index.js
+++ b/packages/embark/src/lib/modules/solidity/index.js
@@ -145,7 +145,8 @@ class Solidity {
             compiled_object[className].abiDefinition = contract.abi;
             compiled_object[className].userdoc = contract.userdoc;
             compiled_object[className].filename = filename;
-            compiled_object[className].originalFilename = originalFilepaths[path.basename(filename)];
+            const normalized = path.normalize(filename);
+            compiled_object[className].originalFilename = Object.values(originalFilepaths).find(ogFilePath => normalized.indexOf(ogFilePath) > -1);
           }
         }
 


### PR DESCRIPTION
This caused the right tab on the editor to not work on Windows.
So instead of just doing a match, I check with an indexOf, because the path can be not super exact.