### PR TITLE
fix(@embark/webserver): don't spin up webserver if pipeline is disabled

### DIFF
--- a/packages/embark-webserver/src/index.js
+++ b/packages/embark-webserver/src/index.js
@@ -16,6 +16,7 @@ class WebServer {
     this.fs = embark.fs;
     this.buildDir = embark.config.buildDir;
     this.webServerConfig = embark.config.webServerConfig;
+
     if (!this.webServerConfig.enabled) {
       return;
     }

--- a/packages/embark/src/lib/core/config.js
+++ b/packages/embark/src/lib/core/config.js
@@ -532,6 +532,10 @@ Config.prototype.loadWebServerConfigFile = function() {
     this.webServerConfig = webServerConfig;
   }
 
+  if (!this.pipelineConfig.enabled) {
+    this.webServerConfig.enabled = false;
+  }
+
   this.events.emit('config:load:webserver', this.webServerConfig);
 };
 


### PR DESCRIPTION
The webserver's job is to serve files generated by Embark's built-in pipeline,
however, since v4 users can choose they front-end tool to take care of building,
bundling and packing their DApps. Usually these tools come with a built-in
dev server as well.

Therefore, when the pipeline is turned off (which also soon will be the default),
there's not need start a webserver.