### PR TITLE
refactor(@embark/template_generator): use yarn to install template deps if embark cli is in monorepo

### DIFF
--- a/packages/embark/src/lib/utils/template_generator.js
+++ b/packages/embark/src/lib/utils/template_generator.js
@@ -226,9 +226,11 @@ class TemplateGenerator {
         }
       }
 
-      runCmd('npm install', {exitOnError: false}, (err) => {
+      const installCmd = this.monorepoRootPath ? 'yarn install' : 'npm install';
+
+      runCmd(installCmd, {exitOnError: false}, (err) => {
         if (err) {
-          console.error(__('Could not install dependencies. Try running `npm install` inside the project directory.').red);
+          console.error(__(`Could not install dependencies. Try running \`${installCmd}\` inside the project directory.`).red);
         }
         console.log(__('Init complete').green);
         console.log('\n' + __('App ready at ').green + templatePath);


### PR DESCRIPTION
If the `embark` cli is detected to be inside the monorepo, the template generator yarn-links any template deps that are part of the monorepo into the dapp. However, `embarkjs-connector-web3` now has a dependency on `embark-core`, which in turn has a dependency on `embark-i18n`. That causes `npm install` to fail inside the dapp because npm checks for deps of `embarkjs-connector-web3` relative to the dapp instead of checking relative to the symlink. `yarn install` does not suffer from that behavior so use it instead.