### PR TITLE
fix(@embark/deployment): don't break when using abiDefinitions

### DIFF
--- a/packages/embark-deployment/src/contract_deployer.js
+++ b/packages/embark-deployment/src/contract_deployer.js
@@ -96,6 +96,10 @@ class ContractDeployer {
 
     async.waterfall([
       function checkContractBytesize(next) {
+        if (!contract.code) {
+          return next();
+        }
+
         const code = (contract.code.indexOf('0x') === 0) ? contract.code.substr(2) : contract.code;
         const contractCodeLength = Buffer.from(code, 'hex').toString().length;
         if(contractCodeLength > MAX_CONTRACT_BYTECODE_LENGTH) {


### PR DESCRIPTION
In https://github.com/embark-framework/embark/pull/1119 we've introduced a feature where
users can provide an already compiled ABI for Smart Contracts so they can be used
without the need to compiling them again.

This also means that, internally, those Smart Contract object won't have any
bytecode attached to it.

Later on, in https://github.com/embark-framework/embark/commit/387d33a076cb7a4acd59c212e662f19288498556,  we've introduced a warning
which is rendered when a Smart Contract's bytecode is too large. The check expects
a Smart Contract object to have bytecode associated to it, which will break the code
in cases where a Smart Contract has already an ABI and therefore didn't need compilation.

This commit ensures we only check a Smart Contract's bytecode when bytecode exists for
the Smart Contract in question.