### PR TITLE
test: disable test script for packages without any tests

### DIFF
--- a/packages/embarkjs-ipfs/package.json
+++ b/packages/embarkjs-ipfs/package.json
@@ -46,7 +46,7 @@
     "qa": "npm-run-all build package",
     "reset": "npx rimraf build-test dist embarkjs-*.tgz package",
     "start": "npm run watch",
-    "test": "mocha \"build-test/**/*.js\" --exit --no-timeouts --require source-map-support/register",
+    "// test": "mocha \"build-test/**/*.js\" --exit --no-timeouts --require source-map-support/register",
     "watch": "run-p \"build:** -- --verbose --watch\""
   },
   "dependencies": {

--- a/packages/embarkjs-swarm/package.json
+++ b/packages/embarkjs-swarm/package.json
@@ -46,7 +46,7 @@
     "qa": "npm-run-all build package",
     "reset": "npx rimraf build-test dist embarkjs-*.tgz package",
     "start": "npm run watch",
-    "test": "mocha \"build-test/**/*.js\" --exit --no-timeouts --require source-map-support/register",
+    "// test": "mocha \"build-test/**/*.js\" --exit --no-timeouts --require source-map-support/register",
     "watch": "run-p \"build:** -- --verbose --watch\""
   },
   "dependencies": {

--- a/packages/embarkjs-whisper/package.json
+++ b/packages/embarkjs-whisper/package.json
@@ -46,7 +46,7 @@
     "qa": "npm-run-all build package",
     "reset": "npx rimraf build-test dist embarkjs-*.tgz package",
     "start": "npm run watch",
-    "test": "mocha \"build-test/**/*.js\" --exit --no-timeouts --require source-map-support/register",
+    "// test": "mocha \"build-test/**/*.js\" --exit --no-timeouts --require source-map-support/register",
     "watch": "run-p \"build:** -- --verbose --watch\""
   },
   "dependencies": {


### PR DESCRIPTION
Several `embarkjs-*` packages specify a `"test":` script in their respective `package.json` files but lack any tests, causing `yarn test` in the root of the monorepo to fail. For now, disable those scripts.