### PR TITLE
fix(embark-ui): correctly calculate which transactions to display

### DIFF
--- a/packages/embark-ui/src/actions/index.js
+++ b/packages/embark-ui/src/actions/index.js
@@ -82,6 +82,15 @@ export const blocks = {
   failure: (error) => action(BLOCKS[FAILURE], {error})
 };
 
+export const BLOCKS_FULL = createRequestTypes('BLOCKS_FULL');
+export const blocksFull = {
+  request: (from, limit) => {
+    return action(BLOCKS_FULL[REQUEST], {from, limit, txObjects: true, txReceipts: true});
+  },
+  success: (blocksFull) => action(BLOCKS_FULL[SUCCESS], {blocksFull}),
+  failure: (error) => action(BLOCKS_FULL[FAILURE], {error})
+};
+
 export const BLOCK = createRequestTypes('BLOCK');
 export const block = {
   request: (blockNumber) => action(BLOCK[REQUEST], {blockNumber}),

--- a/packages/embark-ui/src/components/Blocks.js
+++ b/packages/embark-ui/src/components/Blocks.js
@@ -38,7 +38,7 @@ const Blocks = ({blocks, changePage, currentPage, numberOfPages}) => (
               </Row>
             </div>
           ))}
-          <Pagination changePage={changePage} currentPage={currentPage} numberOfPages={numberOfPages}/>
+          {numberOfPages > 0 && <Pagination changePage={changePage} currentPage={currentPage} numberOfPages={numberOfPages}/>}
         </CardBody>
       </Card>
     </Col>

