### PR TITLE
fix(@embark/solidity): fix recursive error on Windows

### DIFF
--- a/packages/embark-code-generator/src/index.js
+++ b/packages/embark-code-generator/src/index.js
@@ -1,5 +1,5 @@
 import { __ } from 'embark-i18n';
-import { dappPath, embarkPath, joinPath } from 'embark-utils';
+import { dappPath, embarkPath, joinPath, toForwardSlashes } from 'embark-utils';
 import * as fs from 'fs-extra';
 import { transform } from "@babel/core";
 const async = require('async');
@@ -474,7 +474,7 @@ class CodeGenerator {
           if (err) {
             return next(err);
           }
-          next(null, joinPath(symlinkDir, name).replace(/\\/g, '/'));
+          next(null, toForwardSlashes(joinPath(symlinkDir, name)));
         });
       },
       // Remove old symlink because they are not overwritable

--- a/packages/embark-library-manager/src/index.js
+++ b/packages/embark-library-manager/src/index.js
@@ -1,5 +1,5 @@
 import { __ } from 'embark-i18n';
-import { dappPath, embarkPath } from 'embark-utils';
+import { dappPath, embarkPath, normalizePath, toForwardSlashes } from 'embark-utils';
 var Npm = require('./npm.js');
 
 class LibraryManager {
@@ -86,11 +86,11 @@ class LibraryManager {
     if (!wantedVersion || wantedVersion === installedVersion) {
       const nodePath = embarkPath('node_modules');
       const packagePath = require.resolve(packageName, {paths: [nodePath]});
-      return cb(null, packagePath.replace(/\\/g, '/'));
+      return cb(null, normalizePath(packagePath, true));
     }
     // Download package
     this.embark.events.request("version:getPackageLocation", packageName, wantedVersion, (err, location) => {
-      cb(err, dappPath(location).replace(/\\/g, '/'));
+      cb(err, toForwardSlashes(dappPath(location)));
     });
   }
 

--- a/packages/embark-solidity/src/index.js
+++ b/packages/embark-solidity/src/index.js
@@ -26,7 +26,7 @@ class Solidity {
         if (typeof req.body.code !== 'string') {
           return res.send({error: 'Body parameter \'code\' must be a string'});
         }
-        const input = {[req.body.name]: {content: req.body.code.replace(/\r\n/g, '\n')}};
+        const input = {[req.body.name.replace(/\\/g, '/')]: {content: req.body.code.replace(/\r\n/g, '\n')}};
         this.compile_solidity_code(input, {}, true, {}, (errors, result) => {
           const responseData = {errors: errors, result: result};
           this.logger.trace(`POST response /embark-api/contract/compile:\n ${JSON.stringify(responseData)}`);
@@ -209,7 +209,7 @@ class Solidity {
 
             file.prepareForCompilation(options.isCoverage)
               .then(fileContent => {
-                input[file.path] = {content: fileContent.replace(/\r\n/g, '\n')};
+                input[file.path.replace(/\\/g, '/')] = {content: fileContent.replace(/\r\n/g, '\n')};
                 fileCb();
               }).catch((e) => {
                 self.logger.error(__('Error while loading the content of ') + filename);

--- a/packages/embark-solidity/src/index.js
+++ b/packages/embark-solidity/src/index.js
@@ -2,6 +2,7 @@ let async = require('async');
 let SolcW = require('./solcW.js');
 const path = require('path');
 import { __ } from 'embark-i18n';
+import {normalizePath} from 'embark-utils';
 
 class Solidity {
 
@@ -26,7 +27,7 @@ class Solidity {
         if (typeof req.body.code !== 'string') {
           return res.send({error: 'Body parameter \'code\' must be a string'});
         }
-        const input = {[req.body.name.replace(/\\/g, '/')]: {content: req.body.code.replace(/\r\n/g, '\n')}};
+        const input = {[normalizePath(req.body.name, true)]: {content: req.body.code.replace(/\r\n/g, '\n')}};
         this.compile_solidity_code(input, {}, true, {}, (errors, result) => {
           const responseData = {errors: errors, result: result};
           this.logger.trace(`POST response /embark-api/contract/compile:\n ${JSON.stringify(responseData)}`);
@@ -200,7 +201,7 @@ class Solidity {
             let filename = file.path;
 
             for (let directory of self.embark.config.contractDirectories) {
-              directory = directory.replace(/\\/g, '/');
+              directory = normalizePath(directory, true);
               let match = new RegExp("^" + directory);
               filename = filename.replace(match, '');
             }
@@ -209,7 +210,7 @@ class Solidity {
 
             file.prepareForCompilation(options.isCoverage)
               .then(fileContent => {
-                input[file.path.replace(/\\/g, '/')] = {content: fileContent.replace(/\r\n/g, '\n')};
+                input[normalizePath(file.path, true)] = {content: fileContent.replace(/\r\n/g, '\n')};
                 fileCb();
               }).catch((e) => {
                 self.logger.error(__('Error while loading the content of ') + filename);

--- a/packages/embark-test-runner/src/solc_test.js
+++ b/packages/embark-test-runner/src/solc_test.js
@@ -4,6 +4,7 @@ const fs = require('fs-extra');
 const remixTests = require('remix-tests');
 const Base = require('mocha/lib/reporters/base');
 const color = Base.color;
+import {normalizePath} from "embark-utils";
 
 class SolcTest extends Test {
   constructor(options) {
@@ -78,7 +79,7 @@ class SolcTest extends Test {
   runTests(file, cb) {
     const self = this;
     console.info('Running tests'.cyan);
-    const forwardSlashFile = file.replace(/\\/g, '/');
+    const forwardSlashFile = normalizePath(file, true);
 
     async.waterfall([
       function getContracts(next) {
@@ -90,7 +91,7 @@ class SolcTest extends Test {
 
           Object.keys(contracts).forEach((contract) => {
             if (contracts[contract].originalFilename &&
-              contracts[contract].originalFilename.replace(/\\/g, '/') === forwardSlashFile) {
+              normalizePath(contracts[contract].originalFilename, true) === forwardSlashFile) {
               contractsToTest.push(contracts[contract]);
             }
           });
@@ -114,10 +115,10 @@ class SolcTest extends Test {
           let fn = (_callback) => {
             // TODO: web3 is not injected into the function. Issue has been raised on remixTests.
             // To fix once web3 has been made injectable.
-            const contractDetails = { 
-              userdoc: (contract.userdoc || { methods: [] }), 
-              evm: { 
-                methodIdentifiers: contract.functionHashes 
+            const contractDetails = {
+              userdoc: (contract.userdoc || { methods: [] }),
+              evm: {
+                methodIdentifiers: contract.functionHashes
               }
             };
             self.getEmbarkJSContract(contract, (err, embarkjsContract) => {
@@ -129,7 +130,7 @@ class SolcTest extends Test {
             });
           };
           fns.push(fn);
-        
+
         });
         async.series(fns, next);
       }

--- a/packages/embark-utils/src/index.js
+++ b/packages/embark-utils/src/index.js
@@ -38,7 +38,9 @@ import {
   DIAGRAM_PATH,
   EMBARK_PATH,
   PKG_PATH,
-  NODE_PATH
+  NODE_PATH,
+  normalizePath,
+  toForwardSlashes
 } from './pathUtils';
 import { setUpEnv } from './env';
 
@@ -277,6 +279,8 @@ const Utils = {
   dappPath,
   downloadFile,
   embarkPath,
+  normalizePath,
+  toForwardSlashes,
   jsonFunctionReplacer,
   fuzzySearch,
   canonicalHost,

--- a/packages/embark-utils/src/pathUtils.js
+++ b/packages/embark-utils/src/pathUtils.js
@@ -76,3 +76,15 @@ export function urlJoin(url, path) {
 
   return urlChunks.join('/');
 }
+
+export function toForwardSlashes(content) {
+  return content.replace(/\\/g, '/');
+}
+
+export function normalizePath(content, useForwardSlashes = true) {
+  content = path.normalize(content);
+  if (useForwardSlashes && path.sep !== '/') {
+    content = toForwardSlashes(content);
+  }
+  return content;
+}

--- a/packages/embark-watcher/src/index.js
+++ b/packages/embark-watcher/src/index.js
@@ -1,5 +1,5 @@
 import { __ } from 'embark-i18n';
-import { dappPath } from 'embark-utils';
+import { dappPath, toForwardSlashes, normalizePath } from 'embark-utils';
 let chokidar = require('chokidar');
 let path = require('path');
 
@@ -76,9 +76,9 @@ class Watcher {
       // so embark reacts to changes made in imported js files
       // chokidar glob patterns only work with front-slashes
       if (!Array.isArray(files)) {
-        fileGlob = path.join(path.dirname(files), '**', '*.*').replace(/\\/g, '/');
+        fileGlob = toForwardSlashes(path.join(path.dirname(files), '**', '*.*'));
       } else if (files.length === 1) {
-        fileGlob = path.join(path.dirname(files[0]), '**', '*.*').replace(/\\/g, '/');
+        fileGlob = toForwardSlashes(path.join(path.dirname(files[0]), '**', '*.*'));
       }
 
       filesToWatch.push(fileGlob);
@@ -122,7 +122,7 @@ class Watcher {
       }
       webserverConfig = embarkConfig.config.webserver;
     } else {
-      let contractsFolder = embarkConfig.config.replace(/\\/g, '/');
+      let contractsFolder = normalizePath(embarkConfig.config, true);
       if (contractsFolder.charAt(contractsFolder.length - 1) !== '/') {
         contractsFolder += '/';
       }
@@ -145,7 +145,7 @@ class Watcher {
     if (typeof embarkConfig.config === 'object' || embarkConfig.config.contracts) {
       contractConfig = embarkConfig.config.contracts;
     } else {
-      let contractsFolder = embarkConfig.config.replace(/\\/g, '/');
+      let contractsFolder = normalizePath(embarkConfig.config, true);
       if (contractsFolder.charAt(contractsFolder.length - 1) !== '/') {
         contractsFolder += '/';
       }

--- a/packages/embarkjs-connector-web3/index.js
+++ b/packages/embarkjs-connector-web3/index.js
@@ -1,4 +1,4 @@
-const { dappPath, embarkPath } = require('embark-utils');
+const { dappPath, embarkPath, normalizePath, toForwardSlashes } = require('embark-utils');
 const path = require('path');
 
 class EmbarkJSConnectorWeb3 {
@@ -32,7 +32,7 @@ class EmbarkJSConnectorWeb3 {
     });
 
     let web3Location = await web3LocationPromise;
-    web3Location = web3Location.replace(/\\/g, '/');
+    web3Location = normalizePath(web3Location, true);
 
     await this.registerVar('__Web3', require(web3Location));
 
@@ -47,7 +47,7 @@ class EmbarkJSConnectorWeb3 {
     code += "\nEmbarkJS.Blockchain.registerProvider('web3', embarkJSConnectorWeb3);";
     code += "\nEmbarkJS.Blockchain.setProvider('web3', {});";
 
-    const configPath = dappPath(this.config.embarkConfig.generationDir, this.constants.dappArtifacts.dir, this.constants.dappArtifacts.blockchain).replace(/\\/g, '/');
+    const configPath = toForwardSlashes(dappPath(this.config.embarkConfig.generationDir, this.constants.dappArtifacts.dir, this.constants.dappArtifacts.blockchain));
 
     code += `\nif (!global.__Web3) {`; // Only connect when in the Dapp
     code += `\n  const web3ConnectionConfig = require('${configPath}');`;


### PR DESCRIPTION
Long story short, if you have a recursive dep in Solidity, it would still manage to compile, because solc was able to check your inputs and see that the import is in the list of files, but not on Windows, because we used backslahes instead of forward slashes (we import using forward)