### PR TITLE
feat(@embark/blockchain): Restart Ethereum via command

### DIFF
--- a/packages/embark/src/lib/modules/blockchain_process/blockchain.js
+++ b/packages/embark/src/lib/modules/blockchain_process/blockchain.js
@@ -142,6 +142,10 @@ Blockchain.prototype.initStandaloneProcess = function () {
           if (this.ipc.connected) {
             logQueue.forEach(message => { this.ipc.request('blockchain:log', message); });
             logQueue = [];
+            this.ipc.client.on('process:blockchain:stop', () => {
+              this.kill();
+              process.exit(0);
+            });
           }
         });
       }

--- a/packages/embark/src/lib/modules/blockchain_process/blockchainProcessLauncher.js
+++ b/packages/embark/src/lib/modules/blockchain_process/blockchainProcessLauncher.js
@@ -69,6 +69,14 @@ class BlockchainProcessLauncher {
     });
   }
 
+  stopBlockchainNode(cb) {
+    if(this.blockchainProcess) {
+      this.events.on(constants.blockchain.blockchainExit, cb);
+      this.blockchainProcess.exitCallback = () => {}; // don't show error message as the process was killed on purpose
+      this.blockchainProcess.send('exit');
+    }
+  }
+
 }
 
 module.exports = BlockchainProcessLauncher;

--- a/packages/embark/src/lib/modules/console/index.ts
+++ b/packages/embark/src/lib/modules/console/index.ts
@@ -107,7 +107,11 @@ class Console {
           // Avoid HTML injection in the Cockpit
           response = escapeHtml(response);
         }
-        return res.send({ result: response });
+        const jsonResponse = {result: response};
+        if (res.headersSent) {
+          return res.end(jsonResponse);
+        }
+        return res.send(jsonResponse);
       });
     });
   }


### PR DESCRIPTION
Add support for `service blockchain on/off` in the console.

Add `service <process> on/off` command for each process started by Embark, ie `service blockchain on/off` and `service whisper on/off`.

## Commands added
`service blockchain off` - Kills the blockchain process, stops the web3 provider, and shuts down the proxy (if used). In the case of `embark blockchain`, the entire process is exited.

`service blockchain on` - Starts the blockchain process *as a child process of the main embark process* then starts the web3 provider. This happens regardless of whether or not it was initially started with `embark blockchain` (see known issues).

## Known issues
1. If the blockchain process was started with `embark blockchain`, and then the blockchain process is killed with the `service blockchain off` command, when the blockchain process is restarted with `service blockchain on`, it will be restarted as a child process of the main embark process. It may be possible to allow for the blockchain process to be restarted in the same process it was originally started in, however this will take more development effort and can be handled in a different PR.
2. Parity has not been tested as it is currently not working in the master branch.
3. This PR adds a generic registration of commands for each process, ie `service whisper on/off`, however the only supported command is the `service blockchain on/off` command. Further support for other commands can be handled in separate PRs.