### PR TITLE
fix(embark/generator): add back environment to EmbarkJS

### DIFF
--- a/packages/embark/src/lib/modules/code_generator/index.js
+++ b/packages/embark/src/lib/modules/code_generator/index.js
@@ -338,6 +338,7 @@ class CodeGenerator {
             return next(err);
           }
           embarkjsCode += `\nconst EmbarkJS = require("${symlinkDest}").default || require("${symlinkDest}");`;
+          embarkjsCode += `\nEmbarkJS.environment = '${self.env}';`;
           embarkjsCode += "\nglobal.EmbarkJS = EmbarkJS;";
           next();
         });


### PR DESCRIPTION
I had removed EmbarkJS.environemnt by accident when refactoring