### PR TITLE
feat(@embark/embark-reset): allow users to specify files to be removed in reset

### DIFF
--- a/packages/embark/src/cmd/cmd.js
+++ b/packages/embark/src/cmd/cmd.js
@@ -354,7 +354,9 @@ class Cmd {
         embark.initConfig('development', {
           embarkConfig: 'embark.json', interceptLogs: false
         });
-        embark.reset();
+        embark.reset({
+          embarkConfig: 'embark.json'
+        });
       });
   }
 


### PR DESCRIPTION
**Docs for this feature are ready for release here: https://github.com/embark-framework/embark-site/pull/171**

This commit introduces a feature where users can specify which files should be removed
as part of Embark's `reset` command.

This is done by specifying the `options.reset` section in a project's `embark.json`.
The possible options are `defaults: bool` and `files: Array<String>`:

```
// embark.json
{
  ...
  "options": {
    "reset": {
      "defaults": true,
      "files": ["some.file", "some/other.file"]
    }
  }
}
```

`defaults` tells Embark whether or not it should remove the default files that are
defined by the `reset` command. Setting it to `false` will prevent Embark from
removing any of these (mostly files located inside `.embark`).

This gives users fine control as they now can re-add subsets or those file paths
in the `files` property.

If `options.reset` doesn't exist Embark will do the default behaviour, which is
is simply resetting/removing the files it has always removed.