### PR TITLE
feat(@embark/storage): Add command `service ipfs on/off`

### DIFF
--- a/packages/embark-core/constants.json
+++ b/packages/embark-core/constants.json
@@ -61,7 +61,8 @@
   "storage": {
     "init": "init",
     "initiated": "initiated",
-    "restart": "restart"
+    "restart": "restart",
+    "exit": "storageExit"
   },
   "codeGenerator": {
     "gasLimit": 6000000

--- a/packages/embark/src/lib/core/engine.js
+++ b/packages/embark/src/lib/core/engine.js
@@ -278,14 +278,14 @@ class Engine {
         if (!this.config.storageConfig.available_providers.includes("ipfs")) {
           return next();
         }
-        this.events.on("ipfs:process:started", next);
+        this.events.once("ipfs:process:started", next);
         this.registerModule('ipfs');
       },
       (next) => {
         if (!this.config.storageConfig.available_providers.includes("swarm")) {
           return next();
         }
-        this.events.on("swarm:process:started", next);
+        this.events.once("swarm:process:started", next);
         this.registerModule('swarm');
       }
     ], (err) => {

--- a/packages/embark/src/lib/modules/blockchain_process/blockchainProcessLauncher.js
+++ b/packages/embark/src/lib/modules/blockchain_process/blockchainProcessLauncher.js
@@ -71,7 +71,7 @@ class BlockchainProcessLauncher {
 
   stopBlockchainNode(cb) {
     if(this.blockchainProcess) {
-      this.events.on(constants.blockchain.blockchainExit, cb);
+      this.events.once(constants.blockchain.blockchainExit, cb);
       this.blockchainProcess.exitCallback = () => {}; // don't show error message as the process was killed on purpose
       this.blockchainProcess.send('exit');
     }

--- a/packages/embark/src/lib/modules/ipfs/process.js
+++ b/packages/embark/src/lib/modules/ipfs/process.js
@@ -184,6 +184,7 @@ class IPFSProcess extends ProcessWrapper {
   kill() {
     if (this.child) {
       this.child.kill();
+      ipfsProcess.send({result: constants.storage.exit});
     }
   }
 }


### PR DESCRIPTION
Add support for ability to start and stop IPFS via command `service ipfs on/off`.

Add support for `ProcessState.Errored` process state in the `ProcessManager`. This allows for processes being launched and stopped to trigger an error and the resulting process will be in an errored state. Processes in errored states can still attempt to be started and stopped.

## Commands added
`service ipfs on` - starts an IPFS node if not already started. Shows an error if the node is already starting or started.

`service ipfs off` - kills the running IPFS node as long as Embark has started the IPFS process. If the IPFS process was started externally, an error is shown.