### PR TITLE
fix(@cockpit/whisper): ensure message subscription call is working

### DIFF
--- a/packages/embark-ui/src/services/api.js
+++ b/packages/embark-ui/src/services/api.js
@@ -171,11 +171,11 @@ export function toggleBreakpoint(payload) {
 }
 
 export function listenToDebugger(credentials) {
-  return embarkAPI.listenToDebugger(credentials, '/debugger');
+  return embarkAPI.listenToDebugger(credentials);
 }
 
 export function listenToChannel(credentials, channel) {
-  return embarkAPI.listenToChannel(credentials, `/communication/listenTo/${channel}`);
+  return embarkAPI.listenToChannel(credentials, channel);
 }
 
 export function webSocketProcess(credentials, processName) {
@@ -183,25 +183,25 @@ export function webSocketProcess(credentials, processName) {
 }
 
 export function webSocketServices(credentials) {
-  return embarkAPI.webSocketServices(credentials, `/services`);
+  return embarkAPI.webSocketServices(credentials);
 }
 
 export function webSocketContractLogs(credentials) {
-  return embarkAPI.webSocketContractLogs(credentials, `/contracts/logs`);
+  return embarkAPI.webSocketContractLogs(credentials);
 }
 
 export function webSocketContracts(credentials) {
-  return embarkAPI.webSocketContracts(credentials, `/contracts`);
+  return embarkAPI.webSocketContracts(credentials);
 }
 
 export function webSocketContractEvents(credentials) {
-  return embarkAPI.webSocketContractEvents(credentials, `/blockchain/contracts/event`);
+  return embarkAPI.webSocketContractEvents(credentials);
 }
 
 export function webSocketBlockHeader(credentials) {
-  return embarkAPI.webSocketBlockHeader(credentials, `/blockchain/blockHeader`);
+  return embarkAPI.webSocketBlockHeader(credentials);
 }
 
 export function websocketGasOracle(credentials) {
-  return embarkAPI.websocketGasOracle(credentials, `/blockchain/gas/oracle`);
+  return embarkAPI.websocketGasOracle(credentials);
 }


### PR DESCRIPTION
When introducing the `embark-api-client` in https://github.com/embark-framework/embark/commit/c1bbdbf34
we didn't properly update Cockpits apiService, resulting in calls to API endpoints
that don't exist.

This commit fixes a bug where calls to Embark's API to subscribe to whisper
channels are in a broken state.

It also updates Cockpit's apiService to no longer pass ignored parameters to embark-api-client.