### PR TITLE
fix(@embark/tests): Fix contracts app hanging

### DIFF
--- a/dapps/tests/contracts/test/ownable_test.sol
+++ b/dapps/tests/contracts/test/ownable_test.sol
@@ -1,5 +1,5 @@
 pragma solidity ^0.4.7;
-import "./../ownable.sol";
+import "../contracts/ownable.sol";
 
 contract OwnableTests {
   Ownable own;

--- a/packages/embark/src/lib/core/config.js
+++ b/packages/embark/src/lib/core/config.js
@@ -61,6 +61,16 @@ var Config = function(options) {
     self.contractsFiles.push(new File({path: filename, originalPath: filename, type: Types.custom, resolver}));
   });
 
+  self.events.setCommandHandler("config:contractsFiles:reset", (cb) => {
+    self.contractsFiles.forEach((file) => {
+      if(file.path.includes(".embark")) {
+        fs.removeSync(file.path);
+      }
+      self.contractsFiles = self.contractsFiles.filter((contractFile) => contractFile.path !== file.path);
+    });
+    cb();
+  });
+
   self.events.on('file-remove', (fileType, removedPath) => {
     if(fileType !== 'contract') return;
     const normalizedPath = path.normalize(removedPath);

--- a/packages/embark/src/lib/modules/blockchain_connector/provider.js
+++ b/packages/embark/src/lib/modules/blockchain_connector/provider.js
@@ -19,7 +19,7 @@ class Provider {
 
     this.events.setCommandHandler("blockchain:provider:contract:accounts:get", cb => {
       const accounts = this.accounts.map(a => a.address || a);
-      cb(accounts);
+      cb(null, accounts);
     });
   }
 

--- a/packages/embark/src/lib/modules/deployment/contract_deployer.js
+++ b/packages/embark/src/lib/modules/deployment/contract_deployer.js
@@ -115,8 +115,8 @@ class ContractDeployer {
       // TODO: can potentially go to a beforeDeploy plugin
       function getAccounts(next) {
         deploymentAccount = self.blockchain.defaultAccount();
-        self.events.request('blockchain:provider:contract:accounts:get', _accounts => {
-          accounts = _accounts;
+        self.events.request('blockchain:provider:contract:accounts:get', (_err, blockchainAccounts) => {
+          accounts = blockchainAccounts;
 
           // applying deployer account configuration, if any
           if (typeof contract.fromIndex === 'number') {

--- a/packages/embark/src/lib/modules/solidity/index.js
+++ b/packages/embark/src/lib/modules/solidity/index.js
@@ -183,8 +183,9 @@ class Solidity {
               .then(fileContent => {
                 input[file.path] = {content: fileContent.replace(/\r\n/g, '\n')};
                 fileCb();
-              }).catch((_e) => {
+              }).catch((e) => {
                 self.logger.error(__('Error while loading the content of ') + filename);
+                self.logger.debug(e);
                 fileCb();
               });
           },

--- a/packages/embark/src/lib/modules/tests/index.js
+++ b/packages/embark/src/lib/modules/tests/index.js
@@ -105,6 +105,16 @@ class TestRunner {
       if (err) {
         return cb(err);
       }
+      self.fs.remove('.embark/contracts', (err) => {
+        if(err) {
+          console.error(__("Error deleting compiled contracts from .embark"), err);
+        }
+      });
+      self.fs.remove('.embark/remix_tests.sol', (err) => {
+        if(err) {
+          console.error(__("Error deleting '.embark/remix_tests.sol'"), err);
+        }
+      });
       let totalFailures = results.reduce((acc, result) => acc + result.failures, 0);
       if (totalFailures) {
         return cb(` > Total number of failures: ${totalFailures}`.red.bold);
@@ -228,8 +238,10 @@ class TestRunner {
         return cb(err);
       }
       let failures = runs.reduce((acc, val) => acc + val, 0);
-      self.fs.remove('.embark/contracts', (_err) => {
-        cb(null, {failures});
+      self.events.request('config:contractsFiles:reset', () => {
+        global.config({}, (err) => {
+          cb(err, {failures});
+        });
       });
     });
   }
@@ -265,7 +277,9 @@ class TestRunner {
           totalFailures = totalFailures + r.failureNum;
         });
       });
-      cb(null, {failures: totalFailures, pass: totalPass});
+      this.events.request('config:contractsFiles:reset', () => {
+        cb(null, {failures: totalFailures, pass: totalPass});
+      });
     });
   }
 }

--- a/packages/embark/src/lib/modules/tests/solc_test.js
+++ b/packages/embark/src/lib/modules/tests/solc_test.js
@@ -47,9 +47,9 @@ class SolcTest extends Test {
       function determineContractsToDeploy(next) {
         self.events.request("contracts:list", (err, contracts) => {
           let contractsToDeploy = contracts.filter((contract) => {
-            return contract.filename && contract.filename.indexOf('_test.sol') >= 0;
+            return contract.originalFilename && contract.originalFilename.indexOf('_test.sol') >= 0;
           });
-          let assertLib = contracts.filter((contract) => contract.filename === 'remix_tests.sol')[0];
+          let assertLib = contracts.filter((contract) => contract.originalFilename === 'remix_tests.sol')[0];
           next(null, [assertLib].concat(contractsToDeploy));
         });
       },
@@ -89,8 +89,8 @@ class SolcTest extends Test {
           const contractsToTest = [];
 
           Object.keys(contracts).forEach((contract) => {
-            if (contracts[contract].filename &&
-              contracts[contract].filename.replace(/\\/g, '/') === forwardSlashFile) {
+            if (contracts[contract].originalFilename &&
+              contracts[contract].originalFilename.replace(/\\/g, '/') === forwardSlashFile) {
               contractsToTest.push(contracts[contract]);
             }
           });
@@ -120,7 +120,7 @@ class SolcTest extends Test {
                 methodIdentifiers: contract.functionHashes 
               }
             };
-            this.getEmbarkJSContract(contract, (err, embarkjsContract) => {
+            self.getEmbarkJSContract(contract, (err, embarkjsContract) => {
               if(err) {
                 return _callback(err);
               }

--- a/packages/embark/src/lib/modules/tests/test.js
+++ b/packages/embark/src/lib/modules/tests/test.js
@@ -28,7 +28,7 @@ class Test {
     this.embarkjs = {};
 
     this.events.setCommandHandler("blockchain:provider:contract:accounts:get", cb => {
-      cb(this.accounts);
+      this.events.request("blockchain:getAccounts", cb);
     });
   }
 


### PR DESCRIPTION
Contract app hangs when attempting to test the solc contract in the test folder.

There were several causes:
1. The test contract needed a referenced contract path updated
2. Contracts that had been compiled in the JS tests were being deleted at the end of the JS test run, which caused errors with the files not being found. The fix was to reset the contracts config to no longer require the non-test contracts to be compiled/deployed.
3. Contract filtering was attempting to filter on a property `filename` that must have been changed to `originalFilename` at some point and therefore was not filtering properly.
4. The accounts used by the contract deployer were getting overwritten when `SolcTest` was instantiated and thus preventing the `remix_tests` `Assert` library from getting deployed.