### PR TITLE
fix(@embark/debugger): Add error handling to prevent crash

### DIFF
--- a/packages/embark/src/lib/modules/debugger/index.ts
+++ b/packages/embark/src/lib/modules/debugger/index.ts
@@ -75,7 +75,7 @@ class TransactionDebugger {
       if (err) { return cb([]); }
       for (const variable of Object.keys(globals || {})) {
         const value: any = globals[variable];
-        if (line.indexOf(variable) >= 0) {
+        if (line && line.indexOf(variable) >= 0) {
           foundVars.push({name: variable, value});
         }
       }
@@ -83,7 +83,7 @@ class TransactionDebugger {
       for (const variable of Object.keys(knownVars.locals || {})) {
         const value: any = knownVars.locals[variable];
         const variableName: string = variable.split(" ")[0];
-        if (line.indexOf(variableName) >= 0) {
+        if (line && line.indexOf(variableName) >= 0) {
           foundVars.push({name: variable, value});
         }
       }
@@ -91,7 +91,7 @@ class TransactionDebugger {
       for (const variable of Object.keys(knownVars.contract || {})) {
         const value: any = knownVars.contract[variable];
         const variableName: string = variable.split(" ")[0];
-        if (line.indexOf(variableName) >= 0) {
+        if (line && line.indexOf(variableName) >= 0) {
           foundVars.push({name: variable, value});
         }
       }


### PR DESCRIPTION
During deploy with a failing transaction, embark was crashing due to the variable `line` being passed in as undefined.

Add better error handling to catch this error and prevent embark from crashing.