### PR TITLE
fix(@cockpit/deployment): Check if contracts deployed when connected to MetaMask

### DIFF
--- a/packages/embark-ui/src/actions/index.js
+++ b/packages/embark-ui/src/actions/index.js
@@ -360,6 +360,13 @@ export const web3EstimateGas = {
   failure: (error, payload) => action(WEB3_ESTIMAGE_GAS[FAILURE], {web3Error: error, contract: payload.contract})
 };
 
+export const WEB3_IS_DEPLOYED = createRequestTypes('WEB3_IS_DEPLOYED');
+export const web3IsDeployed = {
+  request: (contract, args) => action(WEB3_IS_DEPLOYED[REQUEST], {contract, args}),
+  success: (isDeployed, payload) => action(WEB3_IS_DEPLOYED[SUCCESS], {contract: payload.contract, isDeployed}),
+  failure: (error, payload) => action(WEB3_IS_DEPLOYED[FAILURE], {web3Error: error, contract: payload.contract})
+};
+
 export const START_DEBUG = createRequestTypes('START_DEBUG');
 export const startDebug = {
   request: (txHash) => action(START_DEBUG[REQUEST], {txHash}),

--- a/packages/embark-ui/src/containers/DeploymentContainer.js
+++ b/packages/embark-ui/src/containers/DeploymentContainer.js
@@ -10,7 +10,14 @@ import {
 import ContractsDeployment from '../components/ContractsDeployment';
 import DataWrapper from "../components/DataWrapper";
 import PageHead from '../components/PageHead';
-import {getContracts, getDeploymentPipeline, getWeb3, getWeb3GasEstimates, getWeb3Deployments} from "../reducers/selectors";
+import {
+  getContracts,
+  getDeploymentPipeline,
+  getWeb3,
+  getWeb3GasEstimates,
+  getWeb3Deployments,
+  getWeb3ContractsDeployed
+} from "../reducers/selectors";
 
 class DeploymentContainer extends Component {
   componentDidMount() {
@@ -29,6 +36,7 @@ class DeploymentContainer extends Component {
                               web3EstimateGas={this.props.web3EstimateGas}
                               web3Deployments={this.props.web3Deployments}
                               web3GasEstimates={this.props.web3GasEstimates}
+                              web3ContractsDeployed={this.props.web3ContractsDeployed}
                               updateDeploymentPipeline={this.props.updateDeploymentPipeline} />
         )} />
       </React.Fragment>
@@ -43,6 +51,7 @@ function mapStateToProps(state) {
     web3: getWeb3(state),
     web3Deployments: getWeb3Deployments(state),
     web3GasEstimates: getWeb3GasEstimates(state),
+    web3ContractsDeployed: getWeb3ContractsDeployed(state),
     error: state.errorMessage,
     loading: state.loading
   };
@@ -60,7 +69,7 @@ DeploymentContainer.propTypes = {
   web3Deploy: PropTypes.func,
   web3Deployments: PropTypes.object,
   web3EstimateGas: PropTypes.func,
-  web3GasEstimates: PropTypes.object,
+  web3GasEstimates: PropTypes.object
 };
 
 export default connect(

--- a/packages/embark-ui/src/reducers/index.js
+++ b/packages/embark-ui/src/reducers/index.js
@@ -3,7 +3,7 @@ import {REQUEST, SUCCESS, FAILURE, CONTRACT_COMPILE, FILES, LOGOUT, AUTHENTICATE
         FETCH_CREDENTIALS, UPDATE_BASE_ETHER, CHANGE_THEME, FETCH_THEME, EXPLORER_SEARCH, DEBUGGER_INFO,
         SIGN_MESSAGE, VERIFY_MESSAGE, TOGGLE_BREAKPOINT, UPDATE_PREVIEW_URL,
         UPDATE_DEPLOYMENT_PIPELINE, WEB3_CONNECT, WEB3_DEPLOY, WEB3_ESTIMAGE_GAS, FETCH_EDITOR_TABS,
-        SAVE_FILE, SAVE_FOLDER, REMOVE_FILE, DECODED_TRANSACTION} from "../actions";
+        SAVE_FILE, SAVE_FOLDER, REMOVE_FILE, DECODED_TRANSACTION, WEB3_IS_DEPLOYED} from "../actions";
 import {EMBARK_PROCESS_NAME, DARK_THEME, DEPLOYMENT_PIPELINES, DEFAULT_HOST, ELEMENTS_LIMIT} from '../constants';
 
 const BN_FACTOR = 10000;
@@ -353,7 +353,7 @@ function breakpoints(state = {}, action) {
   return state;
 }
 
-function web3(state = {deployments: {}, gasEstimates: {}}, action) {
+function web3(state = {deployments: {}, gasEstimates: {}, contractsDeployed: {}}, action) {
   if (action.type === WEB3_CONNECT[SUCCESS]) {
     return {...state, instance: action.web3};
   } else if (action.type === WEB3_DEPLOY[REQUEST]) {
@@ -368,6 +368,12 @@ function web3(state = {deployments: {}, gasEstimates: {}}, action) {
     return {...state, gasEstimates: {...state['gasEstimates'], [action.contract.className]: {gas: action.gas, running: false, error: null}}};
   } else if (action.type === WEB3_ESTIMAGE_GAS[FAILURE]){
     return {...state, gasEstimates: {...state['gasEstimates'], [action.contract.className]: {error: action.web3Error, running: false}}};
+  } else if (action.type === WEB3_IS_DEPLOYED[REQUEST]) {
+    return {...state, contractsDeployed: {...state['contractsDeployed'], [action.contract.className]: {running: true, error: null}}};
+  } else if (action.type === WEB3_IS_DEPLOYED[SUCCESS]){
+    return {...state, contractsDeployed: {...state['contractsDeployed'], [action.contract.className]: {isDeployed: action.isDeployed, running: false, error: null}}};
+  } else if (action.type === WEB3_IS_DEPLOYED[FAILURE]){
+    return {...state, contractsDeployed: {...state['contractsDeployed'], [action.contract.className]: {error: action.web3Error, running: false}}};
   }
 
   return state

--- a/packages/embark-ui/src/reducers/selectors.js
+++ b/packages/embark-ui/src/reducers/selectors.js
@@ -237,6 +237,10 @@ export function getWeb3Deployments(state) {
   return state.web3.deployments;
 }
 
+export function getWeb3ContractsDeployed(state) {
+  return state.web3.contractsDeployed;
+}
+
 export function getDebuggerInfo(state) {
   return state.debuggerInfo;
 }

--- a/packages/embark-ui/src/services/web3.js
+++ b/packages/embark-ui/src/services/web3.js
@@ -30,3 +30,18 @@ export function deploy({web3, contract, args}) {
       .then(() => {});
     });
 }
+
+export function isDeployed({web3, contract}) {
+  if(!contract.deployedAddress) return Promise.resolve(false);
+  return new Promise((resolve, reject) => {
+    web3.eth.getCode(contract.deployedAddress, (err, byteCode) => {
+      if(err) return reject(err);
+      const deployedAddress = contract.deployedAddress.replace("0x", "").toLowerCase();
+      resolve(
+        byteCode === `0x${contract.runtimeBytecode}` || // case when contract has been deployed or redeployed
+        byteCode === `0x73${deployedAddress}${contract.runtimeBytecode.replace("730000000000000000000000000000000000000000", "")}` || // case when library deployed already
+        byteCode === `0x${contract.runtimeBytecode.replace("0000000000000000000000000000000000000000", deployedAddress)}` // case when library has been redeployed
+      );
+    });
+  });
+}


### PR DESCRIPTION
When connected to metamask, and “Injected Web3” is selected on the Deployment page of Cockpit, check to see if contracts have already been deployed or not.

For contracts that have not been deployed, or set to an address in the config, these should now all be re-deployable.

Supports libraries (that have bytecode with `0x73<address><bytecode>`).