### PR TITLE
fix(@embark/solidity): show a better error message in debug

### DIFF
--- a/packages/embark-contracts-manager/src/index.js
+++ b/packages/embark-contracts-manager/src/index.js
@@ -581,7 +581,7 @@ class ContractsManager {
         self.compileError = true;
         self.events.emit("status", __("Compile/Build error"));
         self.events.emit("outputError", __("Error building Dapp, please check console"));
-        self.logger.error(__("Error Compiling/Building contracts: ") + err);
+        self.logger.error(__("Error Compiling/Building contracts"));
       } else {
         self.compileError = false;
       }

--- a/packages/embark-solidity/src/index.js
+++ b/packages/embark-solidity/src/index.js
@@ -49,15 +49,18 @@ class Solidity {
         return callback(output.errors);
       }
 
+      let isError = false;
       if (output.errors) {
         for (let i = 0; i < output.errors.length; i++) {
-          if (output.errors[i].type === 'Warning') {
-            self.logger.warn(output.errors[i].formattedMessage);
-          }
           if (output.errors[i].type === 'Error' || output.errors[i].severity === 'error') {
-            return callback(new Error("Solidity errors: " + output.errors[i].formattedMessage).message);
+            isError = true;
           }
+          self.logger.warn(output.errors[i].formattedMessage);
+          self.logger.debug(output.errors[i].message); // Print more error information in debug
         }
+      }
+      if (isError) {
+        return callback(__("You have solidity errors. Fix them before moving on."));
       }
 
       self.events.emit('contracts:compiled:solc', output);


### PR DESCRIPTION
When running with `loglevel=debug` you will now get more information about an error in solidity
Useful for internal errors, because solidity otherwise doesn't output much information

Also made it so that we print all errors before exiting.