### PR TITLE
feat(@embark/embarkjs): add bytecode to contract

### DIFF
--- a/packages/embarkjs/src/blockchain.js
+++ b/packages/embarkjs/src/blockchain.js
@@ -253,6 +253,9 @@ let Contract = function(options) {
   ContractClass.abi = ContractClass.options.abi;
   ContractClass.address = this.address;
   ContractClass.gas = this.gas;
+  ContractClass.bytecode = '0x' + options.code;
+  ContractClass.runtime_bytecode = '0x' + options.runtime_bytecode;
+  ContractClass.real_runtime_bytecode = '0x' + options.real_runtime_bytecode;
 
   let originalMethods = Object.keys(ContractClass);
 


### PR DESCRIPTION
The `runtime_bytecode` is a useful information to remotely check if a smart contract matches our local informations.

This information was present in the configuration provided to the `EmbarkJS.Blockchain.Contract` constructor but was not saved, so we had no way to recover this information from artifacts.

I added three fields to the instance: `bytecode`, `runtime_bytecode` and `real_runtime_bytecode`.