### PR TITLE
fix(embark/compiler): fix errors and bugs with solc 0.4.18

### DIFF
--- a/packages/embark/src/lib/modules/solidity/solcP.js
+++ b/packages/embark/src/lib/modules/solidity/solcP.js
@@ -57,7 +57,7 @@ class SolcProcess extends ProcessWrapper {
       let output = func(JSON.stringify(jsonObj), this.findImports.bind(this));
       cb(null, output);
     } catch (err) {
-      cb(err.message);
+      cb(err.message || err);
     }
   }
 


### PR DESCRIPTION
solc 0.4.18 does stuff really weird. Instead of outputting normally like this: 
```
{
  "C:/dev/embark_demo/.embark/contracts/zlib2.sol": {
    "ZAMyLib2": [
      {
        "length": 20,
        "start": 237
      }
    ]
  }
}
```
It looks like this:
```
{
  "C": {
    "/dev/embark_demo/.embark/contracts/zlib2.sol:ZAMyLib2": [
      {
        "length": 20,
        "start": 233
      }
    ]
  }
}
```
Those changes make sure that we structure the output to work correctly