### PR TITLE
fix(@embark/embarkjs-whisper): Messages.isAvailable() should always r…

### DIFF
--- a/dapps/templates/demo/app/dapp.js
+++ b/dapps/templates/demo/app/dapp.js
@@ -35,11 +35,8 @@ class App extends React.Component {
         return this.setState({error: err.message || err});
       }
 
-      EmbarkJS.Messages.Providers.whisper.getWhisperVersion((err, _version) => {
-        if (err) {
-          return console.log(err);
-        }
-        this.setState({whisperEnabled: true});
+      EmbarkJS.Messages.isAvailable().then(result => {
+        this.setState({whisperEnabled: result});
       });
 
       EmbarkJS.Storage.isAvailable().then((result) => {

--- a/packages/embarkjs/src/messages.js
+++ b/packages/embarkjs/src/messages.js
@@ -21,7 +21,7 @@ Messages.setProvider = function (providerName, options) {
 
 Messages.isAvailable = function () {
   if (!this.currentMessages) {
-    return false;
+    return Promise.resolve(false);
   }
   return this.currentMessages.isAvailable();
 };


### PR DESCRIPTION
…eturn a promise

`EmbarkJS.Messages.isAvailable()` in some cases return synchronously (when whisper isn't
set up), in other cases asynchronously. This actually breaks our demo application for
the following reason:

We check for Whisper's availability via:

```
EmbarkJS.Messages.Providers.whisper.getWhisperVersion((err, _version) => {
  if (err) {
    return console.log(err);
  }
  this.setState({whisperEnabled: true});
});
```

There's a couple of problems here:

- This code will break right away when whisper isn't available, resulting in an error:
  ```
  Cannot read property _requestManager of undefined
  ```

- The reason this error happens is because there's no `web3` object available inside
  our EmbarkJS.Messages code. Even though there **is** a web3 object, EmbarkJS.Messages
  doesn't know about this because it only sets it when its `setProvider()` API is called,
  which effectively doesn't happen at all when Whisper isn't enabled on the connected
  node

- While this could be fixed with a simple check on whether EmbarkJS.Messages' internal
  `web3` references is a thing, really what should be used in the demo is the `isAvailable()`
  API.

`isAvailable()` should always return a promise (similar to `EmbarkJS.Storage.isAvailable()`.

This commit ensures that `isAvailable()` always returns a promise and changes the demo
template to use `isAvailable()` over `getWhisperVersion()`.