### PR TITLE
fix: run geth in archival mode

### DIFF
--- a/packages/embark/src/lib/modules/blockchain_process/gethClient.js
+++ b/packages/embark/src/lib/modules/blockchain_process/gethClient.js
@@ -73,6 +73,10 @@ class GethClient {
       cmd.push("--syncmode=" + config.syncMode);
     }
 
+    if(this.runAsArchival(config)) {
+      cmd.push("--gcmode=archive");
+    }
+
     if (config.account && config.account.password) {
       const resolvedPath = path.resolve(fs.dappPath(), config.account.password);
       cmd.push(`--password=${resolvedPath}`);
@@ -133,6 +137,10 @@ class GethClient {
       cmd = "--networkid=" + config.networkId;
     }
     return cmd;
+  }
+
+  runAsArchival(config) {
+    return config.networkId === 1337 || config.archivalMode;
   }
 
   initGenesisCommmand() {

--- a/packages/embark/src/lib/modules/blockchain_process/parityClient.js
+++ b/packages/embark/src/lib/modules/blockchain_process/parityClient.js
@@ -102,6 +102,10 @@ class ParityClient {
       }
     }
 
+    if(this.runAsArchival(config)) {
+      cmd.push("--pruning=archive");
+    }
+
     return cmd;
   }
 
@@ -125,6 +129,10 @@ class ParityClient {
       parsed = match[1].trim();
     }
     return parsed;
+  }
+
+  runAsArchival(config) {
+    return config.networkId === 1337 || config.archivalMode;
   }
 
   isSupportedVersion(parsedVersion) {


### PR DESCRIPTION
This will only be enabled for test networks in order to be able to debug
transactions that have occurred in the past.