### PR TITLE
fix(@embark/deployment): only log error when error exists

### DIFF
--- a/packages/embark/src/lib/modules/deployment/index.js
+++ b/packages/embark/src/lib/modules/deployment/index.js
@@ -108,7 +108,9 @@ class DeployManager {
             });
           }
         ], (err) => {
-          self.logger.error(err);
+          if (err) {
+            self.logger.error(err);
+          }
           done(err);
         });
       });


### PR DESCRIPTION
This was a regression introduced in https://github.com/embark-framework/embark/commit/72fc80df53785f802a121f209c3088ad7817e884