### PR TITLE
docs(contributing): Update the syntax of the header and scope

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -141,7 +141,7 @@ Each commit message consists of a **header**, a **body** and a **footer**.  The 
 format that includes a **type**, a **scope** and a **subject**:
 
 ```
-<type>(<scope>): <subject>
+type(@embark|@cockpit/<SCOPE>): <subject>
 <BLANK LINE>
 <body>
 <BLANK LINE>
@@ -189,7 +189,9 @@ The following is the list of supported scopes:
 
 * **@embark/cli** - Embark command line interface
 * **@embark/core** - Embark core
-* **@embark/<module>** - Embark core module
+* **@embark/<`module`>** - Embark core module (any folder name under `packages/embark/src/lib/modules`), ie `@embark/console` or `@embark/debugger`
+* **@embark/<`package`>** - Embark npm package in the monorepo (any folder name under `packages/`), ie `@embark/embarkjs` or `@embark/embark-compiler`
+* **@cockpit/<`section`>** - Cockpit site section, ie `@cockpit/explorer`
 
 There are currently a few exceptions to the "use package name" rule:
 


### PR DESCRIPTION
Add more detailed syntax and examples surrounding the commit header and scopes.