### PR TITLE
feat(@embark/proxy): Add dev tx to proxy when request fails to get a response

### DIFF
--- a/packages/embark/src/lib/modules/blockchain_listener/index.js
+++ b/packages/embark/src/lib/modules/blockchain_listener/index.js
@@ -1,5 +1,6 @@
-const ProcessLogsApi = require('../../modules/process_logs_api');
+const async = require('async');
 const DevTxs = require('./dev_txs');
+const ProcessLogsApi = require('../../modules/process_logs_api');
 
 const PROCESS_NAME = 'blockchain';
 
@@ -25,6 +26,23 @@ class BlockchainListener {
     this.ipc = ipc;
     this.isDev = this.embark.config.env === "development";
     this.devTxs = null;
+    this.fs = this.embark.fs;
+    this.proxyLogFile = this.fs.dappPath(".embark", "proxyLogs.json");
+
+    this.writeProxyLogFile = async.cargo((tasks, callback) => {
+      const data = this._readProxyLogs();
+
+      tasks.forEach(task => {
+        data[new Date().getTime()] = task;
+      });
+
+      this.fs.writeJson(this.proxyLogFile, data, err => {
+        if (err) {
+          console.error(err);
+        }
+        callback();
+      });
+    });
 
     this.ipc.server.once('connect', () => {
       this.processLogsApi = new ProcessLogsApi({embark: this.embark, processName: PROCESS_NAME, silent: true});
@@ -39,6 +57,7 @@ class BlockchainListener {
       });
 
       this._registerConsoleCommands();
+      this._listenToIpcCommands();
     }
   }
 
@@ -52,6 +71,20 @@ class BlockchainListener {
     this.ipc.on('blockchain:log', ({logLevel, message}) => {
       this.processLogsApi.logHandler.handleLog({logLevel, message});
     });
+  }
+
+  _listenToIpcCommands() {
+    this.ipc.on('blockchain:proxy:log', (log) => {
+      this.logger.trace(log);
+    });
+    this.ipc.on('blockchain:proxy:logtofile', (log) => {
+      this._saveProxyLog(log);
+    });
+
+    this.ipc.on('blockchain:devtxs:sendtx', () => {
+      this._sendTx(() => {});
+    });
+
   }
 
   _registerConsoleCommands() {
@@ -113,6 +146,19 @@ class BlockchainListener {
       return this.devTxs.sendTx(cb);
     }
     this.events.once('blockchain:devtxs:ready', () => { this.devTxs.sendTx(cb); });
+  }
+
+  _saveProxyLog(log) {
+    this.writeProxyLogFile.push(log);
+  }
+
+  _readProxyLogs() {
+    this.fs.ensureFileSync(this.proxyLogFile);
+    try {
+      return JSON.parse(this.fs.readFileSync(this.proxyLogFile));
+    } catch (_error) {
+      return {};
+    }
   }
 }
 

--- a/packages/embark/src/test/proxy.js
+++ b/packages/embark/src/test/proxy.js
@@ -28,14 +28,14 @@ describe('embark.Proxy', function () {
       const to = "to";
       const data = "data";
 
-      proxy.trackRequest({
+      proxy.trackRequest({ws: true, data: {
         id: 1,
         method: constants.blockchain.transactionMethods.eth_sendTransaction,
         params: [{
           to: to,
           data: data
         }]
-      });
+      }});
 
       expect(proxy.commList[1]).to.deep.equal({
         type: 'contract-log',
@@ -49,11 +49,11 @@ describe('embark.Proxy', function () {
       const to = "0x2e6242a07ea1c4e79ecc5c69a2dccae19878a280";
       const data = "0x60fe47b1000000000000000000000000000000000000000000000000000000000000115c";
 
-      proxy.trackRequest({
+      proxy.trackRequest({ws: true, data: {
         id: 1,
         method: constants.blockchain.transactionMethods.eth_sendRawTransaction,
         params: ["0xf8852701826857942e6242a07ea1c4e79ecc5c69a2dccae19878a28080a460fe47b1000000000000000000000000000000000000000000000000000000000000115c820a96a04d6e3cbb86d80a75cd51da02bf8f0cc9893d64ca7956ce21b350cc143aa8a023a05878a850e4e7810d08093add07df405298280fdd901ecbabb74e73422cb5e0b0"]
-      });
+      }});
 
       expect(proxy.commList[1]).to.deep.equal({
         type: 'contract-log',
@@ -67,11 +67,11 @@ describe('embark.Proxy', function () {
   describe('#trackResponse', function () {
     describe('when the response is a transaction', function () {
       before(function () {
-        proxy.trackRequest({
+        proxy.trackRequest({ws: true, data: {
           id: 1,
           method: constants.blockchain.transactionMethods.eth_sendTransaction,
           params: [{to: "to", data: "data" }]
-        });
+        }});
       });
 
       it('should populate the transaction when it is a known id', function (done) {
@@ -98,14 +98,14 @@ describe('embark.Proxy', function () {
 
     describe('when the response is a receipt', function () {
       it('should make an ipc call', function (done) {
-        proxy.trackRequest({
+        proxy.trackRequest({ws: true, data: {
           id: 3,
           method: constants.blockchain.transactionMethods.eth_sendTransaction,
           params: [{
             to: "to",
             data: "data"
           }]
-        });
+        }});
 
         proxy.trackResponse({
           id: 3,
@@ -115,14 +115,14 @@ describe('embark.Proxy', function () {
           }
         });
 
-        proxy.trackRequest({
+        proxy.trackRequest({ws: true, data: {
           id: 4,
           method: constants.blockchain.transactionMethods.eth_getTransactionReceipt,
           params: [{
             to: "to",
             data: "data"
           }]
-        });
+        }});
 
         expect(proxy.receipts[4]).to.be.equal(3);
 


### PR DESCRIPTION
Create a dev tx (a 0-value tx that is sent from the `--dev` account to itself) when a request goes through the proxy, but does not get a response after 5 seconds.

Log requests to the console (when log level is trace - enabled with the embark option `--loglevel trace`) that have not received a response and for which a dev tx has been sent.

Add logging to a `proxyLogs.json` log file as well, so that this information can be gleaned later for debugging purposes.

This particular PR Is meant to workaround an issue with running geth with the `--dev` option, as some transactions appear to get stuck, which then builds up further txs in a queue. Only when another tx is sent is the queue then purged as expected.

The remaining issue is that even though a dev tx is sent to relieve the queued txs, the original offending tx still never receives a response from the node. This was the motivation behind creating a proxy log, so that a dev can inspect the txs that are essentially dropped.

**NOTE:** the base branch of this branch is `refactor/devfunds`. Please merge that branch first.