### PR TITLE
fix(@embark/storage): Fix hang when IPFS/Swarm started externally

### DIFF
--- a/packages/embark/src/lib/modules/codeRunner/index.ts
+++ b/packages/embark/src/lib/modules/codeRunner/index.ts
@@ -40,9 +40,8 @@ class CodeRunner {
   private generateListener(provider: string, eventType: ProviderEventType) {
     const providerStateName = `${provider}:${eventType}`;
     const eventName = `runcode:${providerStateName}`;
-    this.providerStates[`${provider}:${eventType}`] = false;
     this.events.setCommandHandler(eventName, (cb) => {
-      if (this.providerStates[providerStateName]) {
+      if (this.providerStates[providerStateName] === true) {
         return cb();
       }
       this.events.once(eventName, cb);

--- a/packages/embark/src/lib/modules/storage/index.js
+++ b/packages/embark/src/lib/modules/storage/index.js
@@ -50,7 +50,9 @@ class Storage {
     this.embark.addProviderInit('storage', code, shouldInit);
     this.embark.events.request("runcode:storage:providerRegistered", () => {
       this.embark.addConsoleProviderInit('storage', code, shouldInit);
-      cb();
+      this.embark.events.request("runcode:storage:providerSet", () => {
+        cb();
+      });
     });
   }
 

--- a/packages/embarkjs/src/storage.js
+++ b/packages/embarkjs/src/storage.js
@@ -66,7 +66,7 @@ Storage.setProvider = function (providerName, options) {
 
 Storage.isAvailable = function () {
   if (!this.currentStorage) {
-    return false;
+    return Promise.resolve(false);
   }
   return this.currentStorage.isAvailable();
 };


### PR DESCRIPTION
Fix hang when the storage provider (IPFS or Swarm) was started externally before running Embark.

If IPFS/Swarm was already running before `embark run` was run, then the relevant `registerProvider` and `setProvider` code was not being run through the console, and thus the module init event was never fired, preventing the DApp from being built.

This PR refactors the way the IPFS/Swarm process is launched so that the `registerProvider` and `setProvider` code snippets are run through the console in the case of:
* IPFS/Swarm running externally from Embark
* IPFS/Swarm started in a child process by Embark
* Storage is disabled in the DApp config