### PR TITLE
fix(@embark/test-runenr): fix event listener overflow

### DIFF
--- a/packages/embark-test-runner/src/test.js
+++ b/packages/embark-test-runner/src/test.js
@@ -199,6 +199,16 @@ class Test {
     self.ready = false;
 
     async.waterfall([
+      function cleanContracts(next) {
+        Object.keys(self.contracts).forEach(contractName => {
+          if (self.contracts[contractName]._requestManager) {
+            // Remove all data listeners from the contract provider as a listener for `data` is added for each new contract
+            // Removing directly as contract.removeSubscriptions throws errors and doesn't really unsubscribe
+            self.contracts[contractName]._requestManager.provider.removeAllListeners('data');
+          }
+        });
+        next();
+      },
       function checkDeploymentOpts(next) {
         self.checkDeploymentOptions(options, next);
       },


### PR DESCRIPTION
On some Dapps, the number of tests and contracts was so high, that we ended up with `MaxListenersExceededWarning: Possible EventEmitter memory leak detected. 351 data listeners added.` warning.

This is cause each contract created using web3 creates a listener on the `data` event.

However, in the case of tests, contracts are only used in one file at a time, so we can remove the subscription after.

I tried using `removeSubscriptions` that contract objects have, but it ended up trhowing errors and not fixing the problem as it seems broken.
I instead went to the source and called `removeAllListeners`. I make sure that the request manager exists first, so if we ever use another contract instance, it won't crash.