### PR TITLE
fix(@embark/core): move process.on inside ProcessWrapper's constructor

### DIFF
--- a/packages/embark-contracts-manager/src/index.js
+++ b/packages/embark-contracts-manager/src/index.js
@@ -621,7 +621,6 @@ class ContractsManager {
       this.logger.error(__("there are two or more contracts that depend on each other in a cyclic manner").bold.red);
       this.logger.error(__("Embark couldn't determine which one to deploy first").red);
       throw new Error("CyclicDependencyError");
-      //process.exit(0);
     }
 
     return contractList.sort(function (a, b) {

--- a/packages/embark-core/src/processes/processWrapper.js
+++ b/packages/embark-core/src/processes/processWrapper.js
@@ -31,7 +31,7 @@ export class ProcessWrapper {
     function error() {
       if (self.retries > 2) {
           self.kill();
-          process.exit();
+          process.exit(1);
       }
       self.retries++;
     }

--- a/packages/embark-core/src/processes/processWrapper.js
+++ b/packages/embark-core/src/processes/processWrapper.js
@@ -1,11 +1,6 @@
 import { Events } from './eventsWrapper';
 const constants = require('../../constants');
 
-process.on('uncaughtException', function(e) {
-  process.send({error: e.stack});
-});
-
-
 export class ProcessWrapper {
 
   /**
@@ -16,6 +11,9 @@ export class ProcessWrapper {
    * @param {Options}     options    pingParent: true by default
    */
   constructor(options = {}) {
+    process.on('uncaughtException', function(e) {
+      process.send({error: e.stack});
+    });
     this.options = Object.assign({pingParent: true}, options);
     this.interceptLogs();
     this.events = new Events();
@@ -83,7 +81,3 @@ export class ProcessWrapper {
     console.log('Process killed');
   }
 }
-
-process.on('exit', () => {
-  process.exit(0);
-});

--- a/packages/embark-test-runner/src/index.js
+++ b/packages/embark-test-runner/src/index.js
@@ -167,7 +167,7 @@ class TestRunner {
         let deprecatedWarning = function () {
           self.logger.error(__('%s are not supported anymore', 'EmbarkSpec & deployAll').red);
           self.logger.error(__('You can learn about the new revamped tests here: %s', 'https://embark.status.im/docs/testing.html'.underline));
-          if(!options.inProcess) process.exit();
+          if(!options.inProcess) process.exit(1);
         };
 
         global.deployAll = deprecatedWarning;

--- a/packages/embark/src/cmd/cmd_controller.js
+++ b/packages/embark/src/cmd/cmd_controller.js
@@ -259,7 +259,7 @@ class EmbarkController {
       }
       // TODO: this should be moved out and determined somewhere else
       if (canExit || !engine.config.contractsConfig.afterDeploy || !engine.config.contractsConfig.afterDeploy.length) {
-        process.exit();
+        process.exit(err ? 1 : 0);
       }
       engine.logger.info(__('Waiting for after deploy to finish...'));
       engine.logger.info(__('You can exit with CTRL+C when after deploy completes'));
@@ -406,7 +406,7 @@ class EmbarkController {
           engine.logger.info(__("Done. %s generated", options.output).underline);
         });
       }
-      process.exit();
+      process.exit(err ? 1 : 0);
     });
 
   }
@@ -519,7 +519,7 @@ class EmbarkController {
       }
       engine.logger.info(__("finished generating the UI").underline);
       engine.logger.info(__("To see the result, execute {{cmd}} and go to /{{contract}}.html", {cmd: 'embark run'.underline, contract: options.contract}));
-      process.exit();
+      process.exit(0);
     });
   }
 
@@ -610,7 +610,7 @@ class EmbarkController {
       if (err) {
         if (err.message) {
           engine.logger.error(err.message);
-          return engine.logger.debug(err.stack);
+          engine.logger.debug(err.stack);
         }
         engine.logger.error(err);
       } else {
@@ -618,7 +618,7 @@ class EmbarkController {
       }
 
       // needed due to child processes
-      process.exit();
+      process.exit(err ? 1 : 0);
     });
   }
 

--- a/packages/embark/src/cmd/dashboard/repl.js
+++ b/packages/embark/src/cmd/dashboard/repl.js
@@ -112,7 +112,7 @@ class REPL {
     });
 
     this.replServer.on("exit", () => {
-      process.exit();
+      process.exit(0);
     });
 
     done();

--- a/packages/embark/src/lib/modules/blockchain_process/blockchain.js
+++ b/packages/embark/src/lib/modules/blockchain_process/blockchain.js
@@ -470,7 +470,7 @@ var BlockchainClient = function(userConfig, clientName, env, certOptions, onRead
       break;
     default:
       console.error(__('Unknown client "%s". Please use one of the following: %s', userConfig.ethereumClientName, Object.keys(constants.blockchain.clients).join(', ')));
-      process.exit();
+      process.exit(1);
   }
   userConfig.isDev = (userConfig.isDev || userConfig.default);
   userConfig.env = env;

--- a/packages/embark/src/test/accountParser.js
+++ b/packages/embark/src/test/accountParser.js
@@ -13,7 +13,6 @@ describe('embark.AccountParser', function () {
     let web3;
     let testLogger;
     let isHexStrictStub;
-
     before(() => {
       testLogger = new TestLogger({});
       web3 = {
@@ -26,7 +25,6 @@ describe('embark.AccountParser', function () {
         }
       };
       isHexStrictStub = sinon.stub(Web3.utils, 'isHexStrict').returns(true);
-      // Web3.utils.isHexStrict = sinon.stub().returns(true);
     });
 
     after(() => {
@@ -38,18 +36,21 @@ describe('embark.AccountParser', function () {
         privateKey: 'myKey'
       }, web3, fs.dappPath(), testLogger);
 
-      assert.deepEqual(account, {key: Buffer.from('myKey', 'hex'), hexBalance: null});
+      assert.deepEqual(account, {key: '0xmyKey', hexBalance: null});
     });
 
     it('should return two accounts from the keys in the file', function () {
+      const sameFs = require('fs');
+      const readFileSyncStub = sinon.stub(sameFs, 'readFileSync').returns('key1;key2');
       const account = AccountParser.getAccount({
         privateKeyFile: 'keyFiles/twoKeys'
       }, web3, fs.dappPath(), testLogger);
 
       assert.deepEqual(account, [
-        {key: Buffer.from('key1', 'hex'), hexBalance: null},
-        {key: Buffer.from('key2', 'hex'), hexBalance: null}
+        {key:'0xkey1', hexBalance: null},
+        {key: '0xkey2', hexBalance: null}
       ]);
+      readFileSyncStub.restore();
     });
 
     it('should return one account from the mnemonic', function () {


### PR DESCRIPTION
This avoids mistakenly placing process event handlers on the parent process whenever the `embark-core` package is loaded. Also, don't listen for an `'exit'` event on `process` and then call `process.exit(0)` since the event "is emitted after the child process ends" ([docs][docs]), i.e. it's unnecessary to do so and in any case it's not correct to always exit with code `0`.

[docs]: https://nodejs.org/docs/latest-v10.x/api/child_process.html#child_process_event_exit

---

Intended to work together with #1604, though doesn't strictly depend on it.