### PR TITLE
style: use comments to avoid confusion about @types/embark imports

### DIFF
--- a/packages/embark-api/src/index.ts
+++ b/packages/embark-api/src/index.ts
@@ -1,4 +1,4 @@
-import {Embark} from "embark";
+import {Embark} /* supplied by @types/embark in packages/embark-typings */ from "embark";
 import {checkIsAvailable, dockerHostSwap, findNextPort} from "embark-utils";
 import {__} from "i18n";
 

--- a/packages/embark-api/src/server.ts
+++ b/packages/embark-api/src/server.ts
@@ -1,7 +1,7 @@
 import bodyParser from "body-parser";
 import "colors";
 import cors from "cors";
-import {Embark, Plugins} from "embark";
+import {Embark, Plugins} /* supplied by @types/embark in packages/embark-typings */ from "embark";
 import express, {NextFunction, Request, Response} from "express";
 import expressWs from "express-ws";
 import findUp from "find-up";

--- a/packages/embark-compiler/src/index.ts
+++ b/packages/embark-compiler/src/index.ts
@@ -1,4 +1,4 @@
-import {Callback, CompilerPluginObject, Embark, Plugins} from "embark";
+import {Callback, CompilerPluginObject, Embark, Plugins} /* supplied by @types/embark in packages/embark-typings */ from "embark";
 import {__} from "i18n";
 
 const async = require("embark-async-wrapper");

--- a/packages/embark-scaffolding/src/commandOptions.ts
+++ b/packages/embark-scaffolding/src/commandOptions.ts
@@ -1,5 +1,5 @@
 import Ajv from "ajv";
-import { Logger } from "embark";
+import { Logger } /* supplied by @types/embark in packages/embark-typings */ from "embark";
 import {__} from "i18n";
 
 export enum Framework {

--- a/packages/embark-scaffolding/src/contractLanguage/solidityBuilder/index.ts
+++ b/packages/embark-scaffolding/src/contractLanguage/solidityBuilder/index.ts
@@ -1,4 +1,4 @@
-import { Embark } from "embark";
+import { Embark } /* supplied by @types/embark in packages/embark-typings */ from "embark";
 import Handlebars from "handlebars";
 import {__} from "i18n";
 import * as path from "path";

--- a/packages/embark-scaffolding/src/framework/reactBuilder/index.ts
+++ b/packages/embark-scaffolding/src/framework/reactBuilder/index.ts
@@ -1,4 +1,4 @@
-import { Contract, Embark } from "embark";
+import { Contract, Embark } /* supplied by @types/embark in packages/embark-typings */ from "embark";
 import Handlebars from "handlebars";
 import {__} from "i18n";
 import * as path from "path";

--- a/packages/embark-scaffolding/src/index.ts
+++ b/packages/embark-scaffolding/src/index.ts
@@ -1,4 +1,4 @@
-import { Contract, Embark } from "embark";
+import { Contract, Embark } /* supplied by @types/embark in packages/embark-typings */ from "embark";
 import { CommandOptions, ContractLanguage, Framework } from "./commandOptions";
 import { SolidityBuilder } from "./contractLanguage/solidityBuilder";
 import { ReactBuilder } from "./framework/reactBuilder";

--- a/packages/embark-scaffolding/src/smartContractsRecipe.ts
+++ b/packages/embark-scaffolding/src/smartContractsRecipe.ts
@@ -1,5 +1,5 @@
 import Ajv from "ajv";
-import { Logger } from "embark";
+import { Logger } /* supplied by @types/embark in packages/embark-typings */ from "embark";
 import {__} from "i18n";
 import { schema } from "./schema";
 const fs = require("fs");

--- a/packages/embark-utils/src/longRunningProcessTimer.ts
+++ b/packages/embark-utils/src/longRunningProcessTimer.ts
@@ -1,5 +1,5 @@
 import { red } from "colors";
-import { Logger } from "embark";
+import { Logger } /* supplied by @types/embark in packages/embark-typings */ from "embark";
 import { performance, PerformanceObserver } from "perf_hooks";
 import prettyMs from "pretty-ms";
 import { last, recursiveMerge } from "./collections";

--- a/packages/embark-utils/src/transactionUtils.ts
+++ b/packages/embark-utils/src/transactionUtils.ts
@@ -1,4 +1,4 @@
-import { Contract } from "embark";
+import { Contract } /* supplied by @types/embark in packages/embark-typings */ from "embark";
 import { ABIDefinition } from "web3/eth/abi";
 import { decodeParams, sha3 } from "./web3Utils";
 

--- a/packages/embark/src/lib/core/i18n/i18n.ts
+++ b/packages/embark/src/lib/core/i18n/i18n.ts
@@ -3,7 +3,7 @@ import * as i18n from "i18n";
 import * as osLocale from "os-locale";
 import * as path from "path";
 
-import { Maybe } from "embark";
+import { Maybe } /* supplied by @types/embark in packages/embark-typings */ from "embark";
 
 enum LocalType {
   Specified = "specified",

--- a/packages/embark/src/lib/modules/codeRunner/index.ts
+++ b/packages/embark/src/lib/modules/codeRunner/index.ts
@@ -1,6 +1,6 @@
 import VM from "./vm";
 const fs = require("./fs");
-import { Callback, Embark, Events, Logger } from "embark";
+import { Callback, Embark, Events, Logger } /* supplied by @types/embark in packages/embark-typings */ from "embark";
 import Web3 from "web3";
 const EmbarkJS = require("embarkjs");
 

--- a/packages/embark/src/lib/modules/codeRunner/vm.ts
+++ b/packages/embark/src/lib/modules/codeRunner/vm.ts
@@ -1,5 +1,5 @@
 import { each } from "async";
-import { Callback, Logger } from "embark";
+import { Callback, Logger } /* supplied by @types/embark in packages/embark-typings */ from "embark";
 import { NodeVM, NodeVMOptions } from "vm2";
 
 import { recursiveMerge } from "embark-utils";


### PR DESCRIPTION
We could use similar comments for imports related to other `@types` packages, but the need to do it for `@types/embark` (located in `packages/embark-typings`) seems more pressing since `import ... from "embark"` statements in the monorepo can be so easily misunderstood.

Note that the comments, and indeed the whole lines, are automatically erased during babel transpilation of TypeScript since TS types aren't relevant after the `.js` files are built.