### PR TITLE
feat(@embark/storage): Add command `service swarm on/off`

### DIFF
--- a/packages/embark/src/lib/modules/storage/index.js
+++ b/packages/embark/src/lib/modules/storage/index.js
@@ -41,7 +41,7 @@ class Storage {
   }
 
   addSetProviders(cb) {
-    let code = `\nEmbarkJS.Storage.setProviders(${JSON.stringify(this.storageConfig.dappConnection || [])});`;
+    let code = `\nEmbarkJS.Storage.setProviders(${JSON.stringify(this.storageConfig.dappConnection || [])}, {web3});`;
 
     let shouldInit = (storageConfig) => {
       return storageConfig.enabled;

--- a/packages/embark/src/lib/modules/swarm/process.js
+++ b/packages/embark/src/lib/modules/swarm/process.js
@@ -78,6 +78,7 @@ class SwarmProcess extends ProcessWrapper {
   kill() {
     if (this.child) {
       this.child.kill();
+      swarmProcess.send({result: constants.storage.exit});
     }
   }
 }

--- a/packages/embarkjs-swarm/src/index.js
+++ b/packages/embarkjs-swarm/src/index.js
@@ -1,4 +1,3 @@
-/*global web3 */
 let __embarkSwarm = {_swarmConnection: undefined};
 let SwarmAPI = require('swarm-api');
 if (SwarmAPI.default) {
@@ -14,11 +13,15 @@ __embarkSwarm.setProvider = function (options) {
   this._connectError = new Error(`Cannot connect to Swarm node on ${this._connectUrl}`);
 
   return new Promise((resolve, reject) => {
+    if(!options.web3) {
+      reject(__("A web3 object must be passed in to __embarkSwarm.setProvider"));
+    }
+    const {web3, useOnlyGivenProvider} = options;
     try {
-      if (!web3.bzz.currentProvider && !options.useOnlyGivenProvider) {
+      if (!web3.bzz.currentProvider && !useOnlyGivenProvider) {
         this._swarmConnection = new SwarmAPI({gateway: this._connectUrl});
       }
-      else if (options.useOnlyGivenProvider && web3.bzz.givenProvider !== null) {
+      else if (useOnlyGivenProvider && web3.bzz.givenProvider !== null) {
         this._swarmConnection = new SwarmAPI({gateway: web3.bzz.givenProvider});
       }
       resolve(this);

--- a/packages/embarkjs/src/storage.js
+++ b/packages/embarkjs/src/storage.js
@@ -72,11 +72,12 @@ Storage.isAvailable = function () {
 };
 
 // TODO: most of this logic should move to the provider implementations themselves
-Storage.setProviders = function (dappConnOptions) {
+Storage.setProviders = function (dappConnOptions, addlOpts) {
   const self = this;
   detectSeries(dappConnOptions, (dappConn, callback) => {
     let options = dappConn;
     if (dappConn === '$BZZ') options = {"useOnlyGivenProvider": true};
+    options = {...options, ...addlOpts};
     try {
       self.setProvider(dappConn === '$BZZ' ? dappConn : dappConn.provider, options).then(() => {
         self.isAvailable().then((isAvailable) => {


### PR DESCRIPTION
Add support for ability to start and stop Swarm via command `service swarm on/off`.

Fix issue with swarm not starting due to missing web3 object.

## Commands added
`service swarm on` - starts a swarm node if not already started. Shows an error if the node is already starting or started.

`service swarm off` - kills the running swarm node as long as Embark has started the swarm process. If the swarm process was started externally, an error is shown.

## Note
Please do not merge until https://github.com/embark-framework/embark/pull/1564 has been merged, at which point I will rebase this with master.