### PR TITLE
Refactor API server to use a redirect page instead of proxy, and fix a bug in cockpit

### DIFF
--- a/packages/embark-ui/src/services/api.js
+++ b/packages/embark-ui/src/services/api.js
@@ -179,7 +179,7 @@ export function listenToChannel(credentials, channel) {
 }
 
 export function webSocketProcess(credentials, processName) {
-  return embarkAPI.webSocketProcess(credentials, `/process-logs/${processName}`);
+  return embarkAPI.webSocketProcess(credentials, processName);
 }
 
 export function webSocketServices(credentials) {
@@ -205,4 +205,3 @@ export function webSocketBlockHeader(credentials) {
 export function websocketGasOracle(credentials) {
   return embarkAPI.websocketGasOracle(credentials, `/blockchain/gas/oracle`);
 }
-

--- a/packages/embark/package.json
+++ b/packages/embark/package.json
@@ -191,7 +191,6 @@
     "@types/body-parser": "1.17.0",
     "@types/cors": "2.8.4",
     "@types/express": "4.16.0",
-    "@types/express-http-proxy": "1.5.1",
     "@types/express-ws": "3.0.0",
     "@types/find-up": "2.1.0",
     "@types/globule": "1.1.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2723,14 +2723,6 @@
   resolved "https://registry.yarnpkg.com/@types/events/-/events-1.2.0.tgz#81a6731ce4df43619e5c8c945383b3e62a89ea86"
   integrity sha512-KEIlhXnIutzKwRbQkGWb/I4HFqBuUykAdHgDED6xqwXJfONCjF5VoE0cXEiurh3XauygxzeDzgtXUqvLkxFzzA==
 
-"@types/express-http-proxy@1.5.1":
-  version "1.5.1"
-  resolved "https://registry.yarnpkg.com/@types/express-http-proxy/-/express-http-proxy-1.5.1.tgz#0184017b1cfc8ab2a4954d35f90c9b4cc3d7ffcc"
-  integrity sha512-9SOGqwVzbudT5nzF4TjKOu0cWE0HRaTVVivwxUxYMN/7mas6Wt/W5pz53dZIs7Y0fZBjAI3RTDDr+dXtXrv+hA==
-  dependencies:
-    "@types/express" "*"
-    "@types/express-serve-static-core" "*"
-
 "@types/express-serve-static-core@*":
   version "4.16.0"
   resolved "https://registry.yarnpkg.com/@types/express-serve-static-core/-/express-serve-static-core-4.16.0.tgz#fdfe777594ddc1fe8eb8eccce52e261b496e43e7"


### PR DESCRIPTION
# refactor(@embark/api): in dev use cockpit redirect instead of proxy

Embark API server's development proxy from port 55555 to 3000 was attempting to inappropriately forward an `/embark-api/` endpoint for the blockchain process logs to Create React App's development server. Why it was only happening for the one endpoint is not known but probably has to do with timing around registration of the API server's express routes.

The problem can be fixed with a one-line `filter:` function in the options for `express-http-proxy`. However, it was realized that to fix an unrelated problem, whereby the proxy doesn't forward websockets to CRA such that hot reload doesn't work when accessing `embark-ui` in development on port 55555, a switch to `http-proxy-middleware` would be required. That was quickly attempted (easy switch) but there are outstanding [difficulties][bug] with `webpack-dev-server` and `node-http-proxy` that cause CRA to crash.

Switch strategies and refactor the API module to serve a page on port 55555 (in development only) that alerts the developer `embark-ui` should be accessed on port 3000. The page redirects (client-side) after 10 seconds, with URL query params and/or hash preserved. A future version could instead do client-side polling of port 3000 with `fetch` and then redirect only once it's available. The reason for not redirecting immediately is that the intermediate page makes it more obvious what needs to be done, e.g. CRA dev server may need to be started with `yarn start`.

[bug]: https://github.com/webpack/webpack-dev-server/issues/1642

# fix(@cockpit/services): send only process names to embark-api-client

`webSocketProcess` function in `embark-api-client` expects only a process name, but cockpit was calling it with name-strings prepended with `/process-logs/` resulting in bad URLs. Revise cockpit's `services/api` module to call `webSocketProcess` with process names only.