### PR TITLE
fix(embark/simulator): fix account object empty when no mnemonic

### DIFF
--- a/packages/embark/src/lib/modules/blockchain_process/simulator.js
+++ b/packages/embark/src/lib/modules/blockchain_process/simulator.js
@@ -29,7 +29,8 @@ class Simulator {
     cmds.push("-l " + (options.gasLimit || this.blockchainConfig.targetGasLimit || 8000000));
 
     // adding mnemonic only if it is defined in the blockchainConfig or options
-    const mnemonicAccount = this.blockchainConfig.accounts ? this.blockchainConfig.accounts.find(acc => acc.mnemonic) : {};
+    let mnemonicAccount = this.blockchainConfig.accounts ? this.blockchainConfig.accounts.find(acc => acc.mnemonic) : {};
+    mnemonicAccount = mnemonicAccount || {};
     const simulatorMnemonic = mnemonicAccount.mnemonic || options.simulatorMnemonic;
 
     if (simulatorMnemonic) {


### PR DESCRIPTION
Small bug where if there was blockchain accounts, but none of them was a mnemonic, it would return an empty object that would throw on the next line