### PR TITLE
feat(@embark/webserver): Add support for `service webserver on/off`

### DIFF
--- a/packages/embark/src/lib/core/processes/processManager.js
+++ b/packages/embark/src/lib/core/processes/processManager.js
@@ -90,17 +90,18 @@ class ProcessManager {
           const enable = cmd.trim().endsWith('on');
           this.logger.info(`${enable ? 'Starting' :  'Stopping'} the ${name} process...`);
           if(enable) {
-            return this.events.request("processes:launch", name, (err) => {
-              if (err) this.logger.info(err); // writes to embark's console
+            return this.events.request("processes:launch", name, (...args) => {
+              const err = args[0];
+              if (err) return this.logger.error(err); // writes to embark's console
               const process = self.processes[name];
               if(process && process.afterLaunchFn) {
-                process.afterLaunchFn.call(process.afterLaunchFn, err);
+                process.afterLaunchFn.apply(process.afterLaunchFn, args);
               }
               callback(err, `${name} process started.`); // passes a message back to cockpit console
             });
           }
           this.events.request("processes:stop", name, (err) => {
-            if (err) this.logger.info(err); // writes to embark's console
+            if (err) return this.logger.error(err); // writes to embark's console
             callback(err, `${name} process stopped.`); // passes a message back to cockpit console
           });
         }


### PR DESCRIPTION
Add support for `service webserver on/off` commands.

Deprecate commands `webserver start/stop` in favor of `service webserver on/off`.

Handles passing through of arguments to the function executed after process launch.

## Commands added
`service webserver on` - Enables the webserver serving the DApp. Shows an error if the webserver is already starting or started.

`service webserver off` - Disables the webserver serving the DApp. Shows an error if the webserver is already stopping or stopped.

## Commands depcrecated
`webserver start` - This command has been deprecated in favor of `service webserver on` and will be removed in future versions.

`webserver stop` - This command has been deprecated in favor of `service webserver off` and will be removed in future versions.