--- a/packages/embark-ui/src/components/ExplorerDashboardLayout.js
+++ b/packages/embark-ui/src/components/ExplorerDashboardLayout.js
@@ -25,7 +25,7 @@ const ExplorerDashboardLayout = () => (
           <BlocksContainer numBlocksToDisplay={5} overridePageHead={false} />
         </Col>
         <Col xl={6}>
-          <TransactionsContainer overridePageHead={false} />
+          <TransactionsContainer numTxsToDisplay={3} overridePageHead={false} />
         </Col>
       </Row>
     </div>

--- a/packages/embark-ui/src/components/Transactions.js
+++ b/packages/embark-ui/src/components/Transactions.js
@@ -15,6 +15,7 @@ const Transactions = ({transactions, contracts, changePage, currentPage, numberO
           <h2>Transactions</h2>
         </CardHeader>
         <CardBody>
+          {!transactions.length && "No transactions to display"}
           {transactions.map(transaction => (
             <div className="explorer-row border-top" key={transaction.hash}>
               <CardTitleIdenticon id={transaction.hash}>Transaction&nbsp;
@@ -47,7 +48,7 @@ const Transactions = ({transactions, contracts, changePage, currentPage, numberO
               </Row>
             </div>
           ))}
-          {numberOfPages && <Pagination changePage={changePage} currentPage={currentPage} numberOfPages={numberOfPages}/>}
+          {numberOfPages > 0 && <Pagination changePage={changePage} currentPage={currentPage} numberOfPages={numberOfPages}/>}
         </CardBody>
       </Card>
     </Col>

--- a/packages/embark-ui/src/containers/AccountContainer.js
+++ b/packages/embark-ui/src/containers/AccountContainer.js
@@ -2,8 +2,10 @@ import React, {Component} from 'react';
 import {connect} from 'react-redux';
 import PropTypes from 'prop-types';
 import {withRouter} from 'react-router-dom';
-
-import {account as accountAction} from '../actions';
+import {account as accountAction,
+        initBlockHeader,
+        stopBlockHeader,
+        transactions as transactionsAction} from '../actions';
 import Account from '../components/Account';
 import DataWrapper from "../components/DataWrapper";
 import Transactions from '../components/Transactions';
@@ -13,6 +15,12 @@ import {getAccount, getTransactionsByAccount} from "../reducers/selectors";
 class AccountContainer extends Component {
   componentDidMount() {
     this.props.fetchAccount(this.props.match.params.address);
+    this.props.fetchTransactions();
+    this.props.initBlockHeader();
+  }
+
+  componentWillUnmount() {
+    this.props.stopBlockHeader();
   }
 
   render() {
@@ -50,6 +58,9 @@ AccountContainer.propTypes = {
 export default withRouter(connect(
   mapStateToProps,
   {
-    fetchAccount: accountAction.request
+    fetchAccount: accountAction.request,
+    fetchTransactions: transactionsAction.request,
+    initBlockHeader,
+    stopBlockHeader
   }
 )(AccountContainer));

--- a/packages/embark-ui/src/containers/TransactionsContainer.js
+++ b/packages/embark-ui/src/containers/TransactionsContainer.js
@@ -4,7 +4,8 @@ import PropTypes from 'prop-types';
 import {blocksFull as blocksAction,
         contracts as contractsAction,
         initBlockHeader,
-        stopBlockHeader} from '../actions';
+        stopBlockHeader,
+        transactions as transactionsAction} from '../actions';
 import Transactions from '../components/Transactions';
 import DataWrapper from "../components/DataWrapper";
 import PageHead from "../components/PageHead";
@@ -24,6 +25,7 @@ class TransactionsContainer extends Component {
   componentDidMount() {
     this.props.fetchBlocksFull(null, this.numBlocksToFetch);
     this.props.fetchContracts();
+    this.props.fetchTransactions();
     this.props.initBlockHeader();
   }
 
@@ -56,6 +58,7 @@ class TransactionsContainer extends Component {
       this.numberOfBlocks - 1 - (this.numBlocksToFetch * (newPage - 1)),
       this.numBlocksToFetch
     );
+    this.props.fetchTransactions((newPage * MAX_TXS) + MAX_TXS);
   }
 
   getCurrentTransactions() {
@@ -135,6 +138,7 @@ export default connect(
   {
     fetchBlocksFull: blocksAction.request,
     fetchContracts: contractsAction.request,
+    fetchTransactions: transactionsAction.request,
     initBlockHeader,
     stopBlockHeader
   },

--- a/packages/embark-ui/src/reducers/index.js
+++ b/packages/embark-ui/src/reducers/index.js
@@ -18,6 +18,7 @@ const PROCESS_LOGS_LIMIT = ELEMENTS_LIMIT * 2;
 const entitiesDefaultState = {
   accounts: [],
   blocks: [],
+  blocksFull: [],
   transactions: [],
   processes: [],
   services: [],
@@ -41,6 +42,9 @@ const entitiesDefaultState = {
 
 const sorter = {
   blocks: function(a, b) {
+    return b.number - a.number;
+  },
+  blocksFull: function(a, b) {
     return b.number - a.number;
   },
   transactions: function(a, b) {
@@ -114,6 +118,13 @@ const filters = {
     return index === self.findIndex((t) => t.address === account.address);
   },
   blocks: function(block, index, self) {
+    if (index > ELEMENTS_LIMIT) {
+      return false;
+    }
+
+    return index === self.findIndex((t) => t.number === block.number);
+  },
+  blocksFull: function(block, index, self) {
     if (index > ELEMENTS_LIMIT) {
       return false;
     }

--- a/packages/embark-ui/src/reducers/selectors.js
+++ b/packages/embark-ui/src/reducers/selectors.js
@@ -44,6 +44,10 @@ export function getBlocks(state) {
   return state.entities.blocks;
 }
 
+export function getBlocksFull(state) {
+  return state.entities.blocksFull;
+}
+
 export function getLastBlock(state) {
   return state.entities.blocks[0];
 }

--- a/packages/embark-ui/src/sagas/index.js
+++ b/packages/embark-ui/src/sagas/index.js
@@ -47,6 +47,7 @@ export const fetchBlock = doRequest.bind(null, actions.block, api.fetchBlock);
 export const fetchTransaction = doRequest.bind(null, actions.transaction, api.fetchTransaction);
 export const fetchAccounts = doRequest.bind(null, actions.accounts, api.fetchAccounts);
 export const fetchBlocks = doRequest.bind(null, actions.blocks, api.fetchBlocks);
+export const fetchBlocksFull = doRequest.bind(null, actions.blocksFull, api.fetchBlocks);
 export const fetchTransactions = doRequest.bind(null, actions.transactions, api.fetchTransactions);
 export const fetchProcesses = doRequest.bind(null, actions.processes, api.fetchProcesses);
 export const fetchServices = doRequest.bind(null, actions.services, api.fetchServices);
@@ -118,6 +119,10 @@ export function *watchFetchBlock() {
 
 export function *watchFetchBlocks() {
   yield takeEvery(actions.BLOCKS[actions.REQUEST], fetchBlocks);
+}
+
+export function *watchFetchBlocksFull() {
+  yield takeEvery(actions.BLOCKS_FULL[actions.REQUEST], fetchBlocksFull);
 }
 
 export function *watchFetchAccount() {
@@ -389,6 +394,7 @@ export function *initBlockHeader() {
       return;
     }
     yield put({type: actions.BLOCKS[actions.REQUEST]});
+    yield put({type: actions.BLOCKS_FULL[actions.REQUEST], txObjects: true, txReceipts: true});
     yield put({type: actions.TRANSACTIONS[actions.REQUEST]});
   }
 }
@@ -568,6 +574,7 @@ export default function *root() {
     fork(watchFetchVersions),
     fork(watchFetchPlugins),
     fork(watchFetchBlocks),
+    fork(watchFetchBlocksFull),
     fork(watchFetchContracts),
     fork(watchFetchContractProfile),
     fork(watchPostContractFunction),


### PR DESCRIPTION
Revise calculations related to transactions and pagination in the transactions explorer and explorers overview.

Make the number of transactions to display per page configurable and set it to 3 in the explorers overview. Display a "No transactions..." message instead of "0" when there are no transactions to display.

Introduce a `blocksFull` prop, action, api, etc. for calculating lists of transactions relative to block objects that contain full transaction objects instead of hash strings (the function backing the blocks endpoint already supports that) and transaction receipts. In the future, the receipts can be used to filter out constructor transactions for silent contracts.

Make pagination display conditional within the blocks explorer, same as in the transactions explorer.