### PR TITLE
Add accounts array to the describe/contract callback

### DIFF
--- a/dapps/tests/app/test/another_storage_spec.js
+++ b/dapps/tests/app/test/another_storage_spec.js
@@ -26,12 +26,16 @@ config({
   accounts = theAccounts;
 });
 
-contract("AnotherStorage", function() {
+contract("AnotherStorage", function(accountsAgain) {
   const defaultAccount = accounts[0];
   this.timeout(0);
 
   it("should have got the default account in the describe", function () {
     assert.strictEqual(defaultAccount, accounts[0]);
+  });
+
+  it("should have the accounts in the describe callback too", function () {
+    assert.deepStrictEqual(accountsAgain, accounts);
   });
 
   it("should have account with balance", async function() {

--- a/packages/embark-test-runner/src/index.js
+++ b/packages/embark-test-runner/src/index.js
@@ -225,11 +225,11 @@ class TestRunner {
               if (global.embark.needConfig) {
                 global.config({});
               }
-              global.embark.onReady(() => {
+              global.embark.onReady((_err, accounts) => {
                 // Next tick makes sure to not have a hang when tests don't use `config()`
                 // I think this is needed because Mocha expects global.run() to be called ina further event loop
                 process.nextTick(() => {
-                  self.ogMochaDescribe(describeName, callback);
+                  self.ogMochaDescribe(describeName, callback.bind(mocha, accounts));
                   global.run(); // This tells mocha that it can run the test (used in conjunction with `delay()`
                 });
               });

--- a/packages/embark-test-runner/src/test.js
+++ b/packages/embark-test-runner/src/test.js
@@ -26,6 +26,7 @@ class Test {
     this.accounts = [];
     this.embarkjs = {};
     this.dappPath = options.dappPath;
+    this.accounts = [];
 
     this.events.setCommandHandler("blockchain:provider:contract:accounts:get", cb => {
       this.events.request("blockchain:getAccounts", cb);
@@ -112,7 +113,7 @@ class Test {
   onReady(callback) {
     const self = this;
     if (this.ready) {
-      return callback();
+      return callback(null, this.accounts);
     }
     if (this.error) {
       return callback(this.error);
@@ -125,9 +126,9 @@ class Test {
       callback(err);
     };
 
-    readyCallback = () => {
+    readyCallback = (accounts) => {
       self.events.removeListener('tests:deployError', errorCallback);
-      callback();
+      callback(null, accounts);
     };
 
     this.events.once('tests:ready', readyCallback);
@@ -240,8 +241,9 @@ class Test {
         // TODO Do not exit in case of not a normal run (eg after a change)
         if (!self.options.inProcess) process.exit(1);
       }
+      self.accounts = accounts;
       callback(null, accounts);
-      self.events.emit('tests:ready');
+      self.events.emit('tests:ready', accounts);
     });
   }
 


### PR DESCRIPTION
Based off https://github.com/embark-framework/embark/pull/1663

Puts accounts in the callback of `contract` and `describe`