### PR TITLE
feat(@embark/whisper): Remove support for `service whisper on/off`

### DIFF
--- a/site/source/docs/using_the_console.md
+++ b/site/source/docs/using_the_console.md
@@ -36,9 +36,26 @@ Embark (development) > help<ENTER>
 
 This is a good time to read a bit through the available commands and familiarize yourself with them.
 
-## Enabling and disabling process logs
+## Enabling and disabling processes
 
-There are several processes and services that Embark spins up to do its work (e.g. `geth` for blockchain process, `ipfs` as storage daemon etc). Those are the same processes that are listed as "Available Services" in the dashboard.
+There are several processes and services that Embark spins up to do its work (e.g. `geth` for blockchain process, `ipfs` as storage daemon, etc). Those are the same processes that are listed as "Available Services" in the dashboard.
+
+These processes can be enabled and disabled using the `service` command.
+
+Simply specify the process and turn it `on` or `off`:
+
+```
+Embark (development) > service ipfs off
+```
+
+The "Available Services" in the dashboard as well as Cockpit's dashboard will reflect the status of the processes as they are enabled and disabled.
+
+NOTE: There are two processes that cannot be started and stopped via console commands:
+1. **Embark** - The Embark process cannot stop and start itself.
+2. **Whisper** - Whisper cannot be started and stopped via a command because the blockchain process CLI parameters need to be modified and the blockchain process itself would need to be restarted. To disable Whisper, set `enabled: false` in the communications config, then restart Embark. To enable Whisper, set `enabled: true` in the communications config, then restart Embark.
+
+
+## Enabling and disabling process logs
 
 By default, Embark will log output from all processes into the console. Since this can get quite verbose sometimes, we can disable logging for certain processes using the `log` command.
 


### PR DESCRIPTION
Remove support for `service whisper on/off` because Whisper cannot be started without first disabling it in the communications config, then restarting Embark.

Also remove support for `service embark on/off` because Embark itself should not be able to be started/stopped via command.

These commands were only added a few commits back so it is not considered a breaking change.

Refactor the `service [process] on/off` commands so that there is only one command. Previously we had a command registered for each process, ie:
```
service blockchain on/off
service ipfs on/off
…
```

Now, we only have one command with many options:
```
service [process] on/off - Starts/stops the process. Options: blockchain, embark, ipfs, api
```

Whisper is deliberately not included in the available options for the aforementioned reasons.