### PR TITLE
Set helper methods to contract instances

### DIFF
--- a/dapps/tests/app/test/simple_storage_deploy_spec.js
+++ b/dapps/tests/app/test/simple_storage_deploy_spec.js
@@ -5,12 +5,9 @@ const {Utils} = require('Embark/EmbarkJS');
 contract("SimpleStorage Deploy", function () {
   let simpleStorageInstance;
   before(function(done) {
-    Utils.secureSend(web3, SimpleStorage.deploy({arguments: [150]}), {}, true, function(err, receipt) {
-      if(err) {
-        return done(err);
-      }
-      simpleStorageInstance = SimpleStorage;
-      simpleStorageInstance.options.address = receipt.contractAddress;
+    SimpleStorage.deploy([150]);
+    SimpleStorage.deployed().then(instance => {
+      simpleStorageInstance = instance;
       done();
     });
   });

--- a/packages/embark-test-runner/src/test.js
+++ b/packages/embark-test-runner/src/test.js
@@ -365,6 +365,7 @@ class Test {
       const newContract = new EmbarkJS.Blockchain.Contract({
         abi: ${JSON.stringify(contract.abiDefinition)},
         address: "${contract.deployedAddress || ""}" || undefined,
+        code: "${contract.code}",
         from: "${contract.deploymentAccount || ""}" || web3.eth.defaultAccount,
         gas: "${GAS_LIMIT}",
         web3: web3

--- a/packages/embarkjs/src/blockchain.js
+++ b/packages/embarkjs/src/blockchain.js
@@ -1,6 +1,7 @@
 /* global ethereum */
 
-import {reduce} from './async';
+import { reduce } from './async';
+import utils from './utils';
 
 let Blockchain = {
   list: [],
@@ -242,7 +243,7 @@ let Contract = function(options) {
   this.abi = options.abi;
   this.address = options.address;
   this.gas = options.gas;
-  this.code = '0x' + options.code;
+  this.code = utils.hexPrefix(options.code);
 
   this.blockchainConnector = Blockchain.blockchainConnector;
 
@@ -309,40 +310,50 @@ let Contract = function(options) {
     }
   });
 
+  // Assign helpers too
+  for(const method of ["deploy", "new", "at", "send", "deployed"]) {
+    // Make sure we don't override original methods here.
+    if (originalMethods.indexOf(method) >= 0) {
+      console.log(method + " is a reserved word and will not be aliased as a helper");
+      continue;
+    }
+
+    ContractClass[method] = Contract.prototype[method].bind(this);
+  }
+
+  this.contractClass = ContractClass;
+
   return ContractClass;
 };
 
-Contract.prototype.deploy = function(args, _options) {
-  var self = this;
-  var contractParams;
-  var options = _options || {};
+Contract.prototype.deploy = function(args, _options, _txOptions) {
+  const self = this;
+  const options = Object.assign({
+    arguments: args || [],
+    data: this.code
+  }, _options);
 
-  contractParams = args || [];
-
-  contractParams.push({
+  const txOptions = Object.assign({
     from: this.blockchainConnector.getDefaultAccount(),
-    data: this.code,
-    gas: options.gas || 800000
+    gas: this.gas
+  }, _txOptions);
+
+  const contract = this.blockchainConnector.newContract({abi: this.abi});
+
+  this._deployPromise = new Promise((resolve, reject) => {
+    contract.deploy.apply(contract, [options]).send(txOptions).then(instance => {
+      resolve(new Contract({
+        abi: self.abi,
+        code: self.code,
+        address: instance.options.address
+      }));
+
+      // Delete the deploy promise as we don't need to track it anymore.
+      delete self._deployPromise;
+    }).catch(reject);
   });
 
-
-  const contractObject = this.blockchainConnector.newContract({abi: this.abi});
-
-  return new Promise(function (resolve, reject) {
-    contractParams.push(function(err, transaction) {
-      if (err) {
-        reject(err);
-      } else if (transaction.address !== undefined) {
-        resolve(new Contract({
-          abi: self.abi,
-          code: self.code,
-          address: transaction.address
-        }));
-      }
-    });
-
-    contractObject["new"].apply(contractObject, contractParams);
-  });
+  return this._deployPromise;
 };
 
 Contract.prototype.new = Contract.prototype.deploy;
@@ -365,6 +376,22 @@ Contract.prototype.send = function(value, unit, _options) {
   options.value = wei;
 
   return this.blockchainConnector.send(options);
+};
+
+Contract.prototype.deployed = function() {
+  if (this.address === undefined && this._deployPromise === undefined) {
+    const err = Error("contract deployment hasn't happened yet");
+    return Promise.reject(err);
+  }
+
+  // This keeps the original deploy promise so we can fire it as soon as web3 tells us
+  // it's done.
+  if (this._deployPromise) {
+    return this._deployPromise;
+  }
+
+  // Already deployed, just resolve.
+  return Promise.resolve(this);
 };
 
 Blockchain.Contract = Contract;

--- a/packages/embarkjs/src/utils.js
+++ b/packages/embarkjs/src/utils.js
@@ -1,6 +1,12 @@
 /* global Web3 clearInterval setInterval */
 
 let Utils = {
+  hexPrefix: function(str) {
+    if (str === undefined) return;
+    if (str.match(/^0x/)) return str;
+
+    return `0x${str}`;
+  },
   fromAscii: function(str) {
     var _web3 = new Web3();
     return _web3.utils ? _web3.utils.fromAscii(str) : _web3.fromAscii(str);

--- a/packages/embarkjs/src/utils.js
+++ b/packages/embarkjs/src/utils.js
@@ -2,7 +2,7 @@
 
 let Utils = {
   hexPrefix: function(str) {
-    if (str === undefined) return;
+    if (!(str && str.match)) return;
     if (str.match(/^0x/)) return str;
 
     return `0x${str}`;


### PR DESCRIPTION
Set these up so we can call `deploy`, `at`, and `new` on contract classes.