### PR TITLE
refactor(@cockpit/explorer): show pagination when num pages > 1

### DIFF
--- a/packages/embark-ui/src/components/Blocks.js
+++ b/packages/embark-ui/src/components/Blocks.js
@@ -38,7 +38,7 @@ const Blocks = ({blocks, changePage, currentPage, numberOfPages}) => (
               </Row>
             </div>
           ))}
-          {numberOfPages > 0 && <Pagination changePage={changePage} currentPage={currentPage} numberOfPages={numberOfPages}/>}
+          {numberOfPages > 1 && <Pagination changePage={changePage} currentPage={currentPage} numberOfPages={numberOfPages}/>}
         </CardBody>
       </Card>
     </Col>

--- a/packages/embark-ui/src/components/Transactions.js
+++ b/packages/embark-ui/src/components/Transactions.js
@@ -48,7 +48,7 @@ const Transactions = ({transactions, contracts, changePage, currentPage, numberO
               </Row>
             </div>
           ))}
-          {numberOfPages > 0 && <Pagination changePage={changePage} currentPage={currentPage} numberOfPages={numberOfPages}/>}
+          {numberOfPages > 1 && <Pagination changePage={changePage} currentPage={currentPage} numberOfPages={numberOfPages}/>}
         </CardBody>
       </Card>
     </Col>


### PR DESCRIPTION
During work on PRs #1492 and #1494 it became evident that it's not desirable to show pagination controls unless the number of pages is greater than one.