### PR TITLE
ci: on azure pipelines split coveralls and ci:full invocation scripts, run each script conditionally

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -31,11 +31,13 @@ pool:
 
 steps:
 - task: NodeTool@0
+  condition: succeeded()
   displayName: 'Install Node.js'
   inputs:
     versionSpec: $(nodeVersion)
 
 - task: UsepythonVersion@0
+  condition: succeeded()
   displayName: 'Install Python'
   inputs:
     architecture: x64
@@ -62,12 +64,14 @@ steps:
     else
       tar xzvf go-ipfs.tar.gz
     fi
+  condition: succeeded()
   displayName: 'Install IPFS'
 
 - bash: |
     export PATH="$(cd ../Downloads && pwd)/go-ipfs:${PATH}"
     ipfs version
     ipfs init
+  condition: succeeded()
   displayName: 'Initialize IPFS'
 
 - bash: |
@@ -75,6 +79,7 @@ steps:
     export PATH="${HOME}/.yarn/bin:${HOME}/.config/yarn/global/node_modules/.bin:${PATH}"
     yarn --version
     mkdir -p ../Downloads/Yarn
+  condition: succeeded()
   displayName: 'Install Yarn'
 
 - bash: |
@@ -85,16 +90,7 @@ steps:
     yarn config set cache-folder "${PWD}/Yarn" &>/dev/null
     popd &>/dev/null
     npm run ci:full
-    if [[ "$AGENT_OS" = "Linux" ]]; then
-      OS="Linux"
-    fi
-    if [[ "$AGENT_OS" = "Darwin" ]]; then
-      OS="macOS"
-    fi
-    export COVERALLS_GIT_BRANCH=$(node scripts/coveralls-branch-name)
-    export COVERALLS_SERVICE_NAME="Azure Pipelines (${OS})"
-    npm run coveralls
-  condition: ne( variables['Agent.OS'], 'Windows_NT' )
+  condition: and( succeeded(), ne( variables['Agent.OS'], 'Windows_NT' ) )
   displayName: 'Test (*nix)'
 
 - powershell: |
@@ -105,8 +101,25 @@ steps:
     yarn config set cache-folder "$($PWD.Path)\Yarn" | out-null
     popd
     npm run ci:full
-    $env:COVERALLS_GIT_BRANCH=node scripts/coveralls-branch-name
-    $env:COVERALLS_SERVICE_NAME="Azure Pipelines (Windows)"
-    npm run coveralls
-  condition: eq( variables['Agent.OS'], 'Windows_NT' )
+  condition: and( succeeded(), eq( variables['Agent.OS'], 'Windows_NT' ) )
   displayName: 'Test (Windows)'
+
+- bash: |
+    if [[ "$AGENT_OS" = "Linux" ]]; then
+      OS="Linux"
+    fi
+    if [[ "$AGENT_OS" = "Darwin" ]]; then
+      OS="macOS"
+    fi
+    if [[ "$AGENT_OS" = "Windows_NT" ]]; then
+      OS="Windows"
+    fi
+    export CI_PULL_REQUEST=$(node scripts/coveralls-pr-id)
+    if [[ -z "$CI_PULL_REQUEST" ]]; then
+      unset CI_PULL_REQUEST
+    fi
+    export COVERALLS_GIT_BRANCH=$(node scripts/coveralls-branch-name)
+    export COVERALLS_SERVICE_NAME="Azure Pipelines (${OS})"
+    npm run coveralls
+  condition: succeeded()
+  displayName: 'Coveralls'

--- a/scripts/coveralls-pr-id.js
+++ b/scripts/coveralls-pr-id.js
@@ -1,0 +1,12 @@
+/* global process require */
+
+const {execSync} = require('child_process');
+
+let branchName = execSync('git name-rev --name-only HEAD').toString().trim();
+let prId = '';
+
+if (branchName.startsWith('remotes/pull')) {
+  prId = branchName.split('/')[2];
+}
+
+process.stdout.write(prId);


### PR DESCRIPTION
Based on [feedback](https://github.com/lemurheavy/coveralls-public/issues/1298#issuecomment-488316379) from the coveralls team, I was also able to include the PR ids of PR builds, which results in type "pull" instead of "push" in the coveralls builds list, along with a handy link to the relevant PR on github.