### PR TITLE
feat(@embark/embark-blockchain-connector): Add command to get full account info

### DIFF
--- a/packages/embark-blockchain-connector/src/provider.js
+++ b/packages/embark-blockchain-connector/src/provider.js
@@ -22,6 +22,9 @@ class Provider {
       const accounts = this.accounts.map(a => a.address || a);
       cb(null, accounts);
     });
+    this.events.setCommandHandler("blockchain:provider:contract:accounts:getAll", (cb) => {
+      cb(null, this.accounts);
+    });
   }
 
   getNonce(address, callback) {


### PR DESCRIPTION
This PR adds a command to get full account details from the contradts config that includes info like private key.

The existing, and similar command, `blockchain:provider:contract:accounts:get` would only return account addresses if they existed, and not the full account info.

This is required to support obtaining private keys for signing purposes, as needed in the current state of the [`embarkjs-plasma`](https://github.com/embark-framework/embarkjs-plasma) plugin.