### PR TITLE
Move process-logs-api to package and more

### DIFF
--- a/packages/embark-process-logs-api/.npmrc
+++ b/packages/embark-process-logs-api/.npmrc
@@ -1,0 +1,4 @@
+engine-strict = true
+package-lock = false
+save-exact = true
+scripts-prepend-node-path = true

--- a/packages/embark-process-logs-api/README.md
+++ b/packages/embark-process-logs-api/README.md
@@ -1,0 +1,6 @@
+# `embark-process-logs-api`
+
+Registers APIs for Embark process logs
+
+Visit [embark.status.im](https://embark.status.im/) to get started with
+[Embark](https://github.com/embark-framework/embark).

--- a/packages/embark-process-logs-api/package.json
+++ b/packages/embark-process-logs-api/package.json
@@ -1,0 +1,67 @@
+{
+  "name": "embark-process-logs-api",
+  "version": "4.1.0-beta.0",
+  "author": "Iuri Matias <iuri.matias@gmail.com>",
+  "contributors": [],
+  "description": "Registers APIs for Embark process logs",
+  "homepage": "https://github.com/embark-framework/embark/tree/master/packages/embark-process-logs-api#readme",
+  "bugs": "https://github.com/embark-framework/embark/issues",
+  "keywords": [
+    "blockchain",
+    "dapps",
+    "ethereum",
+    "ipfs",
+    "serverless",
+    "solc",
+    "solidity"
+  ],
+  "files": [
+    "dist"
+  ],
+  "license": "MIT",
+  "repository": {
+    "directory": "packages/embark-process-logs-api",
+    "type": "git",
+    "url": "https://github.com/embark-framework/embark.git"
+  },
+  "main": "./dist/index.js",
+  "scripts": {
+    "build": "cross-env BABEL_ENV=node babel src --extensions \".js,.ts\" --out-dir dist --root-mode upward --source-maps",
+    "ci": "npm run qa",
+    "clean": "npm run reset",
+    "lint": "npm-run-all lint:*",
+    "lint:js": "eslint src/",
+    "// lint:ts": "tslint -c tslint.json \"src/**/*.ts\"",
+    "package": "npm pack",
+    "// qa": "npm-run-all lint typecheck build package",
+    "qa": "npm-run-all lint build package",
+    "reset": "npx rimraf dist embark-*.tgz package",
+    "start": "npm run watch",
+    "// typecheck": "tsc",
+    "watch": "run-p watch:*",
+    "watch:build": "npm run build -- --verbose --watch",
+    "// watch:typecheck": "npm run typecheck -- --preserveWatchOutput --watch"
+  },
+  "eslintConfig": {
+    "extends": "../../.eslintrc.json"
+  },
+  "dependencies": {
+    "@babel/runtime-corejs2": "7.3.1",
+    "embark-utils": "^4.1.0-beta.0"
+  },
+  "devDependencies": {
+    "@babel/cli": "7.2.3",
+    "@babel/core": "7.2.2",
+    "cross-env": "5.2.0",
+    "eslint": "5.7.0",
+    "npm-run-all": "4.1.5",
+    "rimraf": "2.6.3",
+    "tslint": "5.11.0",
+    "typescript": "3.3.1"
+  },
+  "engines": {
+    "node": ">=8.12.0",
+    "npm": ">=6.4.1",
+    "yarn": ">=1.12.3"
+  }
+}

--- a/packages/embark-process-logs-api/src/index.js
+++ b/packages/embark-process-logs-api/src/index.js
@@ -1,0 +1,44 @@
+const {escapeHtml, LogHandler} = require('embark-utils');
+
+class ProcessLogsApi {
+  constructor({embark, processName, silent}) {
+    this.embark = embark;
+    this.processName = processName;
+    this.logger = this.embark.logger;
+    this.events = this.embark.events;
+    this.logHandler = new LogHandler({events: this.events, logger: this.logger, processName: this.processName, silent});
+
+    this.registerAPICalls();
+  }
+
+  registerAPICalls() {
+    const apiRoute = '/embark-api/process-logs/' + this.processName;
+    this.embark.registerAPICall(
+      'ws',
+      apiRoute,
+      (ws, _req) => {
+        this.events.on('process-log-' + this.processName, function (log) {
+          log.msg = escapeHtml(log.msg);
+          log.msg_clear = escapeHtml(log.msg_clear);
+
+          ws.send(JSON.stringify(log), () => {});
+        });
+      }
+    );
+    this.embark.registerAPICall(
+      'get',
+      '/embark-api/process-logs/' + this.processName,
+      (req, res) => {
+        let limit = parseInt(req.query.limit, 10);
+        if (!Number.isInteger(limit)) limit = 0;
+        const result = this.logHandler.logs
+          .slice(limit * -1)
+          .map(msg => escapeHtml(msg));
+
+        res.send(JSON.stringify(result));
+      }
+    );
+  }
+}
+
+module.exports = ProcessLogsApi;

--- a/packages/embark-process-logs-api/tsconfig.json
+++ b/packages/embark-process-logs-api/tsconfig.json
@@ -1,0 +1,4 @@
+{
+  "extends": "../../tsconfig.json",
+  "include": ["src/**/*"]
+}

--- a/packages/embark-process-logs-api/tslint.json
+++ b/packages/embark-process-logs-api/tslint.json
@@ -1,0 +1,3 @@
+{
+  "extends": "../../tslint.json"
+}

--- a/packages/embark/package.json
+++ b/packages/embark/package.json
@@ -87,6 +87,7 @@
     "deep-equal": "1.0.1",
     "ejs": "2.6.1",
     "embark-compiler": "^4.0.0",
+    "embark-process-logs-api": "^4.1.0-beta.0",
     "embark-profiler": "^4.1.0-beta.0",
     "embark-reset": "^4.1.0-beta.0",
     "embark-specialconfigs": "^4.1.0-beta.0",

--- a/packages/embark/src/lib/core/processes/processLauncher.js
+++ b/packages/embark/src/lib/core/processes/processLauncher.js
@@ -1,7 +1,7 @@
 const child_process = require('child_process');
 const constants = require('../../constants');
 const path = require('path');
-const ProcessLogsApi = require('../../modules/process_logs_api');
+const ProcessLogsApi = require('embark-process-logs-api');
 
 let processCount = 1;
 class ProcessLauncher {

--- a/packages/embark/src/lib/modules/blockchain_listener/index.js
+++ b/packages/embark/src/lib/modules/blockchain_listener/index.js
@@ -1,6 +1,6 @@
 const async = require('async');
 const DevTxs = require('./dev_txs');
-const ProcessLogsApi = require('../../modules/process_logs_api');
+const ProcessLogsApi = require('embark-process-logs-api');
 const constants = require('../../constants.json');
 
 const PROCESS_NAME = 'blockchain';

--- a/packages/embark/src/lib/modules/embark_listener/index.js
+++ b/packages/embark/src/lib/modules/embark_listener/index.js
@@ -1,4 +1,4 @@
-const ProcessLogsApi = require('../process_logs_api');
+const ProcessLogsApi = require('embark-process-logs-api');
 
 const EMBARK_PROCESS_NAME = 'embark';
 
@@ -25,7 +25,7 @@ class EmbarkListener {
   /**
    * Listens to log events emitted by the Embark application and ensures
    * they are processed through the LogHandler.
-   * 
+   *
    * @return {void}
    */
   _listenToEmbarkLogs() {


### PR DESCRIPTION
- Move logHandler to embark-utils
- move escapeHtml and normalizeInput to embark-utils (in a new file called log-utils, more functions could go there, but those were the two I needed to move for now)
- Move process-logs-api to a package