### PR TITLE
build: bump typescript in all relevant pkgs from v3.3.1 to v3.4.5

### DIFF
--- a/packages/embark-api-client/package.json
+++ b/packages/embark-api-client/package.json
@@ -58,7 +58,7 @@
     "npm-run-all": "4.1.5",
     "rimraf": "2.6.3",
     "tslint": "5.11.0",
-    "typescript": "3.3.1"
+    "typescript": "3.4.5"
   },
   "engines": {
     "node": ">=8.12.0",

--- a/packages/embark-api/package.json
+++ b/packages/embark-api/package.json
@@ -53,7 +53,7 @@
     "npm-run-all": "4.1.5",
     "rimraf": "2.6.3",
     "tslint": "5.11.0",
-    "typescript": "3.3.1"
+    "typescript": "3.4.5"
   },
   "engines": {
     "node": ">=8.12.0",

--- a/packages/embark-async-wrapper/package.json
+++ b/packages/embark-async-wrapper/package.json
@@ -56,7 +56,7 @@
     "npm-run-all": "4.1.5",
     "rimraf": "2.6.3",
     "tslint": "5.11.0",
-    "typescript": "3.3.1"
+    "typescript": "3.4.5"
   },
   "engines": {
     "node": ">=8.12.0",

--- a/packages/embark-authenticator/package.json
+++ b/packages/embark-authenticator/package.json
@@ -59,7 +59,7 @@
     "npm-run-all": "4.1.5",
     "rimraf": "2.6.3",
     "tslint": "5.11.0",
-    "typescript": "3.3.1"
+    "typescript": "3.4.5"
   },
   "engines": {
     "node": ">=8.12.0",

--- a/packages/embark-compiler/package.json
+++ b/packages/embark-compiler/package.json
@@ -51,7 +51,7 @@
     "npm-run-all": "4.1.5",
     "rimraf": "2.6.3",
     "tslint": "5.11.0",
-    "typescript": "3.3.1"
+    "typescript": "3.4.5"
   },
   "engines": {
     "node": ">=8.12.0",

--- a/packages/embark-contracts-manager/package.json
+++ b/packages/embark-contracts-manager/package.json
@@ -60,7 +60,7 @@
     "npm-run-all": "4.1.5",
     "rimraf": "2.6.3",
     "tslint": "5.11.0",
-    "typescript": "3.3.1"
+    "typescript": "3.4.5"
   },
   "engines": {
     "node": ">=8.12.0",

--- a/packages/embark-core/package.json
+++ b/packages/embark-core/package.json
@@ -57,7 +57,7 @@
     "npm-run-all": "4.1.5",
     "rimraf": "2.6.3",
     "tslint": "5.11.0",
-    "typescript": "3.3.1"
+    "typescript": "3.4.5"
   },
   "engines": {
     "node": ">=8.12.0",

--- a/packages/embark-ens/package.json
+++ b/packages/embark-ens/package.json
@@ -61,7 +61,7 @@
     "npm-run-all": "4.1.5",
     "rimraf": "2.6.3",
     "tslint": "5.11.0",
-    "typescript": "3.3.1"
+    "typescript": "3.4.5"
   },
   "engines": {
     "node": ">=8.12.0",

--- a/packages/embark-graph/package.json
+++ b/packages/embark-graph/package.json
@@ -58,7 +58,7 @@
     "npm-run-all": "4.1.5",
     "rimraf": "2.6.3",
     "tslint": "5.11.0",
-    "typescript": "3.3.1"
+    "typescript": "3.4.5"
   },
   "engines": {
     "node": ">=8.12.0",

--- a/packages/embark-library-manager/package.json
+++ b/packages/embark-library-manager/package.json
@@ -58,7 +58,7 @@
     "npm-run-all": "4.1.5",
     "rimraf": "2.6.3",
     "tslint": "5.11.0",
-    "typescript": "3.3.1"
+    "typescript": "3.4.5"
   },
   "engines": {
     "node": ">=8.12.0",

--- a/packages/embark-logger/package.json
+++ b/packages/embark-logger/package.json
@@ -59,7 +59,7 @@
     "npm-run-all": "4.1.5",
     "rimraf": "2.6.3",
     "tslint": "5.11.0",
-    "typescript": "3.3.1"
+    "typescript": "3.4.5"
   },
   "engines": {
     "node": ">=8.12.0",

--- a/packages/embark-process-logs-api/package.json
+++ b/packages/embark-process-logs-api/package.json
@@ -57,7 +57,7 @@
     "npm-run-all": "4.1.5",
     "rimraf": "2.6.3",
     "tslint": "5.11.0",
-    "typescript": "3.3.1"
+    "typescript": "3.4.5"
   },
   "engines": {
     "node": ">=8.12.0",

--- a/packages/embark-profiler/package.json
+++ b/packages/embark-profiler/package.json
@@ -59,7 +59,7 @@
     "npm-run-all": "4.1.5",
     "rimraf": "2.6.3",
     "tslint": "5.11.0",
-    "typescript": "3.3.1"
+    "typescript": "3.4.5"
   },
   "engines": {
     "node": ">=8.12.0",

--- a/packages/embark-scaffolding/package.json
+++ b/packages/embark-scaffolding/package.json
@@ -54,7 +54,7 @@
     "npm-run-all": "4.1.5",
     "rimraf": "2.6.3",
     "tslint": "5.11.0",
-    "typescript": "3.3.1"
+    "typescript": "3.4.5"
   },
   "engines": {
     "node": ">=8.12.0",
@@ -62,4 +62,3 @@
     "yarn": ">=1.12.3"
   }
 }
