### PR TITLE
fix: gas estimates in test

### DIFF
--- a/packages/embark-deployment/src/contract_deployer.js
+++ b/packages/embark-deployment/src/contract_deployer.js
@@ -316,7 +316,14 @@ class ContractDeployer {
         next();
       },
       function estimateCorrectGas(next) {
-        if (contract.gas === 'auto' || !contract.gas) {
+        if (contract._skipGasEstimations) {
+          // This is Ganache's gas limit. We subtract 1 so we don't reach the limit.
+          //
+          // We do this because Ganache's gas estimates are wrong (contract creation
+          // has a base cost of 53k, not 21k, so it sometimes results in out of gas
+          // errors.)
+          contract.gas = 6721975 - 1;
+        } else if (contract.gas === 'auto' || !contract.gas) {
           return self.blockchain.estimateDeployContractGas(deployObject, (err, gasValue) => {
             if (err) {
               return next(err);

--- a/packages/embark-deployment/src/index.js
+++ b/packages/embark-deployment/src/index.js
@@ -36,6 +36,7 @@ class DeployManager {
     this.events.setCommandHandler('deploy:contracts:test', (cb) => {
       self.fatalErrors = true;
       self.deployOnlyOnConfig = true;
+      self.skipGasEstimations = true;
       self.deployContracts(cb);
     });
   }
@@ -70,6 +71,7 @@ class DeployManager {
                   callback = result;
                 }
                 contract._gasLimit = self.gasLimit;
+                contract._skipGasEstimations = self.skipGasEstimations;
                 self.events.request('deploy:contract', contract, (err) => {
                   if (err) {
                     contract.error = err.message || err;


### PR DESCRIPTION
When deploying some more significant contracts in a test (which uses ganache as the blockchain) we ran into some gas estimation problems.

Namely, Ganache will underestimate gas in some scenarios. On their calculation they [assume a base fee of 21000](https://github.com/trufflesuite/ganache-core/blob/8ad1ab29deccbbb4018f6961d0eb7ec984ad8fcb/lib/utils/gasEstimation.js#L33-L39), where, for contract deployments, the [base fee](https://github.com/ethereum/go-ethereum/blob/d0082bb7ec04b4fe3fc9e269fe2673c9cbd094e2/core/state_transition.go#L83) is [higher (53000)](https://github.com/ethereum/go-ethereum/blob/b8f9b3779fbdc62d5a935b57f1360608fa4600b4/params/protocol_params.go#L32).

This PR doesn't seek to fix gas estimation. Instead, it will estimate the gas to be Ganache's default maximum gas per transaction value, minus 1 so we don't hit the max.

Thanks, @PascalPrecht, and @iurimatias for the help in figuring this one out.