### PR TITLE
fix(@embark/ipc): transform functions as string before stringify

### DIFF
--- a/packages/embark-console/src/lib/index.ts
+++ b/packages/embark-console/src/lib/index.ts
@@ -6,6 +6,7 @@ import { __ } from "embark-i18n";
 import { dappPath, escapeHtml, exit, jsonFunctionReplacer } from "embark-utils";
 import stringify from "json-stringify-safe";
 import { dirname } from "path";
+import util from "util";
 import Suggestions from "./suggestions";
 
 type MatchFunction = (cmd: string) => boolean;
@@ -49,7 +50,7 @@ class Console {
             // reformat for IPC reply
             error = { name: "Console error", message: err, stack: err };
           }
-          cb(error, result);
+          cb(error, util.inspect(result));
         });
       });
       this.ipc.on("console:history:save", true, (cmd: string) => {


### PR DESCRIPTION
This fixes a bug where if you have `embark console` connected via IPC to `embark run`, getting an object that contains functions via the console would return an empty object. That's because flatted, the library we use to `stringify`, removes it because of possible circular dependencies.

Only problem with my fix is it doesn't fix getting `SimpleStorage`, ie the `methods` param would still be empty, but doing `SimpleSotrage.methods` works.

~~I tried fixing this by doing a recursive function, but it couldn't handle circular dependencies and I ended up making the choice to make a simple yet flawed solution instead of a complex but complete one, because the result is not worth the cost IMO. Tell me if you think otherwise.~~

Fixed by using util.inspect for the data