### PR TITLE
cherry-pick: chore(release): 4.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [4.0.1](https://github.com/embark-framework/embark/compare/v4.0.0...v4.0.1) (2019-03-26)
+
+
+### Bug Fixes
+
+* **@embark/utils:** Fix proxy crash with unknown function ([d03481e](https://github.com/embark-framework/embark/commit/d03481e))
+
+
+
+
+
 # [4.0.0](https://github.com/embark-framework/embark/compare/v4.0.0-beta.2...v4.0.0) (2019-03-18)
 
 

--- a/dapps/templates/boilerplate/CHANGELOG.md
+++ b/dapps/templates/boilerplate/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [4.0.1](https://github.com/embark-framework/embark/compare/v4.0.0...v4.0.1) (2019-03-26)
+
+**Note:** Version bump only for package embark-dapp-template-boilerplate
+
+
+
+
+
 # [4.0.0](https://github.com/embark-framework/embark/compare/v4.0.0-beta.2...v4.0.0) (2019-03-18)
 
 **Note:** Version bump only for package embark-dapp-template-boilerplate

--- a/dapps/templates/boilerplate/package.json
+++ b/dapps/templates/boilerplate/package.json
@@ -1,6 +1,6 @@
 {
   "name": "embark-dapp-template-boilerplate",
-  "version": "4.0.0",
+  "version": "4.0.1",
   "description": "Basic DApp template for Embark",
   "homepage": "https://github.com/embark-framework/embark/tree/master/dapps/templates/boilerplate#readme",
   "bugs": "https://github.com/embark-framework/embark/issues",
@@ -33,7 +33,7 @@
     "url": "https://github.com/embark-framework/embark.git"
   },
   "devDependencies": {
-    "embark": "^4.0.0",
+    "embark": "^4.0.1",
     "embark-reset": "^4.0.0",
     "embarkjs-connector-web3": "^4.0.0",
     "npm-run-all": "4.1.5",

--- a/dapps/templates/demo/CHANGELOG.md
+++ b/dapps/templates/demo/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [4.0.1](https://github.com/embark-framework/embark/compare/v4.0.0...v4.0.1) (2019-03-26)
+
+**Note:** Version bump only for package embark-dapp-template-demo
+
+
+
+
+
 # [4.0.0](https://github.com/embark-framework/embark/compare/v4.0.0-beta.2...v4.0.0) (2019-03-18)
 
 **Note:** Version bump only for package embark-dapp-template-demo

--- a/dapps/templates/demo/package.json
+++ b/dapps/templates/demo/package.json
@@ -1,6 +1,6 @@
 {
   "name": "embark-dapp-template-demo",
-  "version": "4.0.0",
+  "version": "4.0.1",
   "description": "Demo DApp for Embark",
   "homepage": "https://github.com/embark-framework/embark/tree/master/dapps/templates/demo#readme",
   "bugs": "https://github.com/embark-framework/embark/issues",
@@ -33,7 +33,7 @@
     "url": "https://github.com/embark-framework/embark.git"
   },
   "devDependencies": {
-    "embark": "^4.0.0",
+    "embark": "^4.0.1",
     "embark-reset": "^4.0.0",
     "embarkjs-connector-web3": "^4.0.0",
     "npm-run-all": "4.1.5",

--- a/dapps/templates/simple/CHANGELOG.md
+++ b/dapps/templates/simple/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [4.0.1](https://github.com/embark-framework/embark/compare/v4.0.0...v4.0.1) (2019-03-26)
+
+**Note:** Version bump only for package embark-dapp-template-simple
+
+
+
+
+
 # [4.0.0](https://github.com/embark-framework/embark/compare/v4.0.0-beta.2...v4.0.0) (2019-03-18)
 
 **Note:** Version bump only for package embark-dapp-template-simple

--- a/dapps/templates/simple/package.json
+++ b/dapps/templates/simple/package.json
@@ -1,6 +1,6 @@
 {
   "name": "embark-dapp-template-simple",
-  "version": "4.0.0",
+  "version": "4.0.1",
   "description": "Contracts-only DApp template for Embark",
   "homepage": "https://github.com/embark-framework/embark/tree/master/dapps/templates/simple#readme",
   "bugs": "https://github.com/embark-framework/embark/issues",
@@ -29,7 +29,7 @@
     "url": "https://github.com/embark-framework/embark.git"
   },
   "devDependencies": {
-    "embark": "^4.0.0",
+    "embark": "^4.0.1",
     "embark-reset": "^4.0.0",
     "embarkjs-connector-web3": "^4.0.0",
     "npm-run-all": "4.1.5",

--- a/dapps/tests/app/CHANGELOG.md
+++ b/dapps/tests/app/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [4.0.1](https://github.com/embark-framework/embark/compare/v4.0.0...v4.0.1) (2019-03-26)
+
+**Note:** Version bump only for package embark-dapp-test-app
+
+
+
+
+
 # [4.0.0](https://github.com/embark-framework/embark/compare/v4.0.0-beta.2...v4.0.0) (2019-03-18)
 
 **Note:** Version bump only for package embark-dapp-test-app

--- a/dapps/tests/app/package.json
+++ b/dapps/tests/app/package.json
@@ -3,7 +3,7 @@
   "devDependencies": {
     "@babel/code-frame": "7.0.0",
     "bootstrap": "3.4.0",
-    "embark": "^4.0.0",
+    "embark": "^4.0.1",
     "embark-dapp-test-service": "^4.0.0",
     "embark-reset": "^4.0.0",
     "embarkjs-connector-web3": "^4.0.0",
@@ -24,5 +24,5 @@
     "reset": "npx embark-reset",
     "test": "npx embark test"
   },
-  "version": "4.0.0"
+  "version": "4.0.1"
 }

--- a/dapps/tests/contracts/CHANGELOG.md
+++ b/dapps/tests/contracts/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [4.0.1](https://github.com/embark-framework/embark/compare/v4.0.0...v4.0.1) (2019-03-26)
+
+**Note:** Version bump only for package embark-dapp-test-contracts
+
+
+
+
+
 # [4.0.0](https://github.com/embark-framework/embark/compare/v4.0.0-beta.2...v4.0.0) (2019-03-18)
 
 **Note:** Version bump only for package embark-dapp-test-contracts

--- a/dapps/tests/contracts/package.json
+++ b/dapps/tests/contracts/package.json
@@ -1,7 +1,7 @@
 {
   "description": "Test DApp for integration testing purposes",
   "devDependencies": {
-    "embark": "^4.0.0",
+    "embark": "^4.0.1",
     "embark-reset": "^4.0.0",
     "embarkjs-connector-web3": "^4.0.0"
   },
@@ -14,5 +14,5 @@
     "reset": "npx embark-reset",
     "test": "npx embark test"
   },
-  "version": "4.0.0"
+  "version": "4.0.1"
 }

--- a/lerna.json
+++ b/lerna.json
@@ -16,5 +16,5 @@
   },
   "npmClient": "yarn",
   "useWorkspaces": true,
-  "version": "4.0.0"
+  "version": "4.0.1"
 }

--- a/packages/embark-api-client/package.json
+++ b/packages/embark-api-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "embark-api-client",
-  "version": "4.0.0",
+  "version": "4.0.1",
   "author": "Iuri Matias <iuri.matias@gmail.com>",
   "contributors": [],
   "description": "Embark api module",

--- a/packages/embark-profiler/package.json
+++ b/packages/embark-profiler/package.json
@@ -1,6 +1,6 @@
 {
   "name": "embark-profiler",
-  "version": "4.0.0",
+  "version": "4.0.1",
   "author": "Iuri Matias <iuri.matias@gmail.com>",
   "contributors": [],
   "description": "Smart contract profiler for Embark DApps",

--- a/packages/embark-specialconfigs/package.json
+++ b/packages/embark-specialconfigs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "embark-specialconfigs",
-  "version": "4.0.0",
+  "version": "4.0.1",
   "author": "Iuri Matias <iuri.matias@gmail.com>",
   "contributors": [],
   "description": "Adds various configs to embark's contract.js config file",

--- a/packages/embark-ui/CHANGELOG.md
+++ b/packages/embark-ui/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [4.0.1](https://github.com/embark-framework/embark/compare/v4.0.0...v4.0.x) (2019-03-26)
+
+**Note:** Version bump only for package embark-ui
+
+
+
+
+
 # [4.0.0](https://github.com/embark-framework/embark/compare/v4.0.0-beta.2...v4.0.0) (2019-03-18)
 
 

--- a/packages/embark-ui/package.json
+++ b/packages/embark-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "embark-ui",
-  "version": "4.0.0",
+  "version": "4.0.1",
   "author": "Iuri Matias <iuri.matias@gmail.com>",
   "contributors": [],
   "description": "Web frontend for interactive DApp development with Embark",

--- a/packages/embark-utils/package.json
+++ b/packages/embark-utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "embark-utils",
-  "version": "4.0.0",
+  "version": "4.0.1",
   "author": "Iuri Matias <iuri.matias@gmail.com>",
   "contributors": [],
   "description": "Utils used by Embark",

--- a/packages/embark-webserver/package.json
+++ b/packages/embark-webserver/package.json
@@ -1,6 +1,6 @@
 {
   "name": "embark-webserver",
-  "version": "4.0.0",
+  "version": "4.0.1",
   "author": "Iuri Matias <iuri.matias@gmail.com>",
   "contributors": [],
   "description": "Webserver for Embark",

--- a/packages/embark-whisper/package.json
+++ b/packages/embark-whisper/package.json
@@ -1,6 +1,6 @@
 {
   "name": "embark-whisper",
-  "version": "4.0.0",
+  "version": "4.0.1",
   "author": "Iuri Matias <iuri.matias@gmail.com>",
   "contributors": [],
   "description": "Module to add Whisper support to Embark",

--- a/packages/embark/CHANGELOG.md
+++ b/packages/embark/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [4.0.1](https://github.com/embark-framework/embark/compare/v4.0.0...v4.0.1) (2019-03-26)
+
+
+### Bug Fixes
+
+* **@embark/utils:** Fix proxy crash with unknown function ([d03481e](https://github.com/embark-framework/embark/commit/d03481e))
+
+
+
+
+
 # [4.0.0](https://github.com/embark-framework/embark/compare/v4.0.0-beta.2...v4.0.0) (2019-03-18)
 
 **Note:** Version bump only for package embark

--- a/packages/embark/package.json
+++ b/packages/embark/package.json
@@ -1,6 +1,6 @@
 {
   "name": "embark",
-  "version": "4.0.0",
+  "version": "4.0.1",
   "author": "Iuri Matias <iuri.matias@gmail.com>",
   "contributors": [],
   "description": "Embark is a framework that allows you to easily develop and deploy DApps",
@@ -89,7 +89,7 @@
     "embark-compiler": "^4.0.0",
     "embark-whisper": "^4.0.0",
     "embark-reset": "^4.0.0",
-    "embark-ui": "^4.0.0",
+    "embark-ui": "^4.0.1",
     "embark-vyper": "^4.0.0",
     "embark-profiler": "^4.0.0",
     "embark-specialconfigs": "^4.0.0",

--- a/packages/embarkjs-ipfs/package.json
+++ b/packages/embarkjs-ipfs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "embarkjs-ipfs",
-  "version": "4.0.0",
+  "version": "4.0.1",
   "author": "Iuri Matias <iuri.matias@gmail.com>",
   "contributors": [],
   "description": "Ipfs plugin for embarkjs",

--- a/packages/embarkjs-swarm/package.json
+++ b/packages/embarkjs-swarm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "embarkjs-swarm",
-  "version": "4.0.0",
+  "version": "4.0.1",
   "author": "Iuri Matias <iuri.matias@gmail.com>",
   "contributors": [],
   "description": "Swarm plugin for embarkjs",

--- a/packages/embarkjs-whisper/package.json
+++ b/packages/embarkjs-whisper/package.json
@@ -1,6 +1,6 @@
 {
   "name": "embarkjs-whisper",
-  "version": "4.0.0",
+  "version": "4.0.1",
   "author": "Iuri Matias <iuri.matias@gmail.com>",
   "contributors": [],
   "description": "Whisper plugin for embarkjs",


### PR DESCRIPTION
This commit has been originally cherry-picked from d0d89fc5ae4663c27e4b6b5c9cfcf1b47e645d6e and
slightly modified to update all packages, as meanwhile, new packages have been added to `master`.

The reason this commit is cherry-picked from `4.0.x` branch is because
it wasn't created from `master`.

Purpose is mainly to update `CHANGELOG` and get the package versions in sync again.