### PR TITLE
fix(@embark/api): specify colors package as a dependency

### DIFF
--- a/packages/embark-api/package.json
+++ b/packages/embark-api/package.json
@@ -42,6 +42,7 @@
   },
   "dependencies": {
     "@babel/runtime-corejs2": "7.3.1",
+    "colors": "1.3.2",
     "embark-async-wrapper": "^4.0.0",
     "embark-utils": "^4.1.0-beta.0"
   },


### PR DESCRIPTION
In the monorepo it works without `colors` specified as a dep, but it's important to specify all dependencies correctly for the sake of production installs.