### PR TITLE
fix(embark-ui): AccountContainer should get txs for cold load case

### DIFF
--- a/packages/embark-ui/src/containers/AccountContainer.js
+++ b/packages/embark-ui/src/containers/AccountContainer.js
@@ -2,8 +2,10 @@ import React, {Component} from 'react';
 import {connect} from 'react-redux';
 import PropTypes from 'prop-types';
 import {withRouter} from 'react-router-dom';
-
-import {account as accountAction} from '../actions';
+import {account as accountAction,
+        initBlockHeader,
+        stopBlockHeader,
+        transactions as transactionsAction} from '../actions';
 import Account from '../components/Account';
 import DataWrapper from "../components/DataWrapper";
 import Transactions from '../components/Transactions';
@@ -13,6 +15,12 @@ import {getAccount, getTransactionsByAccount} from "../reducers/selectors";
 class AccountContainer extends Component {
   componentDidMount() {
     this.props.fetchAccount(this.props.match.params.address);
+    this.props.fetchTransactions();
+    this.props.initBlockHeader();
+  }
+
+  componentWillUnmount() {
+    this.props.stopBlockHeader();
   }
 
   render() {
@@ -50,6 +58,9 @@ AccountContainer.propTypes = {
 export default withRouter(connect(
   mapStateToProps,
   {
-    fetchAccount: accountAction.request
+    fetchAccount: accountAction.request,
+    fetchTransactions: transactionsAction.request,
+    initBlockHeader,
+    stopBlockHeader
   }
 )(AccountContainer));

--- a/packages/embark-ui/src/containers/TransactionsContainer.js
+++ b/packages/embark-ui/src/containers/TransactionsContainer.js
@@ -4,7 +4,8 @@ import PropTypes from 'prop-types';
 import {blocksFull as blocksAction,
         contracts as contractsAction,
         initBlockHeader,
-        stopBlockHeader} from '../actions';
+        stopBlockHeader,
+        transactions as transactionsAction} from '../actions';
 import Transactions from '../components/Transactions';
 import DataWrapper from "../components/DataWrapper";
 import PageHead from "../components/PageHead";
@@ -24,6 +25,7 @@ class TransactionsContainer extends Component {
   componentDidMount() {
     this.props.fetchBlocksFull(null, this.numBlocksToFetch);
     this.props.fetchContracts();
+    this.props.fetchTransactions();
     this.props.initBlockHeader();
   }
 
@@ -56,6 +58,7 @@ class TransactionsContainer extends Component {
       this.numberOfBlocks - 1 - (this.numBlocksToFetch * (newPage - 1)),
       this.numBlocksToFetch
     );
+    this.props.fetchTransactions((newPage * MAX_TXS) + MAX_TXS);
   }
 
   getCurrentTransactions() {
@@ -135,6 +138,7 @@ export default connect(
   {
     fetchBlocksFull: blocksAction.request,
     fetchContracts: contractsAction.request,
+    fetchTransactions: transactionsAction.request,
     initBlockHeader,
     stopBlockHeader
   },


### PR DESCRIPTION
Don't implicitly rely on explorer overview having been loaded to initially populate `entities.transactions`. Also, that container should watch for new blocks/transactions same as the other explorer containers.

Restore `getTransactions` and related to TransactionsContainer. It's no longer the basis of pagination (it didn't work as desired), but when navigating through the transaction pages that action will ensure more transactions are fetched so that the account page will list more of an account's transactions over time. That was a side effect of `getTransactions` before it was removed in favor of `getBlocksFull`, which is still the basis of revised pagination logic in the transactions explorer.