### PR TITLE
fix(docs): ensure paginator helper has `__()` local

### DIFF
--- a/site/themes/embark/languages/en.yml
+++ b/site/themes/embark/languages/en.yml
@@ -267,10 +267,10 @@ footer:
 
 paginator:
   prev:
-    label: &larr; Previous
+    label: Previous
     title: Previous article
   next:
-    label: Next &rarr;
+    label: Next
     title: Next article
 
 page:

--- a/site/themes/embark/scripts/docs_paginator.js
+++ b/site/themes/embark/scripts/docs_paginator.js
@@ -6,6 +6,8 @@ hexo.extend.helper.register('docs_paginator', function() {
   const sidebar = this.site.data.sidebar[type];
   const path = pathFn.basename(this.path);
   const prefix = 'sidebar.' + type + '.';
+  const __ = hexo.theme.i18n.__(this.page.lang || this.page.language);
+
   let list = {};
 
   for (var i in sidebar) {
@@ -19,6 +21,7 @@ hexo.extend.helper.register('docs_paginator', function() {
 
   return nunjucks.render(pathFn.join(hexo.theme_dir, 'layout/partial/paginator.swig'), {
     prev: index < keys.length -1 ? { path: 'docs/'+keys[index+1] } : null,
-    next: index > 0 ? { path: 'docs/'+keys[index-1] } : null
+    next: index > 0 ? { path: 'docs/'+keys[index-1] } : null,
+    __
   });
 });


### PR DESCRIPTION
Templates used for rendering data inside helpers need to all over their local variables
passed down so they can be evaluated against some context object.

We didn't pass down the i18n `__()` function to the paginator template of our custom
theme resulting in compilation errors during site generation.

This commit fixes it.