### PR TITLE
refactor(@cockpit/explorer): revise transactions explorer per techniques of PRs #1492, #1494

### DIFF
--- a/packages/embark-ui/src/actions/index.js
+++ b/packages/embark-ui/src/actions/index.js
@@ -100,7 +100,7 @@ export const block = {
 
 export const TRANSACTIONS = createRequestTypes('TRANSACTIONS');
 export const transactions = {
-  request: (blockFrom) => action(TRANSACTIONS[REQUEST], {blockFrom}),
+  request: (blockFrom, blockLimit) => action(TRANSACTIONS[REQUEST], {blockFrom, blockLimit}),
   success: (transactions) => action(TRANSACTIONS[SUCCESS], {transactions}),
   failure: (error) => action(TRANSACTIONS[FAILURE], {error})
 };


### PR DESCRIPTION
In addition to introducing improvements per #1492 and #1494, adjust the transactions request action to allow for a `blockLimit` argument, since that API parameter is supported by embark.

Revise `changePage` to invoke `fetchTransactions` correctly, i.e. with arguments pertaining to a starting block number and a block limit.

These changes together fix most of the pagination problems related to exploring transactions, i.e. badly mis-ordered results are no longer displayed.

However, a *wart* still remains related to estimation of the total number of transactions and pages. Sometimes the calculated number of pages for the transactions explorer doesn't match up to the actual number of transactions on the blockchain (owing to estimation). The pagination controls and display of transactions will temporarily behave a little strangely if one jumps ahead in the pages, e.g. a jump from cockpit explorer overview's transactions page 1 to page 5 for embark's demo, if an additional transaction has been added and the explorer overview is freshly loaded. This behavior is related to the fact that actions such as `fetchBlocksFull` and `fetchTransactions` are async without any means to determine when all actions have completed and React re-/rendering has settled down.

There are probably some architectural changes that could improve the situation, but they're outside the scope of this PR and in no way easy to solve by means of React lifecycle methods. In fact, attempts to make an improvement with `componentDidUpdate` (and watching what happens in the debugger) revealed the nature of the problem, as described above.