### PR TITLE
fix: coverage codegen issues

### DIFF
--- a/packages/embark-coverage/src/contractEnhanced.ts
+++ b/packages/embark-coverage/src/contractEnhanced.ts
@@ -72,6 +72,22 @@ export class ContractEnhanced {
   }
 
   public save() {
+    // Right before saving, we do another parser pass to make sure that we're not sending bad
+    // solidity code into the sunset.
+    //
+    // Because of the way the augmentation works, ie. we sprinkle events between each line of
+    // code to register that it was reached, there are cases (ie. an `if` statament without `{}`)
+    // where it breaks.
+    //
+    // It sucks that we have to throw away those files, but it beats the alternative of badly
+    // exiting and not being able to get any coverage at all. Because it still sucks:
+    // TODO(andremedeiros): do this right.
+    try {
+      parser.parse(this.source, {});
+    } catch (error) {
+      this.source = this.originalSource;
+    }
+
     fs.ensureFileSync(this.coverageFilepath);
     fs.writeFileSync(this.coverageFilepath, this.source);
   }


### PR DESCRIPTION
So, this is a fun one. In some files, coverage will break because of the way we inject the coverage statements.

An example of how this broke is:

```solidity
        if (byte0 < STRING_SHORT_START)
emit __StatementCoverage(20000034);
            return 1;
emit __StatementCoverage(20000035);
        else if (byte0 < STRING_LONG_START)
emit __StatementCoverage(20000036);
            return byte0 - STRING_SHORT_START + 1;
emit __StatementCoverage(20000037);
        else if (byte0 < LIST_SHORT_START) {
            assembly {
                let byteLen := sub(byte0, 0xb7) // # of bytes the actual length is
                memPtr := add(memPtr, 1) // skip over the first byte
            /* 32 byte word size */
                let dataLen := div(mload(memPtr), exp(256, sub(32, byteLen))) // right shifting to get the len
                len := add(dataLen, add(byteLen, 1))
            }
        }
```

In this example, the `if` block isn't enclosed by `{}` thus making the multiple statements invalid code.

I have to come back to this one and fix it properly with minimal code intervention, as I'm not sure that "just" adding `{}` will lead to potential scope issues.

For now, we do another parsing pass right before we write the instrumented code to make sure the parser is happy. Doing it this way is relatively cheap and shouldn't be too hard on performance.