### PR TITLE
build: adjust reset script to delete coverage dirs if pkg has test script

### DIFF
--- a/packages/embark-console/package.json
+++ b/packages/embark-console/package.json
@@ -35,7 +35,7 @@
     "lint:ts": "tslint -c tslint.json \"src/**/*.ts\"",
     "package": "npm pack",
     "qa": "npm-run-all lint typecheck build test package",
-    "reset": "npx rimraf dist embark-*.tgz package",
+    "reset": "npx rimraf .nyc_output coverage dist embark-*.tgz package",
     "start": "npm run watch",
     "test": "nyc --reporter=html --reporter=json mocha \"dist/test/**/*.js\" --exit --no-timeouts --require source-map-support/register",
     "typecheck": "tsc",

--- a/packages/embark-debugger/package.json
+++ b/packages/embark-debugger/package.json
@@ -33,7 +33,7 @@
     "lint:ts": "tslint -c tslint.json \"src/**/*.ts\"",
     "package": "npm pack",
     "qa": "npm-run-all lint typecheck build package",
-    "reset": "npx rimraf dist embark-*.tgz package",
+    "reset": "npx rimraf .nyc_output coverage dist embark-*.tgz package",
     "start": "npm run watch",
     "// test": "nyc --reporter=html --reporter=json mocha \"dist/test/**/*.js\" --exit --no-timeouts --require source-map-support/register",
     "typecheck": "tsc",

--- a/packages/embark-deploy-tracker/package.json
+++ b/packages/embark-deploy-tracker/package.json
@@ -35,7 +35,7 @@
     "package": "npm pack",
     "// qa": "npm-run-all lint typecheck build package",
     "qa": "npm-run-all lint build package",
-    "reset": "npx rimraf dist embark-*.tgz package",
+    "reset": "npx rimraf .nyc_output coverage dist embark-*.tgz package",
     "start": "npm run watch",
     "// test": "nyc --reporter=html --reporter=json mocha \"dist/test/**/*.js\" --exit --no-timeouts --require source-map-support/register",
     "// typecheck": "tsc",

--- a/packages/embark-listener/package.json
+++ b/packages/embark-listener/package.json
@@ -35,7 +35,7 @@
     "package": "npm pack",
     "// qa": "npm-run-all lint typecheck build package",
     "qa": "npm-run-all lint build package",
-    "reset": "npx rimraf dist embark-*.tgz package",
+    "reset": "npx rimraf .nyc_output coverage dist embark-*.tgz package",
     "start": "npm run watch",
     "// test": "nyc --reporter=html --reporter=json mocha \"dist/test/**/*.js\" --exit --no-timeouts --require source-map-support/register",
     "// typecheck": "tsc",

--- a/packages/embarkjs-ipfs/package.json
+++ b/packages/embarkjs-ipfs/package.json
@@ -44,9 +44,9 @@
     "package": "npm pack",
     "// qa": "npm-run-all build test package",
     "qa": "npm-run-all build package",
-    "reset": "npx rimraf build-test dist embarkjs-*.tgz package",
+    "reset": "npx rimraf .nyc_output build-test coverage dist embarkjs-*.tgz package",
     "start": "npm run watch",
-    "// test": "mocha \"build-test/**/*.js\" --exit --no-timeouts --require source-map-support/register",
+    "// test": "nyc --reporter=html --reporter=json mocha \"build-test/**/*.js\" --exit --no-timeouts --require source-map-support/register",
     "watch": "run-p \"build:** -- --verbose --watch\""
   },
   "dependencies": {
@@ -62,6 +62,7 @@
     "lodash.clonedeep": "4.5.0",
     "mocha": "5.2.0",
     "npm-run-all": "4.1.5",
+    "nyc": "13.1.0",
     "rimraf": "2.6.3",
     "source-map-support": "0.5.9"
   },

--- a/packages/embarkjs-swarm/package.json
+++ b/packages/embarkjs-swarm/package.json
@@ -44,9 +44,9 @@
     "package": "npm pack",
     "// qa": "npm-run-all build test package",
     "qa": "npm-run-all build package",
-    "reset": "npx rimraf build-test dist embarkjs-*.tgz package",
+    "reset": "npx rimraf .nyc_output build-test coverage dist embarkjs-*.tgz package",
     "start": "npm run watch",
-    "// test": "mocha \"build-test/**/*.js\" --exit --no-timeouts --require source-map-support/register",
+    "// test": "nyc --reporter=html --reporter=json mocha \"build-test/**/*.js\" --exit --no-timeouts --require source-map-support/register",
     "watch": "run-p \"build:** -- --verbose --watch\""
   },
   "dependencies": {
@@ -62,6 +62,7 @@
     "lodash.clonedeep": "4.5.0",
     "mocha": "5.2.0",
     "npm-run-all": "4.1.5",
+    "nyc": "13.1.0",
     "rimraf": "2.6.3",
     "source-map-support": "0.5.9"
   },

--- a/packages/embarkjs-whisper/package.json
+++ b/packages/embarkjs-whisper/package.json
@@ -44,9 +44,9 @@
     "package": "npm pack",
     "// qa": "npm-run-all build test package",
     "qa": "npm-run-all build package",
-    "reset": "npx rimraf build-test dist embarkjs-*.tgz package",
+    "reset": "npx rimraf .nyc_output build-test coverage dist embarkjs-*.tgz package",
     "start": "npm run watch",
-    "// test": "mocha \"build-test/**/*.js\" --exit --no-timeouts --require source-map-support/register",
+    "// test": "nyc --reporter=html --reporter=json mocha \"build-test/**/*.js\" --exit --no-timeouts --require source-map-support/register",
     "watch": "run-p \"build:** -- --verbose --watch\""
   },
   "dependencies": {
@@ -63,6 +63,7 @@
     "lodash.clonedeep": "4.5.0",
     "mocha": "5.2.0",
     "npm-run-all": "4.1.5",
+    "nyc": "13.1.0",
     "rimraf": "2.6.3",
     "source-map-support": "0.5.9"
   },

--- a/packages/embarkjs/package.json
+++ b/packages/embarkjs/package.json
@@ -43,7 +43,7 @@
     "clean": "npm run reset",
     "package": "npm pack",
     "qa": "npm-run-all build test package",
-    "reset": "npx rimraf build-test dist embarkjs-*.tgz package",
+    "reset": "npx rimraf .nyc_output build-test coverage dist embarkjs-*.tgz package",
     "start": "npm run watch",
     "test": "nyc --reporter=html --reporter=json mocha \"build-test/**/*.js\" --exit --no-timeouts --require source-map-support/register",
     "watch": "run-p \"build:** -- --verbose --watch\""


### PR DESCRIPTION
Make the adjustment even if the test script is currently disabled. Consistently use nyc to generate coverage with mocha even if the test script is currently disabled.