### PR TITLE
fix(@embark/library-manager): specify colors package as a dependency

### DIFF
--- a/packages/embark-library-manager/package.json
+++ b/packages/embark-library-manager/package.json
@@ -47,6 +47,7 @@
   },
   "dependencies": {
     "@babel/runtime-corejs2": "7.3.1",
+    "colors": "1.3.2",
     "live-plugin-manager-git-fix": "0.12.1"
   },
   "devDependencies": {


### PR DESCRIPTION
In the monorepo it works without `colors` specified as a dep, but it's important to specify all dependencies correctly for the sake of production installs.