### PR TITLE
fix(@embark/deployment): ensure error messages emitted are logged

### DIFF
--- a/packages/embark/src/lib/modules/deployment/contract_deployer.js
+++ b/packages/embark/src/lib/modules/deployment/contract_deployer.js
@@ -353,8 +353,11 @@ class ContractDeployer {
           self.events.emit("deploy:contract:deployed", contract);
 
           self.registerContract(contract, () => {
-            self.plugins.runActionsForEvent('deploy:contract:deployed', {contract: contract}, () => {
-              return next(null, receipt);
+            self.plugins.runActionsForEvent('deploy:contract:deployed', {contract: contract}, (err) => {
+              if (err) {
+                return next(err);
+              }
+              next(null, receipt);
             });
           });
         }, hash => {

--- a/packages/embark/src/lib/modules/deployment/index.js
+++ b/packages/embark/src/lib/modules/deployment/index.js
@@ -61,7 +61,7 @@ class DeployManager {
               next();
             });
           },
-          function () {
+          function (next) {
             const contractDeploys = {};
             const errors = [];
             contracts.forEach(contract => {
@@ -97,17 +97,20 @@ class DeployManager {
                 _err = __("Error deploying contracts. Please fix errors to continue.");
                 self.logger.error(_err);
                 self.events.emit("outputError", __("Error deploying contracts, please check console"));
-                return done(_err);
+                return next(_err);
               }
               if (contracts.length === 0) {
                 self.logger.info(__("no contracts found"));
-                return done();
+                return next();
               }
               self.logger.info(__("finished deploying contracts"));
-              done(err);
+              next(err);
             });
           }
-        ]);
+        ], (err) => {
+          self.logger.error(err);
+          done(err);
+        });
       });
     });
   }


### PR DESCRIPTION
Errors emitted as part of the `deployAll()` routine got swallowed by
Embark, leaving users in the unknown when the deployment process
"froze".

This commit ensures errors emitted are now logged, making it obvious
when something went wrong.