### PR TITLE
refactor(@embark/embark-utils): replace recursiveMerge with object sp…

### DIFF
--- a/packages/embark-utils/package.json
+++ b/packages/embark-utils/package.json
@@ -47,7 +47,6 @@
   "dependencies": {
     "@babel/runtime-corejs2": "7.3.1",
     "follow-redirects": "1.5.7",
-    "merge": "1.2.1",
     "multihashes": "0.4.14",
     "web3": "1.0.0-beta.37"
   },

--- a/packages/embark-utils/src/index.js
+++ b/packages/embark-utils/src/index.js
@@ -38,11 +38,6 @@ function soliditySha3(arg) {
   return Web3.utils.soliditySha3(arg);
 }
 
-function recursiveMerge(target, source) {
-  const merge = require('merge');
-  return merge.recursive(target, source);
-}
-
 function sha512(arg) {
   if (typeof arg !== 'string') {
     throw new TypeError('argument must be a string');
@@ -67,7 +62,6 @@ const Utils = {
   hashTo32ByteHexString,
   isHex,
   soliditySha3,
-  recursiveMerge,
   sha512
 };
 

--- a/packages/embark/src/lib/core/config.js
+++ b/packages/embark/src/lib/core/config.js
@@ -5,7 +5,7 @@ const path = require('path');
 const deepEqual = require('deep-equal');
 const web3 = require('web3');
 const constants = require('../constants');
-import {canonicalHost, defaultHost, recursiveMerge} from 'embark-utils';
+import {canonicalHost, defaultHost} from 'embark-utils';
 const cloneDeep = require('lodash.clonedeep');
 import { replaceZeroAddressShorthand } from '../utils/addressUtils';
 import { unitRegex } from "../utils/regexConstants";
@@ -219,10 +219,10 @@ Config.prototype._mergeConfig = function(configFilePath, defaultConfig, env, ena
   } else {
     config = fs.readJSONSync(configFilePath + '.json');
   }
-  let configObject = recursiveMerge(defaultConfig, config);
+  let configObject = {...defaultConfig, ...config};
 
   if (env) {
-    return recursiveMerge(configObject['default'] || {}, configObject[env]);
+    return {...configObject['default'] || {}, ...configObject[env]};
   }
   return configObject;
 };
@@ -315,7 +315,7 @@ Config.prototype.loadContractsConfigFile = function() {
     "web3": "1.0.0-beta",
     "solc": "0.5.0"
   };
-  var versions = recursiveMerge(defaultVersions, this.embarkConfig.versions || {});
+  var versions = {...defaultVersions, ...this.embarkConfig.versions || {}};
 
   var configObject = {
     "default": {
@@ -337,7 +337,7 @@ Config.prototype.loadContractsConfigFile = function() {
 
   var contractsConfigs = this.plugins.getPluginsProperty('contractsConfig', 'contractsConfigs');
   contractsConfigs.forEach(function(pluginConfig) {
-    configObject = recursiveMerge(configObject, pluginConfig);
+    configObject = {...configObject, ...pluginConfig};
   });
 
   let configFilePath = this._getFileOrObject(this.configDir, 'contracts', 'contracts');
@@ -413,7 +413,7 @@ Config.prototype.loadExternalContractsFiles = function() {
 };
 
 Config.prototype.loadStorageConfigFile = function() {
-  var versions = recursiveMerge({"ipfs-api": "17.2.4"}, this.embarkConfig.versions || {});
+  var versions = {...{"ipfs-api": "17.2.4"}, ...this.embarkConfig.versions || {}};
 
   var configObject = {
     "default": {
@@ -505,7 +505,7 @@ Config.prototype.loadWebServerConfigFile = function() {
   }
   if (this.webServerConfig) {
     // cli flags to `embark run` should override configFile and defaults (configObject)
-    this.webServerConfig = recursiveMerge(webServerConfig, this.webServerConfig);
+    this.webServerConfig = {...webServerConfig, ...this.webServerConfig};
   } else {
     this.webServerConfig = webServerConfig;
   }
@@ -524,7 +524,7 @@ Config.prototype.loadEmbarkConfigFile = function() {
     "generationDir": "embarkArtifacts"
   };
 
-  this.embarkConfig = recursiveMerge(configObject, this.embarkConfig);
+  this.embarkConfig = {...configObject, ...this.embarkConfig};
 
   const contracts = this.embarkConfig.contracts;
   // determine contract 'root' directories
@@ -561,10 +561,10 @@ Config.prototype.loadPipelineConfigFile = function() {
 
   if (pipelineConfigPath && fs.existsSync(pipelineConfigPath)) {
     delete require.cache[pipelineConfigPath];
-    pipelineConfig = recursiveMerge(
-      recursiveMerge(true, pipelineConfig),
-      require(pipelineConfigPath)
-    );
+    pipelineConfig = {
+      ...pipelineConfig,
+      ...require(pipelineConfigPath)
+    };
   }
 
   this.pipelineConfig = pipelineConfig;

--- a/packages/embark/src/lib/modules/codeRunner/vm.ts
+++ b/packages/embark/src/lib/modules/codeRunner/vm.ts
@@ -2,8 +2,6 @@ import { each } from "async";
 import { Callback, Logger } from "embark";
 import { NodeVM, NodeVMOptions } from "vm2";
 
-import { recursiveMerge } from "embark-utils";
-
 const fs = require("./fs");
 const path = require("path");
 const { isEs6Module, compact } = require("../../utils/utils");
@@ -60,7 +58,7 @@ class VM {
    * @param {Logger} logger Logger.
    */
   constructor(options: NodeVMOptions, private logger: Logger) {
-    this._options = recursiveMerge(this._options, options);
+    this._options = {...this._options, ...options};
 
     this.setupNodeVm(() => { });
   }

--- a/packages/embark/src/lib/modules/ens/README.md
+++ b/packages/embark/src/lib/modules/ens/README.md
@@ -99,4 +99,3 @@ response:
   * ZERO_ADDRESS
   * hashTo32ByteHexString
   * joinPath
-  * recursiveMerge

--- a/packages/embark/src/lib/modules/ens/index.js
+++ b/packages/embark/src/lib/modules/ens/index.js
@@ -1,4 +1,4 @@
-import {joinPath, hashTo32ByteHexString, soliditySha3, recursiveMerge} from 'embark-utils';
+import {joinPath, hashTo32ByteHexString, soliditySha3} from 'embark-utils';
 const namehash = require('eth-ens-namehash');
 const async = require('async');
 const embarkJsUtils = require('embarkjs').Utils;
@@ -413,7 +413,7 @@ class ENS {
       function getNetworkId(next) {
         self.events.request('blockchain:networkId', (networkId) => {
           if (ENS_CONTRACTS_CONFIG[networkId]) {
-            self.ensConfig = recursiveMerge(self.ensConfig, ENS_CONTRACTS_CONFIG[networkId]);
+            self.ensConfig = {...self.ensConfig, ...ENS_CONTRACTS_CONFIG[networkId]};
           }
           next();
         });

--- a/yarn.lock
+++ b/yarn.lock
@@ -12894,7 +12894,7 @@ merge2@^1.2.3:
   resolved "https://registry.yarnpkg.com/merge2/-/merge2-1.2.3.tgz#7ee99dbd69bb6481689253f018488a1b902b0ed5"
   integrity sha512-gdUU1Fwj5ep4kplwcmftruWofEFt6lfpkkr3h860CXbAB9c3hGb55EOL2ali0Td5oebvW0E1+3Sr+Ur7XfKpRA==
 
-merge@1.2.1, merge@^1.2.0:
+merge@^1.2.0:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/merge/-/merge-1.2.1.tgz#38bebf80c3220a8a487b6fcfb3941bb11720c145"
   integrity sha512-VjFo4P5Whtj4vsLzsYBu5ayHhoHJ0UqNm7ibvShmbmoz7tGi0vXaoJbGdB+GmDMLUdg8DpQXEIeVDAe8MaABvQ==


### PR DESCRIPTION
…read operator

As we're relying on Babel transformations we don't need an npm package
to perform recursive object merges and can rather rely on language
features.