### PR TITLE
fix(@embark/pipeline): Support embarkjs-whisper with external pipeline

### DIFF
--- a/packages/embark/package.json
+++ b/packages/embark/package.json
@@ -98,7 +98,7 @@
     "embarkjs": "^4.0.0",
     "embarkjs-ipfs": "^4.0.0",
     "embarkjs-swarm": "^4.0.0",
-    "embarkjs-whisper": "4.0.0",
+    "embarkjs-whisper": "^4.0.0",
     "eth-ens-namehash": "2.0.8",
     "ethereumjs-tx": "1.3.7",
     "ethereumjs-util": "6.0.0",

--- a/packages/embark/package.json
+++ b/packages/embark/package.json
@@ -98,6 +98,7 @@
     "embarkjs": "^4.0.0",
     "embarkjs-ipfs": "^4.0.0",
     "embarkjs-swarm": "^4.0.0",
+    "embarkjs-whisper": "4.0.0",
     "eth-ens-namehash": "2.0.8",
     "ethereumjs-tx": "1.3.7",
     "ethereumjs-util": "6.0.0",


### PR DESCRIPTION
Support embarkjs-whisper with external pipeline.

`embarkjs-whisper` is required by code that is through the VM, and therefore the `embark` package needs to be able to resolve `embarkjs-whisper`.