### PR TITLE
fix(@embark/dapps): old link updated to the latest documentation at website

### DIFF
--- a/dapps/templates/boilerplate/app/index.html
+++ b/dapps/templates/boilerplate/app/index.html
@@ -6,6 +6,6 @@
   </head>
   <body>
     <h3>Welcome to Embark!</h3>
-    <p>See the <a href="http://embark.readthedocs.io/en/latest/index.html" target="_blank">Embark's documentation</a> to see what you can do with Embark!</p>
+    <p>See the <a href="https://embark.status.im/docs/quick_start.html" target="_blank">Embark's documentation</a> to see what you can do with Embark!</p>
   </body>
 </html>


### PR DESCRIPTION
The previous link was pointing to [readthedocs.io](http://embark.readthedocs.io/en/latest/index.html), which wasn't active. 
So here I've replaced it with the link to the [official documentation on the Embark website](https://embark.status.im/docs/quick_start.html).