### PR TITLE
fix(@embark/contracts_manager, @embark/solidity): compare correct property; handle absolute paths correctly 

### DIFF
--- a/packages/embark/src/lib/modules/contracts_manager/index.js
+++ b/packages/embark/src/lib/modules/contracts_manager/index.js
@@ -1,6 +1,6 @@
 let async = require('async');
 const cloneDeep = require('clone-deep');
-
+const path = require('path');
 const utils = require('../../utils/utils.js');
 const constants = require('../../constants');
 
@@ -260,7 +260,6 @@ class ContractsManager {
 
   build(done, _useContractFiles = true, resetContracts = true) {
     let self = this;
-    self.contracts = {};
 
     if(resetContracts) self.contracts = {};
     async.waterfall([
@@ -287,7 +286,7 @@ class ContractsManager {
           self.contractsFiles &&
           self.contractsFiles.every(contractFile =>
             Object.values(self.compiledContracts).find(contract =>
-              contract.originalFilename === contractFile.filename
+              contract.originalFilename === path.normalize(contractFile.originalPath)
             )
           );
         callback(null, allContractsCompiled);


### PR DESCRIPTION
Several problems were discovered when investigating why Windows builds on AppVeyor and Azure Pipelines have been failing. This PR fixes them and #1480 will be rebased against this branch to demonstrate the changes work across all platforms.

### fix(@embark/contracts_manager): compare correct property

Compare a contract's `originalFilename` property to a contract file's normalized `originalPath` property instead of `filename`. The `filename` property seems to have been removed.

### fix(@embark/solidity): handle absolute paths correctly

Detect absolute paths and handle them differently from paths that have not been resolved.