### PR TITLE
build(embark-vyper): use a caret range for embark-async-wrapper

### DIFF
--- a/packages/embark-vyper/package.json
+++ b/packages/embark-vyper/package.json
@@ -47,7 +47,7 @@
   },
   "dependencies": {
     "@babel/runtime-corejs2": "7.3.1",
-    "embark-async-wrapper": "4.0.0-beta.0",
+    "embark-async-wrapper": "^4.0.0-beta.0",
     "shelljs": "0.5.3"
   },
   "devDependencies": {


### PR DESCRIPTION
Member packages of the monorepo should use caret ranges when specifying other packages in the monorepo as dependencies.