### PR TITLE
build: add nohoist entry for bootstrap package relative to dapps/templates/demo

### DIFF
--- a/package.json
+++ b/package.json
@@ -80,6 +80,7 @@
       "embark/embark-test-contract-0",
       "embark/embark-test-contract-1",
       "embark-dapp-template-boilerplate/embarkjs-connector-web3",
+      "embark-dapp-template-demo/bootstrap",
       "embark-dapp-template-demo/embarkjs-connector-web3",
       "embark-dapp-template-simple/embarkjs-connector-web3",
       "embark-dapp-test-app/embark-dapp-test-service",


### PR DESCRIPTION
The demo's `embark.json` relies on the bootstrap package being within the demo's own `node_modules`, but in the monorepo yarn was hoisting it up to the root `node_modules`.