-

--- a/packages/embark-specialconfigs/package.json
+++ b/packages/embark-specialconfigs/package.json
@@ -58,7 +58,7 @@
     "npm-run-all": "4.1.5",
     "rimraf": "2.6.3",
     "tslint": "5.11.0",
-    "typescript": "3.3.1"
+    "typescript": "3.4.5"
   },
   "engines": {
     "node": ">=8.12.0",

--- a/packages/embark-test-runner/package.json
+++ b/packages/embark-test-runner/package.json
@@ -60,7 +60,7 @@
     "npm-run-all": "4.1.5",
     "rimraf": "2.6.3",
     "tslint": "5.11.0",
-    "typescript": "3.3.1"
+    "typescript": "3.4.5"
   },
   "engines": {
     "node": ">=8.12.0",

--- a/packages/embark-transaction-tracker/package.json
+++ b/packages/embark-transaction-tracker/package.json
@@ -58,7 +58,7 @@
     "npm-run-all": "4.1.5",
     "rimraf": "2.6.3",
     "tslint": "5.11.0",
-    "typescript": "3.3.1"
+    "typescript": "3.4.5"
   },
   "engines": {
     "node": ">=8.12.0",

--- a/packages/embark-typings/package.json
+++ b/packages/embark-typings/package.json
@@ -36,7 +36,7 @@
     "@types/web3": "1.0.12",
     "npm-run-all": "4.1.5",
     "tslint": "5.11.0",
-    "typescript": "3.3.1"
+    "typescript": "3.4.5"
   },
   "engines": {
     "node": ">=8.12.0",

--- a/packages/embark-utils/package.json
+++ b/packages/embark-utils/package.json
@@ -68,7 +68,7 @@
     "npm-run-all": "4.1.5",
     "rimraf": "2.6.3",
     "tslint": "5.11.0",
-    "typescript": "3.3.1"
+    "typescript": "3.4.5"
   },
   "engines": {
     "node": ">=8.12.0",

--- a/packages/embark-vyper/package.json
+++ b/packages/embark-vyper/package.json
@@ -58,7 +58,7 @@
     "npm-run-all": "4.1.5",
     "rimraf": "2.6.3",
     "tslint": "5.11.0",
-    "typescript": "3.3.1"
+    "typescript": "3.4.5"
   },
   "engines": {
     "node": ">=8.12.0",

--- a/packages/embark-watcher/package.json
+++ b/packages/embark-watcher/package.json
@@ -57,7 +57,7 @@
     "npm-run-all": "4.1.5",
     "rimraf": "2.6.3",
     "tslint": "5.11.0",
-    "typescript": "3.3.1"
+    "typescript": "3.4.5"
   },
   "engines": {
     "node": ">=8.12.0",
@@ -65,4 +65,3 @@
     "yarn": ">=1.12.3"
   }
 }
-

--- a/packages/embark-webserver/package.json
+++ b/packages/embark-webserver/package.json
@@ -63,7 +63,7 @@
     "npm-run-all": "4.1.5",
     "rimraf": "2.6.3",
     "tslint": "5.11.0",
-    "typescript": "3.3.1"
+    "typescript": "3.4.5"
   },
   "engines": {
     "node": ">=8.12.0",

--- a/packages/embark-whisper/package.json
+++ b/packages/embark-whisper/package.json
@@ -60,7 +60,7 @@
     "npm-run-all": "4.1.5",
     "rimraf": "2.6.3",
     "tslint": "5.11.0",
-    "typescript": "3.3.1"
+    "typescript": "3.4.5"
   },
   "engines": {
     "node": ">=8.12.0",

--- a/packages/embark/package.json
+++ b/packages/embark/package.json
@@ -230,7 +230,7 @@
     "rimraf": "2.6.3",
     "sinon": "4.5.0",
     "tslint": "5.11.0",
-    "typescript": "3.3.1"
+    "typescript": "3.4.5"
   },
   "engines": {
     "node": ">=8.12.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -19003,10 +19003,10 @@ typedarray@^0.0.6:
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
   integrity sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=
 
-typescript@3.3.1:
-  version "3.3.1"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.3.1.tgz#6de14e1db4b8a006ac535e482c8ba018c55f750b"
-  integrity sha512-cTmIDFW7O0IHbn1DPYjkiebHxwtCMU+eTy30ZtJNBPF9j2O1ITu5XH2YnBeVRKWHqF+3JQwWJv0Q0aUgX8W7IA==
+typescript@3.4.5:
+  version "3.4.5"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.4.5.tgz#2d2618d10bb566572b8d7aad5180d84257d70a99"
+  integrity sha512-YycBxUb49UUhdNMU5aJ7z5Ej2XGmaIBL0x34vZ82fn3hGvD+bgrMrVDpatgz2f7YxUMJxMkbWxJZeAvDxVe7Vw==
 
 typewise-core@^1.2, typewise-core@^1.2.0:
   version "1.2.0"


### PR DESCRIPTION
The more recent version of TypeScript works around a [problem][chalk-problem] encountered with the chalk package's type definitions.

[chalk-problem]: https://github.com/chalk/chalk/pull/296#issuecomment-418789492