### PR TITLE
Wait for `config` to finish before calling `describe`

### DIFF
--- a/dapps/templates/boilerplate/test/contract_spec.js
+++ b/dapps/templates/boilerplate/test/contract_spec.js
@@ -1,4 +1,4 @@
-// /*global contract, config, it, assert*/
+/*global contract, it*/
 /*
 const SimpleStorage = require('Embark/contracts/SimpleStorage');
 
@@ -19,10 +19,9 @@ config({
   }
 }, (_err, web3_accounts) => {
   accounts = web3_accounts
-});
+});*/
 
-contract("SimpleStorage", function () {
-  this.timeout(0);
+contract.skip("SimpleStorage", function () {
 
   it("should set constructor value", async function () {
     let result = await SimpleStorage.methods.storedData().call();
@@ -39,5 +38,4 @@ contract("SimpleStorage", function () {
     let balance = await web3.eth.getBalance(accounts[0]);
     assert.ok(parseInt(balance, 10) > 0);
   });
-}
-*/
+});

--- a/dapps/templates/simple/test/contract_spec.js
+++ b/dapps/templates/simple/test/contract_spec.js
@@ -1,4 +1,4 @@
-// /*global contract, config, it, assert*/
+/*global contract, it*/
 /*
 const SimpleStorage = require('Embark/contracts/SimpleStorage');
 
@@ -19,10 +19,9 @@ config({
   }
 }, (_err, web3_accounts) => {
   accounts = web3_accounts
-});
+});*/
 
-contract("SimpleStorage", function () {
-  this.timeout(0);
+contract.skip("SimpleStorage", function () {
 
   it("should set constructor value", async function () {
     let result = await SimpleStorage.methods.storedData().call();
@@ -39,5 +38,4 @@ contract("SimpleStorage", function () {
     let balance = await web3.eth.getBalance(accounts[0]);
     assert.ok(parseInt(balance, 10) > 0);
   });
-}
-*/
+});

--- a/dapps/tests/app/test/another_storage_spec.js
+++ b/dapps/tests/app/test/another_storage_spec.js
@@ -27,7 +27,12 @@ config({
 });
 
 contract("AnotherStorage", function() {
+  const defaultAccount = accounts[0];
   this.timeout(0);
+
+  it("should have got the default account in the describe", function () {
+    assert.strictEqual(defaultAccount, accounts[0]);
+  });
 
   it("should have account with balance", async function() {
     let balance = await web3.eth.getBalance(accounts[0]);

--- a/dapps/tests/app/test/another_storage_spec.js
+++ b/dapps/tests/app/test/another_storage_spec.js
@@ -26,12 +26,16 @@ config({
   accounts = theAccounts;
 });
 
-contract("AnotherStorage", function() {
+contract("AnotherStorage", function(accountsAgain) {
   const defaultAccount = accounts[0];
   this.timeout(0);
 
   it("should have got the default account in the describe", function () {
     assert.strictEqual(defaultAccount, accounts[0]);
+  });
+
+  it("should have the accounts in the describe callback too", function () {
+    assert.deepStrictEqual(accountsAgain, accounts);
   });
 
   it("should have account with balance", async function() {

--- a/packages/embark-test-runner/src/index.js
+++ b/packages/embark-test-runner/src/index.js
@@ -225,13 +225,9 @@ class TestRunner {
               if (global.embark.needConfig) {
                 global.config({});
               }
-              global.embark.onReady(() => {
-                // Next tick makes sure to not have a hang when tests don't use `config()`
-                // I think this is needed because Mocha expects global.run() to be called ina further event loop
-                process.nextTick(() => {
-                  self.ogMochaDescribe(describeName, callback);
-                  global.run(); // This tells mocha that it can run the test (used in conjunction with `delay()`
-                });
+              global.embark.onReady((_err, accounts) => {
+                self.ogMochaDescribe(describeName, callback.bind(mocha, accounts));
+                global.run(); // This tells mocha that it can run the test (used in conjunction with `delay()`
               });
             }
 

--- a/packages/embark-test-runner/src/test.js
+++ b/packages/embark-test-runner/src/test.js
@@ -26,6 +26,7 @@ class Test {
     this.accounts = [];
     this.embarkjs = {};
     this.dappPath = options.dappPath;
+    this.accounts = [];
 
     this.events.setCommandHandler("blockchain:provider:contract:accounts:get", cb => {
       this.events.request("blockchain:getAccounts", cb);
@@ -112,10 +113,14 @@ class Test {
   onReady(callback) {
     const self = this;
     if (this.ready) {
-      return callback();
+      return setImmediate(() => {
+        callback(null, this.accounts);
+      });
     }
     if (this.error) {
-      return callback(this.error);
+      return setImmediate(() => {
+        callback(this.error);
+      });
     }
 
     let errorCallback, readyCallback;
@@ -125,9 +130,9 @@ class Test {
       callback(err);
     };
 
-    readyCallback = () => {
+    readyCallback = (accounts) => {
       self.events.removeListener('tests:deployError', errorCallback);
-      callback();
+      callback(null, accounts);
     };
 
     this.events.once('tests:ready', readyCallback);
@@ -240,8 +245,9 @@ class Test {
         // TODO Do not exit in case of not a normal run (eg after a change)
         if (!self.options.inProcess) process.exit(1);
       }
+      self.accounts = accounts;
       callback(null, accounts);
-      self.events.emit('tests:ready');
+      self.events.emit('tests:ready', accounts);
     });
   }
 

--- a/packages/embark-test-runner/src/test.js
+++ b/packages/embark-test-runner/src/test.js
@@ -240,8 +240,8 @@ class Test {
         // TODO Do not exit in case of not a normal run (eg after a change)
         if (!self.options.inProcess) process.exit(1);
       }
-      self.events.emit('tests:ready');
       callback(null, accounts);
+      self.events.emit('tests:ready');
     });
   }
 

--- a/site/source/docs/contracts_testing.md
+++ b/site/source/docs/contracts_testing.md
@@ -161,7 +161,17 @@ config({
 });
 ```
 
-Notice that we're introducing a global `accounts` variable so we can mutate its state once the accounts are loaded. This is necessary to make the emitted accounts available in any of our spec blocks.
+You can also grab the accounts from the callback of the `contract()` function (`describe` alias):
+
+```
+contract('SomeContract', (accounts) => {
+  const myAccounts = accounts[0];
+
+  it('should do something', async () => {
+    ...
+  });
+});
+```
 
 ## Connecting to a different node
 


### PR DESCRIPTION
This makes it possible to do this: 
```
contract("AnotherStorage", function() {
  const defaultAccount = accounts[0];
```

One weird "hack" I needed to do is call `process.nextTick()`, because otherwise, tests with no `config()` calls would hang for no reason. I was able to put logs everywhere and everythign was called, except the `it`s. So I think it's a bug in Mocha where its event handlers are not set up yet and it waits to do it in a further event loop.