### PR TITLE
fix(@cockpit/utils): properly detect if ENS is enabled

### DIFF
--- a/packages/embark-ui/src/reducers/selectors.js
+++ b/packages/embark-ui/src/reducers/selectors.js
@@ -170,7 +170,7 @@ export function getEnsErrors(state) {
 }
 
 export function isEnsEnabled(state) {
-  return Boolean(state.entities.plugins.find((plugin) => plugin.name === 'ens'));
+  return Boolean(state.entities.plugins.find((plugin) => plugin.name === 'embark-ens'));
 }
 
 export function getFiles(state) {


### PR DESCRIPTION
With the move of Embark's modules into their own packages, the names under
which they are registered in the API service have changed as well.

This caused Cockpit to no longer being able to properly detect whether
ENS is enabled in the current Embark project