### PR TITLE
fix(@embark/blockchain-process): fix bug that fs wasn't available

### DIFF
--- a/packages/embark-api/package.json
+++ b/packages/embark-api/package.json
@@ -44,6 +44,7 @@
     "@babel/runtime-corejs2": "7.3.1",
     "colors": "1.3.2",
     "embark-async-wrapper": "^4.0.0",
+    "embark-core": "^4.1.0-beta.0",
     "embark-i18n": "^4.1.0-beta.0",
     "embark-utils": "^4.1.0-beta.0"
   },

--- a/packages/embark-api/src/server.ts
+++ b/packages/embark-api/src/server.ts
@@ -2,6 +2,7 @@ import bodyParser from "body-parser";
 import "colors";
 import cors from "cors";
 import {Embark, Plugins} /* supplied by @types/embark in packages/embark-typings */ from "embark";
+import { embarkPath } from "embark-core";
 import { __ } from "embark-i18n";
 import express, {NextFunction, Request, Response} from "express";
 import expressWs from "express-ws";
@@ -29,7 +30,7 @@ export default class Server {
 
   constructor(private embark: Embark, private port: number, private hostname: string, private plugins: Plugins) {
     this.expressInstance = this.initApp();
-    this.embarkUiBuildDir = (findUp.sync("node_modules/embark-ui/build", {cwd: embark.fs.embarkPath()}) || embark.fs.embarkPath("node_modules/embark-ui/build"));
+    this.embarkUiBuildDir = (findUp.sync("node_modules/embark-ui/build", {cwd: embarkPath()}) || embarkPath("node_modules/embark-ui/build"));
   }
 
   public enableLogging() {
@@ -42,16 +43,16 @@ export default class Server {
 
   private get isInsideMonorepo() {
     if (this._isInsideMonorepo === null) {
-      this._isInsideMonorepo = this.embark.fs.existsSync(this.embark.fs.embarkPath("../../packages/embark")) &&
-        this.embark.fs.existsSync(this.embark.fs.embarkPath("../../lerna.json")) &&
-        path.resolve(this.embark.fs.embarkPath("../../packages/embark")) === this.embark.fs.embarkPath();
+      this._isInsideMonorepo = this.embark.fs.existsSync(embarkPath("../../packages/embark")) &&
+        this.embark.fs.existsSync(embarkPath("../../lerna.json")) &&
+        path.resolve(embarkPath("../../packages/embark")) === embarkPath();
     }
     return this._isInsideMonorepo;
   }
 
   private get monorepoRootDir() {
     if (!this._monorepoRootDir && this.isInsideMonorepo) {
-      this._monorepoRootDir = path.resolve(this.embark.fs.embarkPath("../.."));
+      this._monorepoRootDir = path.resolve(embarkPath("../.."));
     }
     return this._monorepoRootDir;
   }

--- a/packages/embark-blockchain-connector/src/index.js
+++ b/packages/embark-blockchain-connector/src/index.js
@@ -1,3 +1,4 @@
+import { dappPath } from 'embark-core';
 import { __ } from 'embark-i18n';
 const Web3 = require('web3');
 const async = require('async');
@@ -30,7 +31,7 @@ class BlockchainConnector {
     this.contractsSubscriptions = [];
     this.contractsEvents = [];
     this.fs = embark.fs;
-    this.logFile = this.fs.dappPath(".embark", "contractEvents.json");
+    this.logFile = dappPath(".embark", "contractEvents.json");
 
     this.writeLogFile = async.cargo((tasks, callback) => {
       const data = this._readEvents();

--- a/packages/embark-blockchain-connector/src/provider.js
+++ b/packages/embark-blockchain-connector/src/provider.js
@@ -1,3 +1,4 @@
+import { dappPath } from 'embark-core';
 import { __ } from 'embark-i18n';
 const async = require('async');
 const { AccountParser } = require('embark-utils');
@@ -16,7 +17,6 @@ class Provider {
     this.logger = options.logger;
     this.isDev = options.isDev;
     this.events = options.events;
-    this.fs = options.fs;
     this.nonceCache = {};
 
     this.events.setCommandHandler("blockchain:provider:contract:accounts:get", cb => {
@@ -72,11 +72,11 @@ class Provider {
         self.logger.warn('Error while getting the node\'s accounts.', err.message || err);
       }
 
-      self.blockchainAccounts = AccountParser.parseAccountsConfig(self.blockchainConfig.accounts, self.web3, this.fs.dappPath(), self.logger, accounts);
+      self.blockchainAccounts = AccountParser.parseAccountsConfig(self.blockchainConfig.accounts, self.web3, dappPath(), self.logger, accounts);
 
       accounts = accounts.concat(self.blockchainAccounts);
 
-      self.accounts = AccountParser.parseAccountsConfig(self.accountsConfig, self.web3, this.fs.dappPath(), self.logger, accounts);
+      self.accounts = AccountParser.parseAccountsConfig(self.accountsConfig, self.web3, dappPath(), self.logger, accounts);
 
       if (!self.accounts.length) {
         self.accounts = accounts;

--- a/packages/embark-blockchain-listener/src/index.js
+++ b/packages/embark-blockchain-listener/src/index.js
@@ -1,3 +1,4 @@
+import { dappPath } from 'embark-core';
 import { __ } from 'embark-i18n';
 const async = require('async');
 const DevTxs = require('./dev_txs');
@@ -29,7 +30,7 @@ class BlockchainListener {
     this.isDev = this.embark.config.env === constants.environments.development;
     this.devTxs = null;
     this.fs = this.embark.fs;
-    this.proxyLogFile = this.fs.dappPath(".embark", "proxyLogs.json");
+    this.proxyLogFile = dappPath(".embark", "proxyLogs.json");
 
     this.writeProxyLogFile = async.cargo((tasks, callback) => {
       const data = this._readProxyLogs();

--- a/packages/embark-blockchain-process/package.json
+++ b/packages/embark-blockchain-process/package.json
@@ -54,6 +54,7 @@
     "embark-utils": "^4.1.0-beta.0",
     "ethereumjs-tx": "1.3.7",
     "ethereumjs-util": "6.0.0",
+    "fs-extra": "7.0.1",
     "http-proxy": "1.17.0",
     "netcat": "1.3.5",
     "node-http-proxy-json": "0.1.6",

--- a/packages/embark-blockchain-process/src/blockchainProcess.js
+++ b/packages/embark-blockchain-process/src/blockchainProcess.js
@@ -13,7 +13,6 @@ class BlockchainProcess extends ProcessWrapper {
     this.env = options.env;
     this.isDev = options.isDev;
     this.certOptions = options.certOptions;
-    this.embark = options.embark;
 
     i18n.setOrDetectLocale(options.locale);
 
@@ -26,8 +25,7 @@ class BlockchainProcess extends ProcessWrapper {
         certOptions: this.certOptions,
         onReadyCallback: this.blockchainReady.bind(this),
         onExitCallback: this.blockchainExit.bind(this),
-        logger: console,
-        fs: this.embark.fs
+        logger: console
       }
     );
 

--- a/packages/embark-blockchain-process/src/blockchainProcessLauncher.js
+++ b/packages/embark-blockchain-process/src/blockchainProcessLauncher.js
@@ -28,9 +28,9 @@ export class BlockchainProcessLauncher {
       modulePath: joinPath(__dirname, './blockchainProcess.js'),
       logger: this.logger,
       events: this.events,
-      embark: this.embark,
       silent: this.logger.logLevel !== 'trace',
-      exitCallback: this.processEnded.bind(this)
+      exitCallback: this.processEnded.bind(this),
+      embark: this.embark
     });
     this.blockchainProcess.send({
       action: constants.blockchain.init, options: {

--- a/packages/embark-blockchain-process/src/gethClient.js
+++ b/packages/embark-blockchain-process/src/gethClient.js
@@ -1,4 +1,5 @@
 import { __ } from 'embark-i18n';
+import { dappPath, ipcPath } from 'embark-core';
 const async = require('async');
 const {exec, spawn} = require('child_process');
 const path = require('path');
@@ -34,7 +35,6 @@ class GethClient {
     this.versSupported = DEFAULTS.VERSIONS_SUPPORTED;
     this.httpReady = false;
     this.wsReady = !this.config.wsRPC;
-    this.fs = options.fs;
   }
 
   isReady(data) {
@@ -79,7 +79,7 @@ class GethClient {
     }
 
     if (config.account && config.account.password) {
-      const resolvedPath = path.resolve(this.fs.dappPath(), config.account.password);
+      const resolvedPath = path.resolve(dappPath(), config.account.password);
       cmd.push(`--password=${resolvedPath}`);
     }
 
@@ -87,13 +87,13 @@ class GethClient {
       cmd.push("--verbosity=" + config.verbosity);
     }
 
-    cmd.push(`--ipcpath=${this.fs.ipcPath('geth.ipc', true)}`);
+    cmd.push(`--ipcpath=${ipcPath('geth.ipc', true)}`);
 
     return cmd;
   }
 
   getMiner() {
-    return new GethMiner({datadir: this.config.datadir, fs: this.fs});
+    return new GethMiner({datadir: this.config.datadir});
   }
 
   getBinaryPath() {

--- a/packages/embark-blockchain-process/src/miner.js
+++ b/packages/embark-blockchain-process/src/miner.js
@@ -1,6 +1,8 @@
 const async = require('async');
 const NetcatClient = require('netcat/client');
 
+import { ipcPath } from 'embark-core';
+
 //Constants
 const minerStart = 'miner_start';
 const minerStop = 'miner_stop';
@@ -19,7 +21,6 @@ class GethMiner {
     // In the meantime, just set an empty config object
     this.config = {};
     this.datadir = options.datadir;
-    this.fs = options.fs;
     self.interval = null;
     self.callback = null;
     self.started = null;
@@ -44,10 +45,8 @@ class GethMiner {
       }
     }
 
-    const ipcPath = this.fs.ipcPath('geth.ipc', true);
-
     this.client = new NetcatClient();
-    this.client.unixSocket(ipcPath)
+    this.client.unixSocket(ipcPath('geth.ipc', true))
       .enc('utf8')
       .connect()
       .on('data', (response) => {

--- a/packages/embark-blockchain-process/src/parityClient.js
+++ b/packages/embark-blockchain-process/src/parityClient.js
@@ -1,4 +1,6 @@
 import { __ } from 'embark-i18n';
+import { dappPath } from 'embark-core';
+import * as fs from 'fs-extra';
 const async = require('async');
 const path = require('path');
 const os = require('os');
@@ -52,7 +54,6 @@ class ParityClient {
     this.prettyName = "Parity-Ethereum (https://github.com/paritytech/parity-ethereum)";
     this.bin = this.config.ethereumClientBin || DEFAULTS.BIN;
     this.versSupported = DEFAULTS.VERSIONS_SUPPORTED;
-    this.fs = options.fs;
   }
 
   isReady(data) {
@@ -262,7 +263,7 @@ class ParityClient {
     const keysDataDir = datadir + '/keys/DevelopmentChain';
     async.waterfall([
       function makeDir(next) {
-        this.fs.mkdirp(keysDataDir, (err, _result) => {
+        fs.mkdirp(keysDataDir, (err, _result) => {
           next(err);
         });
       },
@@ -270,7 +271,7 @@ class ParityClient {
         self.createDevAccount(keysDataDir, next);
       },
       function mkDevPasswordDir(next) {
-        this.fs.mkdirp(path.dirname(self.config.account.devPassword), (err, _result) => {
+        fs.mkdirp(path.dirname(self.config.account.devPassword), (err, _result) => {
           next(err);
         });
       },
@@ -278,12 +279,12 @@ class ParityClient {
         if (!self.config.account.password) {
           return next(null, os.EOL + 'dev_password');
         }
-        this.fs.readFile(this.fs.dappPath(self.config.account.password), {encoding: 'utf8'}, (err, content) => {
+        fs.readFile(dappPath(self.config.account.password), {encoding: 'utf8'}, (err, content) => {
           next(err, os.EOL + content);
         });
       },
       function updatePasswordFile(passwordList, next) {
-        this.fs.writeFile(self.config.account.devPassword, passwordList, next);
+        fs.writeFile(self.config.account.devPassword, passwordList, next);
       }
     ], (err) => {
       callback(err);
@@ -292,7 +293,7 @@ class ParityClient {
 
   createDevAccount(keysDataDir, cb) {
     const devAccountWallet = keysDataDir + '/dev.wallet';
-    this.fs.writeFile(devAccountWallet, JSON.stringify(DEFAULTS.DEV_WALLET), function(err) {
+    fs.writeFile(devAccountWallet, JSON.stringify(DEFAULTS.DEV_WALLET), function(err) {
       if (err) {
         return cb(err);
       }

--- a/packages/embark-blockchain-process/src/simulator.js
+++ b/packages/embark-blockchain-process/src/simulator.js
@@ -2,7 +2,7 @@ const path = require('path');
 const pkgUp = require('pkg-up');
 let shelljs = require('shelljs');
 import { Proxy } from './proxy';
-import { IPC } from 'embark-core';
+import { IPC, embarkPath, dappPath } from 'embark-core';
 const constants = require('embark-core/constants');
 import { defaultHost, dockerHostSwap } from 'embark-utils';
 const { AccountParser } = require('embark-utils');
@@ -12,7 +12,6 @@ export class Simulator {
     this.blockchainConfig = options.blockchainConfig;
     this.contractsConfig = options.contractsConfig;
     this.logger = options.logger;
-    this.fs = options.fs;
   }
 
   /*eslint complexity: ["error", 25]*/
@@ -44,7 +43,7 @@ export class Simulator {
     let simulatorAccounts = this.blockchainConfig.simulatorAccounts || options.simulatorAccounts;
     if (simulatorAccounts && simulatorAccounts.length > 0) {
       let web3 = new (require('web3'))();
-      let parsedAccounts = AccountParser.parseAccountsConfig(simulatorAccounts, web3, this.fs.dappPath(), this.logger);
+      let parsedAccounts = AccountParser.parseAccountsConfig(simulatorAccounts, web3, dappPath(), this.logger);
       parsedAccounts.forEach((account) => {
         let cmd = '--account="' + account.privateKey + ','+account.hexBalance + '"';
         cmds.push(cmd);
@@ -68,7 +67,7 @@ export class Simulator {
   }
 
   runCommand(cmds, useProxy, host, port) {
-    const ganache_main = require.resolve('ganache-cli', {paths: [this.fs.embarkPath('node_modules')]});
+    const ganache_main = require.resolve('ganache-cli', {paths: [embarkPath('node_modules')]});
     const ganache_json = pkgUp.sync(path.dirname(ganache_main));
     const ganache_root = path.dirname(ganache_json);
     const ganache_bin = require(ganache_json).bin;
@@ -86,7 +85,7 @@ export class Simulator {
     shelljs.exec(`node ${program} ${cmds.join(' ')}`, {async : true});
 
     if(useProxy){
-      let ipcObject = new IPC({ipcRole: 'client', fs: this.fs});
+      let ipcObject = new IPC({ipcRole: 'client'});
       if (this.blockchainConfig.wsRPC) {
         return new Proxy(ipcObject).serve(host, port, true, this.blockchainConfig.wsOrigins, []);
       }

--- a/packages/embark-blockchain-process/src/utils.js
+++ b/packages/embark-blockchain-process/src/utils.js
@@ -55,4 +55,3 @@ export function pingEndpoint(host, port, type, protocol, origin, callback) {
     handleRequest(req, "abort", "response");
   }
 }
-

--- a/packages/embark-code-generator/package.json
+++ b/packages/embark-code-generator/package.json
@@ -52,7 +52,8 @@
     "ejs": "2.6.1",
     "embark-core": "^4.1.0-beta.0",
     "embark-i18n": "^4.1.0-beta.0",
-    "embark-utils": "^4.1.0-beta.0"
+    "embark-utils": "^4.1.0-beta.0",
+    "fs-extra": "7.0.1"
   },
   "devDependencies": {
     "@babel/cli": "7.2.3",

--- a/packages/embark-console-listener/src/index.js
+++ b/packages/embark-console-listener/src/index.js
@@ -1,4 +1,5 @@
 const async = require('async');
+import { dappPath } from 'embark-core';
 import { __ } from 'embark-i18n';
 import { getAddressToContract, getTransactionParams, hexToNumber } from 'embark-utils';
 
@@ -13,7 +14,7 @@ class ConsoleListener {
     this.contractsConfig = embark.config.contractsConfig;
     this.contractsDeployed = false;
     this.outputDone = false;
-    this.logFile = this.fs.dappPath(".embark", "contractLogs.json");
+    this.logFile = dappPath(".embark", "contractLogs.json");
 
     if (this.ipc.ipcRole === 'server') {
       this._listenForLogRequests();

--- a/packages/embark-console/src/lib/index.ts
+++ b/packages/embark-console/src/lib/index.ts
@@ -1,6 +1,7 @@
 import { waterfall } from "async";
 import chalk from "chalk";
 import { Callback, Embark, Events } /* supplied by @types/embark in packages/embark-typings */ from "embark";
+import { dappPath } from "embark-core";
 import constants from "embark-core/constants.json";
 import { __ } from "embark-i18n";
 import { escapeHtml, exit, jsonFunctionReplacer } from "embark-utils";
@@ -39,7 +40,7 @@ class Console {
     this.ipc = options.ipc;
     this.config = options.config;
     this.history = [];
-    this.cmdHistoryFile = options.cmdHistoryFile || this.fs.dappPath(".embark", "cmd_history");
+    this.cmdHistoryFile = options.cmdHistoryFile || dappPath(".embark", "cmd_history");
     this.providerReady = false;
     this.loadHistory();
 

--- a/packages/embark-contracts-manager/src/index.js
+++ b/packages/embark-contracts-manager/src/index.js
@@ -1,3 +1,4 @@
+import { dappPath } from 'embark-core';
 import { __ } from 'embark-i18n';
 const async = require('async');
 const cloneDeep = require('clone-deep');
@@ -321,7 +322,7 @@ class ContractsManager {
             return eachCb();
           }
 
-          self.fs.readFile(self.fs.dappPath(contract.artifact), (err, artifactBuf) => {
+          self.fs.readFile(dappPath(contract.artifact), (err, artifactBuf) => {
             if (err) {
               self.logger.error(__('Error while reading the artifact for "{{className}}" at {{path}}', {className, path: contract.artifact}));
               return eachCb(err);
@@ -359,7 +360,7 @@ class ContractsManager {
           contract.abiDefinition = compiledContract.abiDefinition;
           contract.filename = compiledContract.filename;
           contract.originalFilename = compiledContract.originalFilename || ("contracts/" + contract.filename);
-          contract.path = self.fs.dappPath(contract.originalFilename);
+          contract.path = dappPath(contract.originalFilename);
 
           contract.gas = (contractConfig && contractConfig.gas) || self.contractsConfig.gas || 'auto';
 

--- a/packages/embark-core/index.d.ts
+++ b/packages/embark-core/index.d.ts
@@ -1,0 +1,5 @@
+declare module "embark-core" {
+  function dappPath(...names: string[]): string;
+  function embarkPath(...names: string[]): string;
+  function ipcPath(basename: string, usePipePathOnWindows?: boolean): string;
+}

--- a/packages/embark-core/package.json
+++ b/packages/embark-core/package.json
@@ -49,6 +49,7 @@
   "dependencies": {
     "@babel/runtime-corejs2": "7.3.1",
     "embark-i18n": "^4.1.0-beta.0",
+    "embark-utils": "^4.1.0-beta.0",
     "flatted": "0.2.3",
     "node-ipc": "9.1.1"
   },

--- a/packages/embark-core/src/index.js
+++ b/packages/embark-core/src/index.js
@@ -3,3 +3,5 @@ export { ProcessManager } from './processes/processManager';
 export { ProcessWrapper } from './processes/processWrapper';
 
 export { IPC } from './ipc';
+
+export { embarkPath, dappPath, ipcPath } from './utils';

--- a/packages/embark-core/src/ipc.js
+++ b/packages/embark-core/src/ipc.js
@@ -3,17 +3,18 @@
 const ipc = require('node-ipc');
 const {parse, stringify} = require('flatted/cjs');
 const path = require('path');
+const fs = require('fs-extra');
+import { ipcPath } from './utils';
 
 const EMBARK = 'embark';
 
 export class IPC {
   constructor(options) {
     this.logger = options.logger;
-    this.socketPath = options.socketPath || options.fs.ipcPath('embark.ipc');
+    this.socketPath = options.socketPath || ipcPath('embark.ipc');
     this.ipcRole = options.ipcRole;
     ipc.config.silent = true;
     this.connected = false;
-    this.fs = options.fs;
   }
 
   get client() {
@@ -55,7 +56,7 @@ export class IPC {
   }
 
   serve() {
-    this.fs.mkdirpSync(path.dirname(this.socketPath));
+    fs.mkdirpSync(path.dirname(this.socketPath));
     ipc.serve(this.socketPath, () => {});
     this.server.start();
 

--- a/packages/embark-core/src/utils.js
+++ b/packages/embark-core/src/utils.js
@@ -1,0 +1,28 @@
+import * as path from 'path';
+import {joinPath, sha512, tmpDir} from 'embark-utils';
+
+export function dappPath(...names) {
+  const DAPP_PATH = process.env.DAPP_PATH || process.cwd();
+  return path.join(DAPP_PATH, ...names);
+}
+
+export function ipcPath(basename, usePipePathOnWindows = false) {
+  if (!(basename && typeof basename === 'string')) {
+    throw new TypeError('first argument must be a non-empty string');
+  }
+  if (process.platform === 'win32' && usePipePathOnWindows) {
+    return `\\\\.\\pipe\\${basename}`;
+  }
+  return joinPath(
+    tmpDir(`embark-${sha512(dappPath()).slice(0, 8)}`),
+    basename
+  );
+}
+
+export function embarkPath(...names) {
+  const EMBARK_PATH = process.env.EMBARK_PATH;
+  if (!EMBARK_PATH) {
+    throw new Error('environment variable EMBARK_PATH was not set');
+  }
+  return path.join(EMBARK_PATH, ...names);
+}

--- a/packages/embark-library-manager/package.json
+++ b/packages/embark-library-manager/package.json
@@ -48,6 +48,7 @@
   "dependencies": {
     "@babel/runtime-corejs2": "7.3.1",
     "colors": "1.3.2",
+    "embark-core": "^4.1.0-beta.0",
     "embark-i18n": "^4.1.0-beta.0",
     "live-plugin-manager-git-fix": "0.12.1"
   },

--- a/packages/embark-library-manager/src/index.js
+++ b/packages/embark-library-manager/src/index.js
@@ -1,3 +1,4 @@
+import { dappPath, embarkPath } from 'embark-core';
 import { __ } from 'embark-i18n';
 var Npm = require('./npm.js');
 
@@ -83,13 +84,13 @@ class LibraryManager {
     const wantedVersion = this.versions[packageName];
     let installedVersion = this.embark.config.package.dependencies[packageName];
     if (!wantedVersion || wantedVersion === installedVersion) {
-      const nodePath = this.embark.fs.embarkPath('node_modules');
+      const nodePath = embarkPath('node_modules');
       const packagePath = require.resolve(packageName, {paths: [nodePath]});
       return cb(null, packagePath.replace(/\\/g, '/'));
     }
     // Download package
     this.embark.events.request("version:getPackageLocation", packageName, wantedVersion, (err, location) => {
-      cb(err, this.embark.fs.dappPath(location).replace(/\\/g, '/'));
+      cb(err, dappPath(location).replace(/\\/g, '/'));
     });
   }
 

--- a/packages/embark-scaffolding/package.json
+++ b/packages/embark-scaffolding/package.json
@@ -42,6 +42,7 @@
   },
   "dependencies": {
     "@babel/runtime-corejs2": "7.3.1",
+    "embark-core": "^4.1.0-beta.0",
     "embark-i18n": "^4.1.0-beta.0",
     "embark-utils": "^4.1.0-beta.0"
   },

--- a/packages/embark-scaffolding/src/builder.ts
+++ b/packages/embark-scaffolding/src/builder.ts
@@ -1,3 +1,3 @@
 export interface Builder {
-  build(): Promise<string[]>;
+  build(): Promise<Array<(string| undefined)>>;
 }

--- a/packages/embark-scaffolding/src/contractLanguage/solidityBuilder/index.ts
+++ b/packages/embark-scaffolding/src/contractLanguage/solidityBuilder/index.ts
@@ -1,4 +1,5 @@
 import { Embark } /* supplied by @types/embark in packages/embark-typings */ from "embark";
+import { dappPath } from "embark-core";
 import { __ } from "embark-i18n";
 import Handlebars from "handlebars";
 import * as path from "path";
@@ -48,7 +49,7 @@ export class SolidityBuilder implements Builder {
     const filename = `${contractName}.sol`;
     const contractDirs = this.embark.config.embarkConfig.contracts;
     const contractDir = Array.isArray(contractDirs) ? contractDirs[0] : contractDirs;
-    const filePath = this.embark.fs.dappPath(contractDir.replace(/\*/g, ""), filename);
+    const filePath = dappPath(contractDir.replace(/\*/g, ""), filename);
     if (!this.options.overwrite && this.embark.fs.existsSync(filePath)) {
       this.embark.logger.error(__(`The contract ${contractName} already exists, skipping.`));
       return;

--- a/packages/embark-scaffolding/src/framework/reactBuilder/index.ts
+++ b/packages/embark-scaffolding/src/framework/reactBuilder/index.ts
@@ -1,4 +1,5 @@
 import { Contract, Embark } /* supplied by @types/embark in packages/embark-typings */ from "embark";
+import { dappPath } from "embark-core";
 import { __ } from "embark-i18n";
 import Handlebars from "handlebars";
 import * as path from "path";
@@ -45,7 +46,7 @@ export class ReactBuilder implements Builder {
   }
 
   private updateEmbarkJson(contractName: string, files: string[]) {
-    const embarkJsonPath = path.join(this.embark.fs.dappPath(), "embark.json");
+    const embarkJsonPath = path.join(dappPath(), "embark.json");
     const embarkJson = this.embark.fs.readJSONSync(embarkJsonPath);
     embarkJson.app[`js/${contractName}.js`] = `app/${contractName}.js`;
     embarkJson.app[`${contractName}.html`] = `app/${contractName}.html`;
@@ -128,8 +129,8 @@ export class ReactBuilder implements Builder {
   }
 
   private saveFiles(contractName: string, indexCode: string, dappCode: string) {
-    const indexFilePath = path.join(this.embark.fs.dappPath(), "app", `${contractName}.html`);
-    const dappFilePath = path.join(this.embark.fs.dappPath(), "app", `${contractName}.js`);
+    const indexFilePath = path.join(dappPath(), "app", `${contractName}.html`);
+    const dappFilePath = path.join(dappPath(), "app", `${contractName}.js`);
 
     if (!this.options.overwrite && (this.embark.fs.existsSync(indexFilePath) || this.embark.fs.existsSync(dappFilePath))) {
       return [];

--- a/packages/embark-scaffolding/src/index.ts
+++ b/packages/embark-scaffolding/src/index.ts
@@ -7,7 +7,7 @@ import { SmartContractsRecipe } from "./smartContractsRecipe";
 export default class Scaffolding {
 
   constructor(private embark: Embark, private options: any) {
-    this.embark.events.setCommandHandler("scaffolding:generate:contract", (cmdLineOptions: any,  cb: (files: string[]) => void) => {
+    this.embark.events.setCommandHandler("scaffolding:generate:contract", (cmdLineOptions: any,  cb: (files: Array<(string|undefined)>) => void) => {
       this.generateContract(cmdLineOptions).then(cb);
     });
 

--- a/packages/embark-solidity/src/solcW.js
+++ b/packages/embark-solidity/src/solcW.js
@@ -1,5 +1,5 @@
 import { __ } from 'embark-i18n';
-import { ProcessLauncher } from 'embark-core';
+import { dappPath, ProcessLauncher } from 'embark-core';
 import {joinPath} from 'embark-utils';
 const uuid = require('uuid/v1');
 
@@ -58,7 +58,7 @@ class SolcW {
           if (err) {
             return done(err);
           }
-          let requirePath = self.embark.fs.dappPath(path);
+          let requirePath = dappPath(path);
           self.solcProcess.send({action: 'installAndLoadCompiler', solcVersion: solcVersion, packagePath: requirePath});
         });
       });

--- a/packages/embark-test-runner/package.json
+++ b/packages/embark-test-runner/package.json
@@ -48,6 +48,7 @@
   "dependencies": {
     "@babel/runtime-corejs2": "7.3.1",
     "async": "2.6.1",
+    "embark-core": "^4.1.0-beta.0",
     "embark-i18n": "^4.1.0-beta.0",
     "embark-utils": "^4.1.0-beta.0",
     "mocha": "5.2.0"

--- a/packages/embark-test-runner/src/index.js
+++ b/packages/embark-test-runner/src/index.js
@@ -1,3 +1,4 @@
+import { dappPath, embarkPath } from 'embark-core';
 import { __ } from 'embark-i18n';
 const async = require('async');
 const Mocha = require('mocha');
@@ -85,18 +86,18 @@ class TestRunner {
         }
 
         global.embark.events.emit('tests:finished', function() {
-          runCmd(`${self.fs.embarkPath('node_modules/.bin/istanbul')} report --root .embark --format html --format lcov`,
+          runCmd(`${embarkPath('node_modules/.bin/istanbul')} report --root .embark --format html --format lcov`,
             {silent: false, exitOnError: false}, (err) => {
               if (err) {
                 return next(err);
               }
-              console.info(`Coverage report created. You can find it here: ${self.fs.dappPath('coverage/index.html')}\n`);
+              console.info(`Coverage report created. You can find it here: ${dappPath('coverage/index.html')}\n`);
               const opn = require('opn');
               const _next = () => { next(null, results); };
               if (options.noBrowser) {
                 return next(null, results);
               }
-              opn(self.fs.dappPath('coverage/index.html'), {wait: false})
+              opn(dappPath('coverage/index.html'), {wait: false})
                 .then(() => timer(1000))
                 .then(_next, _next);
             });
@@ -157,7 +158,7 @@ class TestRunner {
   runJSTests(files, options, cb) {
     const self = this;
     const test = new Test({loglevel: options.loglevel, node: options.node, events: self.events, logger: self.logger,
-      config: self.embark.config, ipc: self.ipc, coverage: options.coverage, inProcess: options.inProcess, dappPath: this.embark.fs.dappPath()});
+      config: self.embark.config, ipc: self.ipc, coverage: options.coverage, inProcess: options.inProcess, dappPath: dappPath()});
     async.waterfall([
       function setupGlobalNamespace(next) {
         global.embark = test;

--- a/packages/embark-utils/src/index.js
+++ b/packages/embark-utils/src/index.js
@@ -1,3 +1,5 @@
+const path = require('path');
+const os = require('os');
 const http = require('follow-redirects').http;
 const https = require('follow-redirects').https;
 const shelljs = require('shelljs');
@@ -218,14 +220,17 @@ function buildUrlFromConfig(configObj) {
   return buildUrl(configObj.protocol, canonicalHost(configObj.host), configObj.port, configObj.type);
 }
 
+function joinPath() {
+  return path.join.apply(path.join, arguments);
+}
+
+function tmpDir(...args) { return joinPath(os.tmpdir(), ...args); }
 
 const Utils = {
   buildUrl,
   buildUrlFromConfig,
-  joinPath: function() {
-    const path = require('path');
-    return path.join.apply(path.join, arguments);
-  },
+  joinPath,
+  tmpDir,
   jsonFunctionReplacer,
   fuzzySearch,
   canonicalHost,

--- a/packages/embark-watcher/package.json
+++ b/packages/embark-watcher/package.json
@@ -47,6 +47,7 @@
   },
   "dependencies": {
     "@babel/runtime-corejs2": "7.3.1",
+    "embark-core": "^4.1.0-beta.0",
     "embark-i18n": "^4.1.0-beta.0",
     "chokidar": "2.0.4"
   },

--- a/packages/embark-watcher/src/index.js
+++ b/packages/embark-watcher/src/index.js
@@ -1,3 +1,4 @@
+import { dappPath } from 'embark-core';
 import { __ } from 'embark-i18n';
 let chokidar = require('chokidar');
 let path = require('path');
@@ -164,14 +165,14 @@ class Watcher {
 
   watchPipelineConfig(embarkConfig, callback) {
     let filesToWatch = [
-      this.fs.dappPath('', DAPP_WEBPACK_CONFIG_FILE),
-      this.fs.dappPath('', DAPP_BABEL_LOADER_OVERRIDES_CONFIG_FILE)
+      dappPath('', DAPP_WEBPACK_CONFIG_FILE),
+      dappPath('', DAPP_BABEL_LOADER_OVERRIDES_CONFIG_FILE)
     ];
 
     if (typeof embarkConfig.config === 'object' && embarkConfig.config.pipeline) {
       filesToWatch.push(embarkConfig.config.pipeline);
     } else if (typeof embarkConfig.config === 'string') {
-      filesToWatch.push(this.fs.dappPath(embarkConfig.config, DAPP_PIPELINE_CONFIG_FILE));
+      filesToWatch.push(dappPath(embarkConfig.config, DAPP_PIPELINE_CONFIG_FILE));
     }
 
     this.watchFiles(filesToWatch, (eventName, path) => {

--- a/packages/embark-webserver/src/server.js
+++ b/packages/embark-webserver/src/server.js
@@ -1,3 +1,4 @@
+import { dappPath } from 'embark-core';
 const async = require('async');
 let serveStatic = require('serve-static');
 import { __ } from 'embark-i18n';
@@ -50,8 +51,8 @@ class Server {
       return callback(null, message);
     }
 
-    const coverage = serveStatic(this.fs.dappPath('coverage/__root__/'), {'index': ['index.html', 'index.htm']});
-    const coverageStyle = serveStatic(this.fs.dappPath('coverage/'));
+    const coverage = serveStatic(dappPath('coverage/__root__/'), {'index': ['index.html', 'index.htm']});
+    const coverageStyle = serveStatic(dappPath('coverage/'));
     const main = serveStatic(this.buildDir, {'index': ['index.html', 'index.htm']});
 
     this.app = express();
@@ -72,7 +73,7 @@ class Server {
     this.app.use('/coverage', coverage);
     this.app.use(coverageStyle);
 
-    this.app.use(express.static(path.join(this.fs.dappPath(this.dist)), {'index': ['index.html', 'index.htm']}));
+    this.app.use(express.static(path.join(dappPath(this.dist)), {'index': ['index.html', 'index.htm']}));
 
     this.app.ws('/', () => {});
     const wss = expressWs.getWss('/');
@@ -92,7 +93,7 @@ class Server {
     if (this.enableCatchAll === true) {
       this.app.get('/*', function(req, res) {
         self.logger.trace('webserver> GET ' + req.path);
-        res.sendFile(path.join(self.fs.dappPath(self.dist, 'index.html')));
+        res.sendFile(path.join(dappPath(self.dist, 'index.html')));
       });
     }
 

--- a/packages/embark/src/cmd/cmd_controller.js
+++ b/packages/embark/src/cmd/cmd_controller.js
@@ -1,4 +1,5 @@
 import { BlockchainClient, Simulator } from 'embark-blockchain-process';
+import { dappPath, embarkPath } from 'embark-core';
 import { __ } from 'embark-i18n';
 let async = require('async');
 const constants = require('embark-core/constants');
@@ -420,7 +421,7 @@ class EmbarkController {
   }
 
   async reset(options) {
-    const embarkConfig = require(fs.dappPath(options.embarkConfig || 'embark.json'));
+    const embarkConfig = require(dappPath(options.embarkConfig || 'embark.json'));
 
     let removePaths = [];
     let defaultPaths = [...defaultResetPaths];
@@ -449,13 +450,13 @@ class EmbarkController {
   }
 
   ejectWebpack() {
-    var embarkConfig = fs.embarkPath('dist/lib/modules/pipeline/webpack.config.js');
-    var dappConfig = fs.dappPath('webpack.config.js');
+    var embarkConfig = embarkPath('dist/lib/modules/pipeline/webpack.config.js');
+    var dappConfig = dappPath('webpack.config.js');
     fs.copyPreserve(embarkConfig, dappConfig);
     console.log(__('webpack config ejected to:').dim.yellow);
     console.log(`${dappConfig}`.green);
-    var embarkOverrides = fs.embarkPath('dist/lib/modules/pipeline/babel-loader-overrides.js');
-    var dappOverrides = fs.dappPath('babel-loader-overrides.js');
+    var embarkOverrides = embarkPath('dist/lib/modules/pipeline/babel-loader-overrides.js');
+    var dappOverrides = dappPath('babel-loader-overrides.js');
     fs.copyPreserve(embarkOverrides, dappOverrides);
     console.log(__('webpack overrides ejected to:').dim.yellow);
     console.log(`${dappOverrides}`.green);

--- a/packages/embark/src/lib/core/config.js
+++ b/packages/embark/src/lib/core/config.js
@@ -5,6 +5,7 @@ const path = require('path');
 const deepEqual = require('deep-equal');
 const web3 = require('web3');
 const constants = require('embark-core/constants');
+import { dappPath } from 'embark-core';
 import { __ } from 'embark-i18n';
 import {
   buildUrlFromConfig,
@@ -89,7 +90,7 @@ var Config = function(options) {
 };
 
 // TODO remove this at some point as it is now in plugin
-Config.prototype.dappPath = fs.dappPath;
+Config.prototype.dappPath = dappPath;
 
 Config.prototype.loadConfigFiles = function(options) {
   var interceptLogs = options.interceptLogs;
@@ -248,9 +249,9 @@ Config.prototype._mergeConfig = function(configFilePath, defaultConfig, env, ena
 
 Config.prototype._getFileOrObject = function(object, filePath, property) {
   if (typeof object === 'object') {
-    return object[property] ? fs.dappPath(object[property]) : object[property];
+    return object[property] ? dappPath(object[property]) : object[property];
   }
-  return fs.dappPath(object, filePath);
+  return dappPath(object, filePath);
 };
 
 Config.prototype.loadBlockchainConfigFile = function() {
@@ -573,7 +574,7 @@ Config.prototype.loadPipelineConfigFile = function() {
   if (pipelineConfigPath !== undefined) {
     // At this point, `pipelineConfigPath` could be either `config/pipeline` or a filepath including its extension.
     // We need to make sure that we always have an extension.
-    pipelineConfigPath = `${fs.dappPath(pipelineConfigPath)}${path.extname(pipelineConfigPath) === '.js' ? '' : '.js'}`;
+    pipelineConfigPath = `${dappPath(pipelineConfigPath)}${path.extname(pipelineConfigPath) === '.js' ? '' : '.js'}`;
   }
 
   let pipelineConfig = defaultPipelineConfig;

--- a/packages/embark/src/lib/core/engine.js
+++ b/packages/embark/src/lib/core/engine.js
@@ -1,6 +1,5 @@
 import { __ } from 'embark-i18n';
 import { ProcessManager, IPC } from 'embark-core';
-const fs = require('./fs');
 const async = require('async');
 
 const utils = require('../utils/utils');
@@ -42,7 +41,7 @@ class Engine {
       utils.interceptLogs(console, this.logger);
     }
 
-    this.ipc = new IPC({logger: this.logger, ipcRole: this.ipcRole, fs});
+    this.ipc = new IPC({logger: this.logger, ipcRole: this.ipcRole});
     if (this.ipc.isClient()) {
       return this.ipc.connect((_err) => {
         callback();

--- a/packages/embark/src/lib/core/file.ts
+++ b/packages/embark/src/lib/core/file.ts
@@ -1,3 +1,4 @@
+import { dappPath, embarkPath } from "embark-core";
 import { __ } from "embark-i18n";
 import * as path from "path";
 import { ImportRemapping, prepareForCompilation } from "../utils/solidity/remapImports";
@@ -35,14 +36,14 @@ export class File {
     this.originalPath = options.originalPath || "";
 
     if (this.type === Types.custom && this.pluginPath) {
-      this.path = path.join(this.pluginPath, options.path).replace(fs.dappPath(), "");
+      this.path = path.join(this.pluginPath, options.path).replace(dappPath(), "");
       if (this.path.startsWith("/")) {
         this.path = this.path.substring(1);
       }
     } else if (this.type === Types.http) {
       const external = utils.getExternalContractUrl(options.externalUrl, this.providerUrl);
       this.externalUrl = external.url;
-      this.path = path.normalize(fs.dappPath(external.filePath));
+      this.path = path.normalize(dappPath(external.filePath));
     } else {
       this.path = path.normalize(options.path);
     }
@@ -59,7 +60,7 @@ export class File {
     return new Promise<string>((resolve) => {
       switch (this.type) {
         case Types.embarkInternal: {
-          const content = fs.readFileSync(fs.embarkPath(path.join("dist", this.path)), "utf-8");
+          const content = fs.readFileSync(embarkPath(path.join("dist", this.path)), "utf-8");
           return resolve(content);
         }
 

--- a/packages/embark/src/lib/core/plugin.js
+++ b/packages/embark/src/lib/core/plugin.js
@@ -1,8 +1,9 @@
 const utils = require('../utils/utils.js');
+import { dappPath, embarkPath } from 'embark-core';
 import { __ } from 'embark-i18n';
 import {joinPath} from 'embark-utils';
 const constants = require('embark-core/constants');
-const fs = require('./fs.js');
+const fs = require('fs-extra');
 const deepEqual = require('deep-equal');
 
 // TODO: pass other params like blockchainConfig, contract files, etc..
@@ -33,6 +34,7 @@ var Plugin = function(options) {
   this.embarkjs_code = [];
   this.embarkjs_init_code = {};
   this.embarkjs_init_console_code = {};
+  this.fs = fs;
   this.afterContractsDeployActions = [];
   this.onDeployActions = [];
   this.eventActions = {};
@@ -41,7 +43,6 @@ var Plugin = function(options) {
   this.events = options.events;
   this.config = options.config;
   this.plugins = options.plugins;
-  this.fs = options.fs;
   this.env = options.env;
   this.loaded = false;
   this.currentContext = options.context;
@@ -57,8 +58,8 @@ var Plugin = function(options) {
   }
 };
 
-Plugin.prototype.dappPath = fs.dappPath;
-Plugin.prototype.embarkPath = fs.embarkPath;
+Plugin.prototype.dappPath = dappPath;
+Plugin.prototype.embarkPath = embarkPath;
 
 Plugin.prototype._log = function(type) {
   this._loggerObject[type](this.name + ':', ...[].slice.call(arguments, 1));
@@ -117,7 +118,7 @@ Plugin.prototype.loadInternalPlugin = function() {
 };
 
 Plugin.prototype.loadPluginFile = function(filename) {
-  return this.fs.readFileSync(this.pathToFile(filename)).toString();
+  return fs.readFileSync(this.pathToFile(filename)).toString();
 };
 
 Plugin.prototype.pathToFile = function(filename) {

--- a/packages/embark/src/lib/core/plugins.js
+++ b/packages/embark/src/lib/core/plugins.js
@@ -1,3 +1,4 @@
+import { dappPath, embarkPath } from 'embark-core';
 const async = require('async');
 var Plugin = require('./plugin.js');
 var fs = require('../core/fs.js');
@@ -60,7 +61,7 @@ Plugins.prototype.loadInternalPlugin = function(pluginName, pluginConfig, isPack
     pluginPath = pluginName;
     plugin = require(pluginName);
   } else {
-    pluginPath = this.fs.embarkPath('dist/lib/modules/' + pluginName);
+    pluginPath = embarkPath('dist/lib/modules/' + pluginName);
     plugin = require(pluginPath);
   }
 
@@ -88,7 +89,7 @@ Plugins.prototype.loadInternalPlugin = function(pluginName, pluginConfig, isPack
 };
 
 Plugins.prototype.loadPlugin = function(pluginName, pluginConfig) {
-  let pluginPath = this.fs.dappPath('node_modules', pluginName);
+  let pluginPath = dappPath('node_modules', pluginName);
   let plugin = require(pluginPath);
 
   if (plugin.default) {

--- a/packages/embark/src/lib/modules/coverage/index.ts
+++ b/packages/embark/src/lib/modules/coverage/index.ts
@@ -1,3 +1,4 @@
+import { dappPath } from "embark-core";
 import * as globule from "globule";
 import * as path from "path";
 import Web3Contract from "web3/eth/contract";
@@ -68,8 +69,8 @@ export default class Coverage {
   }
 
   private writeCoverageReport(cb: () => void) {
-    this.fs.ensureDirSync(path.join(this.fs.dappPath(), ".embark"));
-    const coveragePath = path.join(this.fs.dappPath(), ".embark", "coverage.json");
+    this.fs.ensureDirSync(path.join(dappPath(), ".embark"));
+    const coveragePath = path.join(dappPath(), ".embark", "coverage.json");
 
     const coverageReport = this.contracts.reduce((acc: {[name: string]: ICoverage}, contract) => {
       if (contract.source) {

--- a/packages/embark/src/lib/modules/deploytracker/index.js
+++ b/packages/embark/src/lib/modules/deploytracker/index.js
@@ -1,5 +1,7 @@
+import { dappPath } from 'embark-core';
 import { __ } from 'embark-i18n';
 import { sha3 } from 'embark-utils';
+import * as fs from 'fs-extra';
 
 class DeployTracker {
 
@@ -7,7 +9,6 @@ class DeployTracker {
     this.logger = embark.logger;
     this.events = embark.events;
     this.embark = embark;
-    this.fs = embark.fs;
     this.trackContracts = (options.trackContracts !== false);
 
     // TODO: unclear where it comes from
@@ -21,13 +22,13 @@ class DeployTracker {
   loadChainTrackerFile() {
     if (this.chainFile === false) return;
     if (this.chainFile === undefined) this.chainFile = ".embark/chains.json";
-    this.chainFile = this.fs.dappPath(this.chainFile);
-    if (!this.fs.existsSync(this.chainFile)) {
+    this.chainFile = dappPath(this.chainFile);
+    if (!fs.existsSync(this.chainFile)) {
       this.logger.info(this.chainFile + ' ' + __('file not found, creating it...'));
-      this.fs.outputJSONSync(this.chainFile, {});
+      fs.outputJSONSync(this.chainFile, {});
     }
 
-    this.chainConfig = this.fs.readJSONSync(this.chainFile);
+    this.chainConfig = fs.readJSONSync(this.chainFile);
   }
 
   registerEvents() {
@@ -109,7 +110,7 @@ class DeployTracker {
     if (this.chainConfig === false) {
       return;
     }
-    this.fs.writeJSONSync(this.chainFile, this.chainConfig, {spaces: 2});
+    fs.writeJSONSync(this.chainFile, this.chainConfig, {spaces: 2});
   }
 
 }

--- a/packages/embark/src/lib/modules/ipfs/index.js
+++ b/packages/embark/src/lib/modules/ipfs/index.js
@@ -1,3 +1,4 @@
+import { dappPath, embarkPath } from 'embark-core';
 import { __ } from 'embark-i18n';
 const UploadIPFS = require('./upload.js');
 const utils = require('../../utils/utils.js');
@@ -68,12 +69,12 @@ class IPFS {
     this.events.request("version:get:ipfs-api", (ipfsApiVersion) => {
       let currentIpfsApiVersion = require('../../../../package.json').dependencies["ipfs-api"];
       if (ipfsApiVersion === currentIpfsApiVersion) {
-        const nodePath = this.fs.embarkPath('node_modules');
+        const nodePath = embarkPath('node_modules');
         const ipfsPath = require.resolve("ipfs-api", {paths: [nodePath]});
         return cb(null, ipfsPath);
       }
       this.events.request("version:getPackageLocation", "ipfs-api", ipfsApiVersion, (err, location) => {
-        cb(err, this.fs.dappPath(location));
+        cb(err, dappPath(location));
       });
     });
   }

--- a/packages/embark/src/lib/modules/pipeline/webpackConfigReader.js
+++ b/packages/embark/src/lib/modules/pipeline/webpackConfigReader.js
@@ -1,5 +1,6 @@
+import { dappPath, embarkPath } from 'embark-core';
 const {errorMessage} = require('../../utils/utils');
-const fs = require('../../core/fs');
+const fs = require('fs-extra');
 
 class WebpackConfigReader {
   constructor(options) {
@@ -7,8 +8,8 @@ class WebpackConfigReader {
   }
 
   async readConfig(callback){
-    const dappConfigPath = fs.dappPath('webpack.config.js');
-    const defaultConfigPath = fs.embarkPath('dist/lib/modules/pipeline', 'webpack.config.js');
+    const dappConfigPath = dappPath('webpack.config.js');
+    const defaultConfigPath = embarkPath('dist/lib/modules/pipeline', 'webpack.config.js');
 
     let config, configPath;
     try {

--- a/packages/embark/src/lib/modules/pipeline/webpackProcess.js
+++ b/packages/embark/src/lib/modules/pipeline/webpackProcess.js
@@ -1,6 +1,5 @@
-import { ProcessWrapper } from 'embark-core';
+import { dappPath, ProcessWrapper } from 'embark-core';
 const constants = require('embark-core/constants');
-const fs = require('../../core/fs');
 const webpack = require('webpack');
 const writeFile = require('util').promisify(require('fs').writeFile);
 const {errorMessage} = require('../../utils/utils');
@@ -26,15 +25,15 @@ class WebpackProcess extends ProcessWrapper {
   async webpackRun(assets, importsList, callback) {
     try {
       await writeFile(
-        fs.dappPath('.embark/embark-aliases.json'),
+        dappPath('.embark/embark-aliases.json'),
         JSON.stringify(importsList)
       );
       await writeFile(
-        fs.dappPath('.embark/embark-assets.json'),
+        dappPath('.embark/embark-assets.json'),
         JSON.stringify(assets)
       );
       await writeFile(
-        fs.dappPath('.embark/embark-pipeline.json'),
+        dappPath('.embark/embark-pipeline.json'),
         JSON.stringify(this.pipelineConfig)
       );
     } catch (e) {
@@ -67,12 +66,12 @@ class WebpackProcess extends ProcessWrapper {
     try {
       this._log('info', 'Pipeline: '.cyan + 'writing file ' + ('.embark/stats.report').bold.dim);
       await writeFile(
-        fs.dappPath('.embark/stats.report'),
+        dappPath('.embark/stats.report'),
         stats.toString(config.stats)
       );
       this._log('info', 'Pipeline: '.cyan + 'writing file ' + ('.embark/stats.json').bold.dim);
       await writeFile(
-        fs.dappPath('.embark/stats.json'),
+        dappPath('.embark/stats.json'),
         JSON.stringify(stats.toJson(config.stats))
       );
       if (stats.hasErrors()) {

--- a/packages/embark/src/lib/modules/swarm/process.js
+++ b/packages/embark/src/lib/modules/swarm/process.js
@@ -1,7 +1,6 @@
-import { ProcessWrapper } from 'embark-core';
+import { dappPath, ProcessWrapper } from 'embark-core';
 const child_process = require('child_process');
 const constants = require('embark-core/constants');
-const fs = require('../../core/fs');
 
 let swarmProcess;
 
@@ -22,7 +21,7 @@ class SwarmProcess extends ProcessWrapper {
     // use our storage config address/password if we have it
     if (this.storageConfig.account && this.storageConfig.account.address && this.storageConfig.account.password) {
       bzzaccount = this.storageConfig.account.address;
-      password = fs.dappPath(this.storageConfig.account.password);
+      password = dappPath(this.storageConfig.account.password);
     }
     // default to our blockchain config account, or our default account
     else if (this.blockchainConfig.account &&
@@ -33,14 +32,14 @@ class SwarmProcess extends ProcessWrapper {
       // config/blockchain.js > account > address or the first address returned from web3.eth.getAccounts
       // (usually the default account)
       bzzaccount = this.blockchainConfig.account.address || this.defaultAccount;
-      password = fs.dappPath(this.blockchainConfig.account.password);
+      password = dappPath(this.blockchainConfig.account.password);
       console.trace(`Swarm account/password falling back to the blockchain account ${this.blockchainConfig.account.address || this.defaultAccount}. The account is either specified in config/blockchain.js > account > address or is the first address returned from web3.eth.getAccounts. The password is specified in config/blockchain.js > account > address.`);
     }
     else {
       return 'Account address and password are needed in the storage config to start the Swarm process';
     }
 
-    const datadir = this.blockchainConfig.datadir || fs.dappPath(`.embark/development/datadir`);
+    const datadir = this.blockchainConfig.datadir || dappPath(`.embark/development/datadir`);
     const args = [
       '--datadir', datadir,
       '--bzzaccount', bzzaccount,

--- a/packages/embark/src/lib/utils/solidity/remapImports.ts
+++ b/packages/embark/src/lib/utils/solidity/remapImports.ts
@@ -1,3 +1,4 @@
+import { dappPath, embarkPath } from "embark-core";
 import * as path from "path";
 import { File, Types } from "../../core/file";
 import { removePureView, replacePureView } from "./code";
@@ -36,13 +37,13 @@ const prepareInitialFile = async (file: File) => {
     return await file.content;
   }
 
-  const to = file.path.includes(fs.dappPath(".embark")) ? path.normalize(file.path) : fs.dappPath(".embark", file.path);
+  const to = file.path.includes(dappPath(".embark")) ? path.normalize(file.path) : dappPath(".embark", file.path);
   if (file.type === Types.dappFile || file.type === Types.custom) {
     if (file.resolver) {
       fs.mkdirpSync(path.dirname(to));
       fs.writeFileSync(to, await file.content);
     } else {
-      const from = file.path.includes(fs.dappPath()) ? file.path : fs.dappPath(file.path);
+      const from = file.path.includes(dappPath()) ? file.path : dappPath(file.path);
       if (from !== to) {
         fs.copySync(from, to);
       }
@@ -73,7 +74,7 @@ const buildNewFile = (file: File, importPath: string) => {
   // imported from node_modules, ie import "@aragon/os/contracts/acl/ACL.sol"
   if (isUnresolvedNodeModule(importPath)) {
     from = resolve(importPath);
-    to = importPath.includes(fs.dappPath(".embark")) ? importPath : fs.dappPath(".embark", "node_modules", importPath);
+    to = importPath.includes(dappPath(".embark")) ? importPath : dappPath(".embark", "node_modules", importPath);
     if (from !== to) {
       fs.copySync(from, to);
     }
@@ -100,7 +101,7 @@ const buildNewFile = (file: File, importPath: string) => {
   } else {
     from = path.join(path.dirname(file.path.replace(".embark", ".")), importPath);
     if (importPath === "remix_tests.sol") {
-      to = fs.dappPath(".embark", "remix_tests.sol");
+      to = dappPath(".embark", "remix_tests.sol");
     } else {
       to = path.join(path.dirname(file.path), importPath);
       fs.copySync(from, to);
@@ -177,7 +178,7 @@ const addRemappingsToFile = (file: File, remapImports: RemapImport[]) => {
 
 const resolve = (input: string) => {
   try {
-    return require.resolve(input, { paths: [fs.dappPath("node_modules"), fs.embarkPath("node_modules")] });
+    return require.resolve(input, { paths: [dappPath("node_modules"), embarkPath("node_modules")] });
   } catch (e) {
     return "";
   }
@@ -201,6 +202,6 @@ export const prepareForCompilation = async (file: File, isCoverage = false) => {
     return content;
   }
 
-  removePureView(fs.dappPath(".embark"));
+  removePureView(dappPath(".embark"));
   return replacePureView(content);
 };

--- a/packages/embark/src/lib/utils/template_generator.js
+++ b/packages/embark/src/lib/utils/template_generator.js
@@ -1,3 +1,4 @@
+import { embarkPath } from 'embark-core';
 import { __ } from 'embark-i18n';
 const findUp = require('find-up');
 const fs = require('../core/fs.js');
@@ -110,7 +111,7 @@ class TemplateGenerator {
         this.monorepoRootPath, 'dapps/templates', this.templateName
       );
     } else {
-      const version = fs.readJSONSync(fs.embarkPath('package.json')).version;
+      const version = fs.readJSONSync(embarkPath('package.json')).version;
       templateSpecifier = `${templatePkg}@^${version}`;
     }
 
@@ -145,10 +146,10 @@ class TemplateGenerator {
     if (this._monorepoRootPath === undefined) {
       let monorepoRootPath = null;
       const maybeMonorepoRootPath = fs.existsSync(
-        fs.embarkPath('../../packages/embark')
+        embarkPath('../../packages/embark')
       );
       if (maybeMonorepoRootPath) {
-        const lernaJsonPath = findUp.sync('lerna.json', {cwd: fs.embarkPath()});
+        const lernaJsonPath = findUp.sync('lerna.json', {cwd: embarkPath()});
         if (lernaJsonPath) {
           monorepoRootPath = utils.dirname(lernaJsonPath);
         }

--- a/packages/embark/src/test/accountParser.js
+++ b/packages/embark/src/test/accountParser.js
@@ -1,4 +1,5 @@
 /*global __dirname, describe, it, before, after, require*/
+import { dappPath } from 'embark-core';
 import * as i18n from 'embark-i18n';
 const assert = require('assert');
 const sinon = require('sinon');
@@ -34,7 +35,7 @@ describe('embark.AccountParser', function () {
     it('should return one account with the key', function () {
       const account = AccountParser.getAccount({
         privateKey: 'myKey'
-      }, web3, fs.dappPath(), testLogger);
+      }, web3, dappPath(), testLogger);
 
       assert.deepEqual(account, {key: '0xmyKey', hexBalance: null});
     });
@@ -44,7 +45,7 @@ describe('embark.AccountParser', function () {
       const readFileSyncStub = sinon.stub(sameFs, 'readFileSync').returns('key1;key2');
       const account = AccountParser.getAccount({
         privateKeyFile: 'keyFiles/twoKeys'
-      }, web3, fs.dappPath(), testLogger);
+      }, web3, dappPath(), testLogger);
 
       assert.deepEqual(account, [
         {key:'0xkey1', hexBalance: null},
@@ -56,7 +57,7 @@ describe('embark.AccountParser', function () {
     it('should return one account from the mnemonic', function () {
       const account = AccountParser.getAccount({
         mnemonic: 'example exile argue silk regular smile grass bomb merge arm assist farm'
-      }, web3, fs.dappPath(), testLogger);
+      }, web3, dappPath(), testLogger);
 
       assert.deepEqual(account,
         [{key: "0xf942d5d524ec07158df4354402bfba8d928c99d0ab34d0799a6158d56156d986", hexBalance: null}]);
@@ -66,7 +67,7 @@ describe('embark.AccountParser', function () {
       const account = AccountParser.getAccount({
         mnemonic: 'example exile argue silk regular smile grass bomb merge arm assist farm',
         numAddresses: 2
-      }, web3, fs.dappPath(), testLogger);
+      }, web3, dappPath(), testLogger);
 
       assert.deepEqual(account,
         [
@@ -78,7 +79,7 @@ describe('embark.AccountParser', function () {
     it('should return nothing with bad config', function () {
       const account = AccountParser.getAccount({
         badConfig: 'not working'
-      }, web3, fs.dappPath(), testLogger);
+      }, web3, dappPath(), testLogger);
 
       assert.strictEqual(account, null);
     });
@@ -87,7 +88,7 @@ describe('embark.AccountParser', function () {
       const accounts = AccountParser.getAccount({
         mnemonic: 'example exile argue silk regular smile grass bomb merge arm assist farm',
         numAddresses: 2
-      }, false, fs.dappPath(), testLogger);
+      }, false, dappPath(), testLogger);
 
       assert.deepEqual(accounts,
         [
@@ -97,7 +98,7 @@ describe('embark.AccountParser', function () {
     });
 
     it('should return nodeAccounts', function() {
-      const accounts = AccountParser.getAccount({nodeAccounts: true}, web3, fs.dappPath(), testLogger, [
+      const accounts = AccountParser.getAccount({nodeAccounts: true}, web3, dappPath(), testLogger, [
         "0xb8d851486d1c953e31a44374aca11151d49b8bb3",
         "0xf6d5c6d500cac10ee7e6efb5c1b479cfb789950a"
       ]);

--- a/packages/embark/src/test/blockchain.js
+++ b/packages/embark/src/test/blockchain.js
@@ -1,5 +1,6 @@
 /*globals describe, it*/
 import { BlockchainClient } from 'embark-blockchain-process';
+import { dappPath } from 'embark-core';
 const constants = require('embark-core/constants');
 import {defaultHost} from 'embark-utils';
 const path = require('path');
@@ -19,7 +20,7 @@ describe('embark.Blockchain', function() {
           genesisBlock: false,
           ethereumClientName: 'geth',
           ethereumClientBin: 'geth',
-          datadir: fs.dappPath(".embark/development/datadir"),
+          datadir: dappPath(".embark/development/datadir"),
           mineWhenNeeded: false,
           rpcHost: defaultHost,
           rpcPort: 8545,

--- a/packages/embark/src/test/config.js
+++ b/packages/embark/src/test/config.js
@@ -1,4 +1,5 @@
 /*globals describe, it*/
+const { dappPath } = require('embark-core');
 const Config = require('../lib/core/config.js');
 const Plugins = require('../lib/core/plugins.js');
 const assert = require('assert');
@@ -192,7 +193,7 @@ describe('embark.Config', function () {
         {
           "type": "http",
           "externalUrl": "https://raw.githubusercontent.com/embark-framework/embark/master/dapps/templates/demo/contracts/simple_storage.sol",
-          "path": fs.dappPath(".embark/contracts/embark-framework/embark/master/dapps/templates/demo/contracts/simple_storage.sol"),
+          "path": dappPath(".embark/contracts/embark-framework/embark/master/dapps/templates/demo/contracts/simple_storage.sol"),
           "originalPath": ".embark/contracts/embark-framework/embark/master/dapps/templates/demo/contracts/simple_storage.sol",
           "pluginPath": '',
           "basedir": "",
@@ -204,7 +205,7 @@ describe('embark.Config', function () {
         {
           "type": "http",
           "externalUrl": "https://raw.githubusercontent.com/status-im/contracts/master/contracts/identity/ERC725.sol",
-          "path": fs.dappPath(".embark/contracts/status-im/contracts/master/contracts/identity/ERC725.sol"),
+          "path": dappPath(".embark/contracts/status-im/contracts/master/contracts/identity/ERC725.sol"),
           "originalPath": ".embark/contracts/status-im/contracts/master/contracts/identity/ERC725.sol",
           "pluginPath": '',
           "basedir": "",
@@ -215,7 +216,7 @@ describe('embark.Config', function () {
         },
         {
           "externalUrl": "https://swarm-gateways.net/bzz:/1ffe993abc835f480f688d07ad75ad1dbdbd1ddb368a08b7ed4d3e400771dd63",
-          "path": fs.dappPath(".embark/contracts/bzz:/1ffe993abc835f480f688d07ad75ad1dbdbd1ddb368a08b7ed4d3e400771dd63"),
+          "path": dappPath(".embark/contracts/bzz:/1ffe993abc835f480f688d07ad75ad1dbdbd1ddb368a08b7ed4d3e400771dd63"),
           "originalPath": ".embark/contracts/bzz:/1ffe993abc835f480f688d07ad75ad1dbdbd1ddb368a08b7ed4d3e400771dd63",
           "type": "http",
           "pluginPath": '',

--- a/packages/embark/src/test/contracts.js
+++ b/packages/embark/src/test/contracts.js
@@ -46,8 +46,7 @@ describe('embark.Contracts', function() {
       }
     });
     let ipcObject = new IPC({
-      ipcRole: 'none',
-      fs
+      ipcRole: 'none'
     });
     plugins.loadInternalPlugin('embark-solidity', {ipc: ipcObject}, true);
 
@@ -189,8 +188,7 @@ describe('embark.Contracts', function() {
       }
     });
     let ipcObject = new IPC({
-      ipcRole: 'none',
-      fs
+      ipcRole: 'none'
     });
     plugins.loadInternalPlugin('embark-solidity', {ipc: ipcObject}, true);
 

--- a/packages/embark/src/test/file.js
+++ b/packages/embark/src/test/file.js
@@ -1,4 +1,5 @@
 /*globals describe, it*/
+const { dappPath } = require('embark-core');
 const {File, Types} = require("../lib/core/file");
 const {expect} = require("chai");
 const fs = require("../lib/core/fs");
@@ -13,15 +14,15 @@ describe('embark.File', function () {
     });
 
     it('should be able to read a file when type is "dappFile"', async () => {
-      const file = new File({path: fs.dappPath('contracts/recursive_test_0.sol'), type: Types.dappFile});
+      const file = new File({path: dappPath('contracts/recursive_test_0.sol'), type: Types.dappFile});
       const content = await file.content;
 
-      const contentFromFileSystem = fs.readFileSync(fs.dappPath("contracts/recursive_test_0.sol")).toString();
+      const contentFromFileSystem = fs.readFileSync(dappPath("contracts/recursive_test_0.sol")).toString();
       expect(content).to.equal(contentFromFileSystem);
     });
 
     it('should be able to execute a resolver when type is "custom"', async () => {
-      const file = new File({path: fs.dappPath('contracts/recursive_test_0.sol'), type: Types.custom, resolver: (callback) => {
+      const file = new File({path: dappPath('contracts/recursive_test_0.sol'), type: Types.custom, resolver: (callback) => {
         callback("test");
       }});
       expect(await file.content).to.equal("test");
@@ -31,7 +32,7 @@ describe('embark.File', function () {
       const file = new File({path: 'test/contracts/recursive_test_0.sol', type: Types.embarkInternal});
       const content = await file.content;
 
-      const contentFromFileSystem = fs.readFileSync(fs.dappPath("contracts/recursive_test_0.sol")).toString();
+      const contentFromFileSystem = fs.readFileSync(dappPath("contracts/recursive_test_0.sol")).toString();
       expect(content).to.equal(contentFromFileSystem);
     });
 

--- a/packages/embark/src/test/modules/console_listener.js
+++ b/packages/embark/src/test/modules/console_listener.js
@@ -96,7 +96,7 @@ function resetTest() {
 
   events = new Events();
   logger = new Logger(events);
-  ipc = new IPC({ipcRole: 'none', fs});
+  ipc = new IPC({ipcRole: 'none'});
   embark = {
     events,
     logger,

--- a/packages/embark/src/test/modules/solidity/remapImports.js
+++ b/packages/embark/src/test/modules/solidity/remapImports.js
@@ -1,4 +1,5 @@
 /*globals describe, it, before*/
+const { dappPath } = require('embark-core');
 const {File, Types} = require("../../../lib/core/file");
 const path = require("path");
 const remapImports = require("../../../lib/utils/solidity/remapImports");
@@ -18,19 +19,19 @@ describe('embark.RemapImports', function () {
     it("should find and add remappings for all recursive imports", (done) => {
       expect(file.importRemappings[0]).to.deep.equal({
         prefix: "./recursive_test_1.sol",
-        target: path.normalize(fs.dappPath(".embark/contracts/recursive_test_1.sol"))
+        target: path.normalize(dappPath(".embark/contracts/recursive_test_1.sol"))
       });
       expect(file.importRemappings[1]).to.deep.equal({
         prefix: "./recursive_test_2.sol",
-        target: path.normalize(fs.dappPath(".embark/contracts/recursive_test_2.sol"))
+        target: path.normalize(dappPath(".embark/contracts/recursive_test_2.sol"))
       });
       expect(file.importRemappings[2]).to.deep.equal({
         prefix: "embark-test-contract-0/recursive_test_3.sol",
-        target: path.normalize(fs.dappPath(".embark/node_modules/embark-test-contract-0/recursive_test_3.sol"))
+        target: path.normalize(dappPath(".embark/node_modules/embark-test-contract-0/recursive_test_3.sol"))
       });
       expect(file.importRemappings[3]).to.deep.equal({
         prefix: "embark-test-contract-1/recursive_test_4.sol",
-        target: path.normalize(fs.dappPath(".embark/node_modules/embark-test-contract-1/recursive_test_4.sol"))
+        target: path.normalize(dappPath(".embark/node_modules/embark-test-contract-1/recursive_test_4.sol"))
       });
       done();
     });
@@ -39,22 +40,22 @@ describe('embark.RemapImports', function () {
       expect(content).to.not.contain("./recursive_test_1.sol");
       expect(content).to.contain(path.normalize(".embark/contracts/recursive_test_1.sol").replace(/\\/g, "/"));
 
-      let contractFromFilesystem = fsNode.readFileSync(fs.dappPath(".embark/contracts/recursive_test_0.sol")).toString();
+      let contractFromFilesystem = fsNode.readFileSync(dappPath(".embark/contracts/recursive_test_0.sol")).toString();
       expect(contractFromFilesystem).to.not.contain("./recursive_test_1.sol");
       expect(contractFromFilesystem).to.contain(path.normalize(".embark/contracts/recursive_test_1.sol").replace(/\\/g, "/"));
-      
-      contractFromFilesystem = fsNode.readFileSync(fs.dappPath(".embark/contracts/recursive_test_1.sol")).toString();
+
+      contractFromFilesystem = fsNode.readFileSync(dappPath(".embark/contracts/recursive_test_1.sol")).toString();
       expect(contractFromFilesystem).to.not.contain("./recursive_test_2.sol");
       expect(contractFromFilesystem).to.contain(path.normalize(".embark/contracts/recursive_test_2.sol").replace(/\\/g, "/"));
 
-      contractFromFilesystem = fsNode.readFileSync(fs.dappPath(".embark/contracts/recursive_test_2.sol")).toString();
+      contractFromFilesystem = fsNode.readFileSync(dappPath(".embark/contracts/recursive_test_2.sol")).toString();
       expect(contractFromFilesystem).to.not.contain("import \"embark-test-contract-0/recursive_test_3.sol\"");
-      expect(contractFromFilesystem).to.contain(`import "${path.normalize(fs.dappPath(".embark/node_modules/embark-test-contract-0/recursive_test_3.sol")).replace(/\\/g, "/")}"`);
-      
-      contractFromFilesystem = fsNode.readFileSync(fs.dappPath(".embark/node_modules/embark-test-contract-0/recursive_test_3.sol")).toString();
+      expect(contractFromFilesystem).to.contain(`import "${path.normalize(dappPath(".embark/node_modules/embark-test-contract-0/recursive_test_3.sol")).replace(/\\/g, "/")}"`);
+
+      contractFromFilesystem = fsNode.readFileSync(dappPath(".embark/node_modules/embark-test-contract-0/recursive_test_3.sol")).toString();
       expect(contractFromFilesystem).to.not.contain("import \"embark-test-contract-1/recursive_test_4.sol\"");
-      expect(contractFromFilesystem).to.contain(`import "${path.normalize(fs.dappPath(".embark/node_modules/embark-test-contract-1/recursive_test_4.sol")).replace(/\\/g, "/")}"`);
-      
+      expect(contractFromFilesystem).to.contain(`import "${path.normalize(dappPath(".embark/node_modules/embark-test-contract-1/recursive_test_4.sol")).replace(/\\/g, "/")}"`);
+
       done();
     });
 
@@ -69,15 +70,15 @@ describe('embark.RemapImports', function () {
     it("should find and add remappings for all recursive imports", (done) => {
       expect(file.importRemappings[0]).to.deep.equal({
         prefix: "./recursive_test_1.sol",
-        target: path.normalize(fs.dappPath(".embark/contracts/embark-framework/embark/master/packages/embark/src/test/contracts/recursive_test_1.sol"))
+        target: path.normalize(dappPath(".embark/contracts/embark-framework/embark/master/packages/embark/src/test/contracts/recursive_test_1.sol"))
       });
       expect(file.importRemappings[1]).to.deep.equal({
         prefix: "./recursive_test_2.sol",
-        target: path.normalize(fs.dappPath(".embark/contracts/embark-framework/embark/master/packages/embark/src/test/contracts/recursive_test_2.sol"))
+        target: path.normalize(dappPath(".embark/contracts/embark-framework/embark/master/packages/embark/src/test/contracts/recursive_test_2.sol"))
       });
       expect(file.importRemappings[2]).to.deep.equal({
         prefix: "embark-test-contract-0/recursive_test_3.sol",
-        target: path.normalize(fs.dappPath(".embark/contracts/embark-framework/embark/master/packages/embark/src/test/contracts/embark-test-contract-0/recursive_test_3.sol"))
+        target: path.normalize(dappPath(".embark/contracts/embark-framework/embark/master/packages/embark/src/test/contracts/embark-test-contract-0/recursive_test_3.sol"))
       });
       done();
     });
@@ -86,17 +87,17 @@ describe('embark.RemapImports', function () {
       expect(content).to.not.contain("./recursive_test_1.sol");
       expect(content).to.contain(path.normalize(".embark/contracts/embark-framework/embark/master/packages/embark/src/test/contracts/recursive_test_1.sol").replace(/\\/g, "/"));
 
-      let contractFromFilesystem = fsNode.readFileSync(fs.dappPath(".embark/contracts/embark-framework/embark/master/packages/embark/src/test/contracts/recursive_test_0.sol")).toString();
+      let contractFromFilesystem = fsNode.readFileSync(dappPath(".embark/contracts/embark-framework/embark/master/packages/embark/src/test/contracts/recursive_test_0.sol")).toString();
       expect(contractFromFilesystem).to.not.contain("./recursive_test_1.sol");
       expect(contractFromFilesystem).to.contain(path.normalize(".embark/contracts/embark-framework/embark/master/packages/embark/src/test/contracts/recursive_test_1.sol").replace(/\\/g, "/"));
-      
-      contractFromFilesystem = fsNode.readFileSync(fs.dappPath(".embark/contracts/embark-framework/embark/master/packages/embark/src/test/contracts/recursive_test_1.sol")).toString();
+
+      contractFromFilesystem = fsNode.readFileSync(dappPath(".embark/contracts/embark-framework/embark/master/packages/embark/src/test/contracts/recursive_test_1.sol")).toString();
       expect(contractFromFilesystem).to.not.contain("./recursive_test_2.sol");
       expect(contractFromFilesystem).to.contain(path.normalize(".embark/contracts/embark-framework/embark/master/packages/embark/src/test/contracts/recursive_test_2.sol").replace(/\\/g, "/"));
 
-      contractFromFilesystem = fsNode.readFileSync(fs.dappPath(".embark/contracts/embark-framework/embark/master/packages/embark/src/test/contracts/recursive_test_2.sol")).toString();
+      contractFromFilesystem = fsNode.readFileSync(dappPath(".embark/contracts/embark-framework/embark/master/packages/embark/src/test/contracts/recursive_test_2.sol")).toString();
       expect(contractFromFilesystem).to.not.contain("import \"embark-test-contract-0/recursive_test_3.sol\"");
-      expect(contractFromFilesystem).to.contain(`import "${path.normalize(fs.dappPath(".embark/contracts/embark-framework/embark/master/packages/embark/src/test/contracts/embark-test-contract-0/recursive_test_3.sol")).replace(/\\/g, "/")}"`);
+      expect(contractFromFilesystem).to.contain(`import "${path.normalize(dappPath(".embark/contracts/embark-framework/embark/master/packages/embark/src/test/contracts/embark-test-contract-0/recursive_test_3.sol")).replace(/\\/g, "/")}"`);
 
       done();
     });

--- a/packages/embark/src/test/modules/solidity/solidity.js
+++ b/packages/embark/src/test/modules/solidity/solidity.js
@@ -11,7 +11,6 @@ let readFile = function(file) {
 
 let ipcObject = new IPC({
   ipcRole: 'none',
-  fs
 });
 
 let generateApiObject = function() {

--- a/packages/embark/src/test/vm_fs.js
+++ b/packages/embark/src/test/vm_fs.js
@@ -1,4 +1,5 @@
 /*global after, before, describe, it, require, process*/
+const { embarkPath } = require('embark-core');
 const {assert} = require('chai');
 const os = require('os');
 const path = require('path');
@@ -14,7 +15,7 @@ describe('fs', () => {
   before(() => {
     oldConsoleError = console.error;
     oldDappPath = process.env.DAPP_PATH;
-    process.env.DAPP_PATH = fs.embarkPath();
+    process.env.DAPP_PATH = embarkPath();
     oldProcessExit = process.exit;
     process.exit = function() {};
 

--- a/packages/embarkjs-connector-web3/index.js
+++ b/packages/embarkjs-connector-web3/index.js
@@ -1,3 +1,4 @@
+const { dappPath, embarkPath } = require('embark-core');
 const path = require('path');
 
 class EmbarkJSConnectorWeb3 {
@@ -46,7 +47,7 @@ class EmbarkJSConnectorWeb3 {
     code += "\nEmbarkJS.Blockchain.registerProvider('web3', embarkJSConnectorWeb3);";
     code += "\nEmbarkJS.Blockchain.setProvider('web3', {});";
 
-    const configPath = this.fs.dappPath(this.config.embarkConfig.generationDir, this.constants.dappArtifacts.dir, this.constants.dappArtifacts.blockchain).replace(/\\/g, '/');
+    const configPath = dappPath(this.config.embarkConfig.generationDir, this.constants.dappArtifacts.dir, this.constants.dappArtifacts.blockchain).replace(/\\/g, '/');
 
     code += `\nif (!global.__Web3) {`; // Only connect when in the Dapp
     code += `\n  const web3ConnectionConfig = require('${configPath}');`;
@@ -76,7 +77,7 @@ class EmbarkJSConnectorWeb3 {
     return new Promise((resolve, reject) => {
       this.events.request("version:get:web3", (web3Version) => {
         if (web3Version === "1.0.0-beta") {
-          const nodePath = this.fs.embarkPath('node_modules');
+          const nodePath = embarkPath('node_modules');
           const web3Path = require.resolve("web3", {paths: [nodePath]});
           return resolve(web3Path);
         }
@@ -84,7 +85,7 @@ class EmbarkJSConnectorWeb3 {
           if (err) {
             return reject(err);
           }
-          const locationPath = this.fs.embarkPath(location);
+          const locationPath = embarkPath(location);
           resolve(locationPath);
         });
       });

--- a/packages/embarkjs-connector-web3/package.json
+++ b/packages/embarkjs-connector-web3/package.json
@@ -30,6 +30,9 @@
     "qa": "npm run package",
     "reset": "npx rimraf embark-*.tgz package"
   },
+  "dependencies": {
+    "embark-core": "^4.1.0-beta.0"
+  },
   "devDependencies": {
     "rimraf": "2.6.3"
   }


### PR DESCRIPTION
This commit remove the dependency on `embark.fs` in several places
and moves some APIs, such as `embarkPath()` and `dappPath()` into
embark-core.

The reason this is done is because we have several `*Process` instances
that are created through child process communication, specifically
`process.send()` APIs. Using those APIs, we can only send data structures
however, methods attached on any of those will get lost.

This is the case when sending `embark.fs` through `process.send()`.

We still need `fs` in those places though, mostly because they are relying
on `embarkPath` and `dappPath()`.

These places are now importing those functions from `embark-core`. Other
API such as `writeFile` or `mkdirp()` can be accessed through `fs-extra`
or `fs` modules.