### PR TITLE
docs(using_the_console): fix typo of methods call

### DIFF
--- a/site/source/docs/using_the_console.md
+++ b/site/source/docs/using_the_console.md
@@ -69,7 +69,7 @@ This applies to synchronous as well as asynchronous APIs, which is very common w
 In both the dashboard's console and the standalone console, you can use `await` for `Promise`-based calls:
 
 ```
-Embark (development) > await SimpleStorage.method.get().call()<ENTER>
+Embark (development) > await SimpleStorage.methods.get().call()<ENTER>
 ```
 
 This works with other objects as well. The following example outputs available accounts emitted by the `web3` object:


### PR DESCRIPTION
There is a typo on Using the console that would confuse newbies.
`await SimpleStorage.method.get().call()<ENTER>` should be `await SimpleStorage.methods.get().call()<ENTER>`