### PR TITLE
fix(@embark/swarm): update url-scheme to bzz-raw

### DIFF
--- a/dapps/tests/app/config/storage.json
+++ b/dapps/tests/app/config/storage.json
@@ -13,7 +13,7 @@
 
     "dappConnection": [
       "$BZZ",
-      {"provider": "swarm", "host": "localhost", "port": 8500, "getUrl": "http://localhost:8500/bzzr:/"},
+      {"provider": "swarm", "host": "localhost", "port": 8500, "getUrl": "http://localhost:8500/bzz-raw:/"},
       {"provider": "ipfs", "host": "localhost", "port": 5001, "getUrl": "http://localhost:8080/ipfs/"}
     ]
   },
@@ -23,7 +23,7 @@
       "provider": "swarm",
       "host": "localhost",
       "port": 8500,
-      "getUrl": "http://localhost:8500/bzzr:/"
+      "getUrl": "http://localhost:8500/bzz-raw:/"
     }
   },
   "livenet": {


### PR DESCRIPTION
Fixes #1643 
bzzr was removed in swarm 0.4.0. This change is necessary to this test dapp work with swarm 0.4.0.

