### PR TITLE
fix(@embark/code-runner): restore EmbarkJS.environment property in the cli dashboard

### DIFF
--- a/packages/embark-code-runner/src/index.ts
+++ b/packages/embark-code-runner/src/index.ts
@@ -23,6 +23,8 @@ export default class CodeRunner {
   constructor(embark: Embark, _options: any) {
     this.logger = embark.logger;
     this.events = embark.events;
+
+    EmbarkJS.environment = embark.env;
     this.vm = new VM({
       require: {
         mock: {

--- a/packages/embark-typings/src/embark.d.ts
+++ b/packages/embark-typings/src/embark.d.ts
@@ -29,6 +29,7 @@ export interface Config {
 }
 
 export interface Embark {
+  env: string;
   events: Events;
   registerAPICall: any;
   registerConsoleCommand: any;


### PR DESCRIPTION
The property is set/available on EmbarkJS in the artifacts, i.e. in a browser build; but sometime since v3.2.4 it was no longer availble in the cli dashboard environment.