### PR TITLE
fix(@embark/pipeline): ensure color methods for logs are available

### DIFF
--- a/packages/embark-pipeline/package.json
+++ b/packages/embark-pipeline/package.json
@@ -48,6 +48,7 @@
   "dependencies": {
     "@babel/runtime-corejs2": "7.3.1",
     "async": "2.6.1",
+    "colors": "1.3.2",
     "embark-core": "^4.1.0-beta.1",
     "embark-i18n": "^4.1.0-beta.1",
     "embark-utils": "^4.1.0-beta.1",

--- a/packages/embark-pipeline/src/webpackProcess.js
+++ b/packages/embark-pipeline/src/webpackProcess.js
@@ -1,3 +1,4 @@
+import 'colors';
 import { ProcessWrapper } from 'embark-core';
 import { dappPath, errorMessage } from 'embark-utils';
 const constants = require('embark-core/constants');


### PR DESCRIPTION
As part of https://github.com/embark-framework/embark/commit/880a3a69462ee07be17c046f41a50429755fe8e0, we've introduced a
regression where the `colors` package isn't imported in the scope anymore where it's
needed. In this case the pipeline package. This resulted in log output messages
such as:

```
undefinedwriting fileundefined
```

Adding the `colors` package as dependency and importing it accordingly
fixes the issue.