### PR TITLE
Add warning for interface contracts + docs

### DIFF
--- a/packages/embark-contracts-manager/src/index.js
+++ b/packages/embark-contracts-manager/src/index.js
@@ -376,6 +376,7 @@ class ContractsManager {
       },
       function setDeployIntention(callback) {
         let className, contract;
+        let showInterfaceMessage = false;
         for (className in self.contracts) {
           contract = self.contracts[className];
           contract.deploy = (contract.deploy === undefined) || contract.deploy;
@@ -389,6 +390,7 @@ class ContractsManager {
 
           if (contract.code === "") {
             const message = __("assuming %s to be an interface", className);
+            showInterfaceMessage = true;
             if (contract.silent) {
               self.logger.trace(message);
             } else {
@@ -396,6 +398,9 @@ class ContractsManager {
             }
             contract.deploy = false;
           }
+        }
+        if (showInterfaceMessage) {
+          self.logger.warn(__('To get more details on interface contracts, go here: %s', 'https://embark.status.im/docs/troubleshooting.html#Assuming-Contract-to-be-an-interface'.underline));
         }
         callback();
       },

--- a/packages/embark-test-runner/src/test.js
+++ b/packages/embark-test-runner/src/test.js
@@ -216,6 +216,7 @@ class Test {
         console.info('Compiling contracts'.cyan);
         self.events.request("contracts:build", false, (err) => {
           self.firstDeployment = false;
+          console.info('Compilation done\n'.cyan);
           next(err);
         });
       },

--- a/site/source/docs/troubleshooting.md
+++ b/site/source/docs/troubleshooting.md
@@ -18,7 +18,7 @@ Issues typically occur if NodeJS and/or Embark are installed using `sudo`, avoid
 
 ## Assuming Contract to be an interface
 
-This warning happens when Embark can't deploy one of your contracts because the compiler did not return a bytecode.
+This warning happens when Embark can't deploy one of your Smart Contracts because the compiler did not return a bytecode.
 
 Here are some of the reasons:
 - If it inherits from an interface, it must have all the functions implemented

--- a/site/source/docs/troubleshooting.md
+++ b/site/source/docs/troubleshooting.md
@@ -16,3 +16,10 @@ If you still have problems and are on Windows, try the following:
 
 Issues typically occur if NodeJS and/or Embark are installed using `sudo`, avoid using it possible. There are [several options](https://docs.npmjs.com/getting-started/fixing-npm-permissions) to fix this. We recommend installing node using [NVM](https://github.com/creationix/nvm/blob/master/README.md)
 
+## Assuming Contract to be an interface
+
+This warning happens when Embark can't deploy one of your contracts because the compiler did not return a bytecode.
+
+Here are some of the reasons:
+- If it inherits from an interface, it must have all the functions implemented
+- The contract's constructor must be `public`


### PR DESCRIPTION
Add docs on how to troubleshoot interface contract and show a message containing a link to that when that warning appears.
Also, show the warning in tests, because before it didn't appear at all, but only show it if the contract was in configs, because otherwise it would flood the user