### PR TITLE
fix(@embarkjs/whisper): don't rely on global EmbarkJS in whisper APIs

### DIFF
--- a/packages/embarkjs-whisper/src/index.js
+++ b/packages/embarkjs-whisper/src/index.js
@@ -47,7 +47,7 @@ __embarkWhisperNewWeb3.sendMessage = function(options) {
   }
   Object.assign(options, {
     sig: this.sig,
-    fromAscii: EmbarkJS.Utils.fromAscii,
+    fromAscii: this.web3.utils.fromAscii,
     toHex: this.web3.utils.toHex,
     symKeyID: options.symKeyID || this.symKeyID,
     post: this.web3.shh.post,
@@ -63,7 +63,7 @@ __embarkWhisperNewWeb3.sendMessage = function(options) {
 
 __embarkWhisperNewWeb3.listenTo = function (options) {
   Object.assign(options, {
-    toAscii: EmbarkJS.Utils.toAscii,
+    toAscii: this.web3.utils.toAscii,
     toHex: this.web3.utils.toHex,
     sig: this.sig,
     subscribe: this.web3.shh.subscribe,


### PR DESCRIPTION
When trying to either sending, or listening to whisper channels within
Embark's consoles (CLI and Cockpit), the console outputs an error that
`EmbarkJS` isn't defined.

E.g. running:

```
> EmbarkJS.Messages.listenTo({ topic: ['somechannel'])
```

Outputs:

```
EmbarkJS is not defined
```

This seemed very odd as outputting `EmbarkJS` and all of its members
worked totally fine.

It turns out that both methods, `listenTo()` and `sendMessage()`, in
`EmbarkJS.Messages` are not necessarily what one thinks they are.
EmbarkJS decorates both methods to create some options that need to be
available in the delegate, two of them being `EmbarkJS.Utils.toAscii`
and `EmbarkJS.Utils.fromAscii` (https://github.com/embark-framework/embark/blob/ac76a40a6156603fa436f1fe173835cff5fb0c3d/packages/embarkjs-whisper/src/index.js#L43-L62 and https://github.com/embark-framework/embark/blob/ac76a40a6156603fa436f1fe173835cff5fb0c3d/packages/embarkjs-whisper/src/index.js#L64-L73)

These two global references to `EmbarkJS` are the only ones in `embarkjs-whisper`
and they are not the same reference as the `EmbarkJS` sandbox global
registered in the VM here https://github.com/embark-framework/embark/blob/ac76a40a6156603fa436f1fe173835cff5fb0c3d/packages/embark-code-runner/src/index.ts#L33.

In other words, the `EmbarkJS is not defined` message actually refers
to the `EmbarkJS` in the wrapping method, not the one registered with
the VM, which is also why inspecting the `EmbarkJS` object through the
VM works fine.

Since the `toAscii()` and `fromAscii()` methods in use are really just
facades around `web3.utils.[fromAscii|toAscii]()`, we can replace the
global EmbarkJS dependency with web3 utils that are already available
anyways.