### PR TITLE
feat(@embark/specialconfigs): introduce dynamic address support

### DIFF
--- a/packages/embark-contracts-manager/src/index.js
+++ b/packages/embark-contracts-manager/src/index.js
@@ -376,7 +376,10 @@ class ContractsManager {
           contract.type = 'file';
           contract.className = className;
 
-          if (contract.address) {
+          if (contract.address && typeof contract.address === 'function') {
+            contract.addressHandler = contract.address;
+            delete contract.address;
+          } else if (contract.address && typeof contract.address === 'string') {
             contract.deployedAddress = contract.address;
           }
 

--- a/packages/embark-deploy-tracker/src/index.js
+++ b/packages/embark-deploy-tracker/src/index.js
@@ -37,8 +37,16 @@ class DeployTracker {
     this.embark.registerActionForEvent("deploy:beforeAll", this.setCurrentChain.bind(this));
 
     this.events.on("deploy:contract:deployed", (contract) => {
-      self.trackContract(contract.className, contract.realRuntimeBytecode, contract.realArgs, contract.deployedAddress);
-      self.save();
+      // TODO(pascal): when the `address` field in the contract configuration
+      // was a function (addressHandler), `contract.realArgs` will be undefined.
+      // Ideally we introduce an event that explicitly triggers tracking as
+      // opposed to implicitly via `deploy:contract:deployed` event.
+      //
+      // For more info see: https://github.com/embark-framework/embark/pull/1695#discussion_r302488701
+      if (contract.realArgs !== undefined) {
+        self.trackContract(contract.className, contract.realRuntimeBytecode, contract.realArgs, contract.deployedAddress);
+        self.save();
+      }
     });
 
     self.embark.registerActionForEvent("deploy:contract:shouldDeploy", (params, cb) => {

--- a/packages/embark-deployment/src/index.js
+++ b/packages/embark-deployment/src/index.js
@@ -69,6 +69,19 @@ class DeployManager {
                 if (typeof result === 'function') {
                   callback = result;
                 }
+                if (contract.addressHandler) {
+                  return self.plugins.runActionsForEvent('contract:address:handler', {contract}, (err, address) => {
+                    if (err) {
+                      errors.push(err);
+                    } else {
+                      contract.address = address;
+                      contract.deployedAddress = address;
+                      self.logger.info(__('{{contractName}} already deployed at {{address}}', {contractName: contract.className.bold.cyan, address: contract.address.bold.cyan}));
+                      self.events.emit("deploy:contract:deployed", contract);
+                    }
+                    callback();
+                  });
+                }
                 contract._gasLimit = self.gasLimit;
                 self.events.request('deploy:contract', contract, (err) => {
                   if (err) {

--- a/packages/embark-specialconfigs/src/index.js
+++ b/packages/embark-specialconfigs/src/index.js
@@ -19,6 +19,7 @@ class SpecialConfigs {
     this.registerBeforeDeployAction();
     this.registerOnDeployAction();
     this.registerDeployIfAction();
+    this.registerAddressHandlerAction();
   }
 
   replaceWithENSAddress(cmd, callback) {
@@ -173,6 +174,22 @@ class SpecialConfigs {
         cb();
       } catch (e) {
         cb(new Error(`Error running beforeDeploy hook for ${contract.className}: ${e.message || e}`));
+      }
+    });
+  }
+
+  registerAddressHandlerAction() {
+    this.embark.registerActionForEvent('contract:address:handler', async (params, cb) => {
+      const contract = params.contract;
+      try {
+        const dependencies = await this.getOnDeployLifecycleHookDependencies({
+          contractConfig: contract,
+          logPrefix: `${contract.className} > addressHandler >`
+        });
+        const address = await contract.addressHandler(dependencies);
+        cb(null, address);
+      } catch (err) {
+        return cb(new Error(`Error running addressHandler for ${contract.className}: ${err.message}`));
       }
     });
   }

--- a/packages/embark-utils/src/index.js
+++ b/packages/embark-utils/src/index.js
@@ -179,7 +179,7 @@ function prepareContractsConfig(config) {
       config.contracts[contractName].gasPrice = getWeiBalanceFromString(gasPrice);
     }
 
-    if (address) {
+    if (address && typeof address === 'string') {
       config.contracts[contractName].address = extendZeroAddressShorthand(address);
     }
 

--- a/site/source/docs/contracts_configuration.md
+++ b/site/source/docs/contracts_configuration.md
@@ -131,7 +131,7 @@ production: {
 
 In order to give users full control over which Smart Contracts should be deployed, Embark comes with a configuration feature called "deployment strategies". Deployment strategies tell Embark whether it should deploy all of the user's Smart Contracts (and its (3rd-party) dependencies, or just deploy individual Smart Contracts.
 
-There are two possible strategy options: 
+There are two possible strategy options:
 
 - **implicit** - This is the default. Using the `implicit` strategy, Embark tries to deploy all Smart Contracts configured in the `contracts` configuration, including its (3rd-party) dependencies.
 - **explicit** - Setting this option to `explicit` tells Embark to deploy the Smart Contracts specified in the `contracts` configuration without their dependencies. This can be combined with [disabling deployment](#Disabling-deployment) of individual Smart Contracts for fine control.
@@ -185,6 +185,28 @@ contracts: {
 }
 ...
 ```
+
+## Dynamic Addresses
+
+There are scenarios in which we want to configure a Smart Contract that is already deployed by a third-party, but its address can only be computed at run-time. For such cases, Embark supports specifying a function as `address`, which returns the address we're interested in. Usually, other Smart Contract instances are needed to perform that computation, so the [`deps` configuration](#Deployment-hooks) comes in handy as well:
+
+```
+contracts: {
+  SimpleStorage: {
+    fromIndex: 0,
+    args: [100],
+  },
+  OtherContract: {
+    deps: ['SimpleStorage'],
+    address: async (deps) => {
+      // use `deps.contracts.SimpleStorage` to determine and return address
+    },
+    abiDefinition: ABI
+  },
+}
+```
+
+In the example above, `OtherContract` will be deployed after `SimpleStorage` because it uses the `deps` property to define Smart Contracts that it depends on. All dependencies are exposed on the `address` function parameter similar to [deployment hooks](#Deployment-hooks).
 
 ## Configuring source files
 
@@ -505,7 +527,7 @@ contracts: {
 }
 ```
 
-Which will result in 
+Which will result in
 
 ```
 SimpleStorage > onDeploy > Hello from onDeploy!


### PR DESCRIPTION
This commit introduces a new Smart Contract configuration `addressHandler`
that lets users define a function to "lazily" compute the address of the
Smart Contract in question.

This is useful when a third-party takes care of deploying a dependency
Smart Contract, but the address of that Smart Contract only being available
at run-time.

Example:

```
contracts: {
  SimpleStorage: {
    fromIndex: 0,
    args: [100],
  },
  OtherContract: {
    deps: ['SimpleStorage'],
    addressHandler: async (deps) => {
      // use `deps.contracts.SimpleStorage` to determine address
    },
    abiDefinition: ABI
  },
}
```

In the example above, `OtherContract` will be deployed after `SimpleStorage`
because it uses the `deps` property to define Smart Contracts that it depends
on. All dependencies are exposed on the `addressHandler` function parameter
similar to deployment hooks.

**Note**: This only works when an ABI is provided for the Smart Contract that
is already deployed (in this case `OtherContract`).

Closes #1690