### PR TITLE
fix(@embark/test-runner): don't run tests on empty files

### DIFF
--- a/packages/embark-test-runner/src/index.js
+++ b/packages/embark-test-runner/src/index.js
@@ -146,7 +146,10 @@ class TestRunner {
             if (err) {
               return cb(errorMessage);
             }
-            cb(null, arr.reduce((a,b) => a.concat(b), []));
+            cb(null, arr.reduce((a,b) => {
+              b = b.filter(f => self.fs.readFileSync(f).length > 0)
+              return a.concat(b);
+            }, []));
           });
         });
       }


### PR DESCRIPTION
Prior to this commit, Embark's test runner would try to run tests
on any file inside a given path, including empty files. This resulted
in test reports with 0 tests and 0 passes.

We now ensure that empty files are filtered out before they get
passed to the test runner.