### PR TITLE
Fix privateKey accounts in accountParser

### DIFF
--- a/packages/embark-utils/src/accountParser.js
+++ b/packages/embark-utils/src/accountParser.js
@@ -67,11 +67,11 @@ class AccountParser {
         return null;
       }
 
-      const key = Buffer.from(accountConfig.privateKey.substr(2), 'hex');
       if (returnAddress) {
+        const key = Buffer.from(accountConfig.privateKey.substr(2), 'hex');
         return ethereumjsWallet.fromPrivateKey(key).getChecksumAddressString();
       }
-      return Object.assign(web3.eth.accounts.privateKeyToAccount(key), {hexBalance});
+      return Object.assign(web3.eth.accounts.privateKeyToAccount(accountConfig.privateKey), {hexBalance});
     } else if (Object.hasOwnProperty('privateKey')) {
       logger.error(__('accounts error: privateKey field is specified but its value is undefined'));
     }
@@ -109,9 +109,8 @@ class AccountParser {
           return null;
         }
 
-        key = Buffer.from(key.substr(2), 'hex');
-
         if (returnAddress) {
+          key = Buffer.from(key.substr(2), 'hex');
           return ethereumjsWallet.fromPrivateKey(key).getChecksumAddressString();
         }
         return Object.assign(web3.eth.accounts.privateKeyToAccount(key), {hexBalance});

--- a/packages/embark/src/lib/modules/blockchain_connector/index.js
+++ b/packages/embark/src/lib/modules/blockchain_connector/index.js
@@ -167,7 +167,8 @@ class BlockchainConnector {
       isDev: this.isDev,
       type: type,
       web3Endpoint: self.web3Endpoint,
-      events: this.events
+      events: this.events,
+      fs: this.fs
     };
     this.provider = new Provider(providerOptions);
 

--- a/packages/embark/src/lib/modules/blockchain_connector/provider.js
+++ b/packages/embark/src/lib/modules/blockchain_connector/provider.js
@@ -15,6 +15,7 @@ class Provider {
     this.logger = options.logger;
     this.isDev = options.isDev;
     this.events = options.events;
+    this.fs = options.fs;
     this.nonceCache = {};
 
     this.events.setCommandHandler("blockchain:provider:contract:accounts:get", cb => {
@@ -70,11 +71,11 @@ class Provider {
         self.logger.warn('Error while getting the node\'s accounts.', err.message || err);
       }
 
-      self.blockchainAccounts = AccountParser.parseAccountsConfig(self.blockchainConfig.accounts, self.web3, self.logger, accounts);
+      self.blockchainAccounts = AccountParser.parseAccountsConfig(self.blockchainConfig.accounts, self.web3, this.fs.dappPath(), self.logger, accounts);
 
       accounts = accounts.concat(self.blockchainAccounts);
 
-      self.accounts = AccountParser.parseAccountsConfig(self.accountsConfig, self.web3, self.logger, accounts);
+      self.accounts = AccountParser.parseAccountsConfig(self.accountsConfig, self.web3, this.fs.dappPath(), self.logger, accounts);
 
       if (!self.accounts.length) {
         self.accounts = accounts;


### PR DESCRIPTION
I was missing the dappPath and also it used a Buffer key instead of the string key like web3 expects