### PR TITLE
feat(@cockpit): Pass tx value as wei and add validation

### DIFF
--- a/packages/embark-contracts-manager/src/index.js
+++ b/packages/embark-contracts-manager/src/index.js
@@ -117,14 +117,13 @@ class ContractsManager {
           if (error) {
             return res.send({error: error.message});
           }
-          const {account, contract, web3} = result;
+          const {account, contract} = result;
           const abi = contract.abiDefinition.find(definition => definition.name === req.body.method);
           const funcCall = (abi.constant === true || abi.stateMutability === 'view' || abi.stateMutability === 'pure') ? 'call' : 'send';
 
           self.events.request("blockchain:contract:create", {abi: contract.abiDefinition, address: contract.deployedAddress}, async (contractObj) => {
             try {
               let value = typeof req.body.value === "number" ? req.body.value.toString() : req.body.value;
-              value = web3.utils.toWei(value, 'ether');
               const gas = await contractObj.methods[req.body.method].apply(this, req.body.inputs).estimateGas({ value });
               contractObj.methods[req.body.method].apply(this, req.body.inputs)[funcCall]({
                 from: account,

--- a/packages/embark-ui/package.json
+++ b/packages/embark-ui/package.json
@@ -59,6 +59,7 @@
     "babel-plugin-named-asset-import": "0.2.3",
     "babel-preset-react-app": "6.1.0",
     "bfj": "6.1.1",
+    "bignumber.js": "2.0.7",
     "case-sensitive-paths-webpack-plugin": "2.1.2",
     "chalk": "2.4.2",
     "classnames": "2.2.6",

--- a/packages/embark-ui/src/constants.js
+++ b/packages/embark-ui/src/constants.js
@@ -13,3 +13,7 @@ export const OPERATIONS = {
   LESS: -1
 };
 export const PAGE_TITLE_PREFIX = "Embark Cockpit";
+export const BALANCE_REGEX = /([0-9]+(?:\.[0-9]+)?)(?: ?([a-zA-Z]*))?/;
+export const ETHER_UNITS = [
+  "noether", "wei", "kwei", "Kwei", "babbage", "femtoether", "mwei", "Mwei", "lovelace", "picoether", "gwei", "Gwei", "shannon", "nanoether", "nano", "szabo", "microether", "micro", "finney", "milliether", "milli", "ether", "kether", "grand", "mether", "gether", "tether"
+];

--- a/packages/embark-ui/src/utils/utils.js
+++ b/packages/embark-ui/src/utils/utils.js
@@ -1,7 +1,10 @@
 import Convert from 'ansi-to-html';
 import qs from 'qs';
 
-import {DARK_THEME} from '../constants';
+import {DARK_THEME, BALANCE_REGEX} from '../constants';
+
+import {toWei} from 'web3-utils';
+import BigNumber from 'bignumber.js';
 
 export function last(array) {
   return array && array.length ? array[array.length - 1] : undefined;
@@ -49,3 +52,19 @@ export function stripQueryParam(location, param) {
 }
 
 export const isDarkTheme = (theme) => theme === DARK_THEME;
+
+export function getWeiBalanceFromString(balanceString: string) {
+  if (!balanceString) {
+    return 0;
+  }
+  const match = balanceString.match(BALANCE_REGEX);
+  if (!match) {
+    throw new Error(`Unrecognized balance string "${balanceString}"`);
+  }
+  // if no units passed in, assume we are dealing with wei
+  if (!match[2]) {
+    return new BigNumber(match[1]).toString(10);
+  }
+
+  return toWei(match[1], match[2]);
+}

--- a/packages/embark-utils/src/constants.ts
+++ b/packages/embark-utils/src/constants.ts
@@ -1,2 +1,2 @@
 export const unitRegex = /([0-9]+) ([a-zA-Z]+)/;
-export const balanceRegex = /([0-9]+) ?([a-zA-Z]*)/;
+export const balanceRegex = /([0-9]+(?:\.[0-9]+)?)(?: ?([a-zA-Z]*))?/;

--- a/yarn.lock
+++ b/yarn.lock
@@ -4542,14 +4542,14 @@ big.js@^3.1.3:
   resolved "https://registry.yarnpkg.com/big.js/-/big.js-3.2.0.tgz#a5fc298b81b9e0dca2e458824784b65c52ba588e"
   integrity sha512-+hN/Zh2D08Mx65pZ/4g5bsmNiZUuChDiQfTUQ7qJr4/kuopCr88xZsAXv6mBoZEsUI4OuGHlX59qE94K2mMW8Q==
 
+bignumber.js@2.0.7, "bignumber.js@git+https://github.com/frozeman/bignumber.js-nolookahead.git":
+  version "2.0.7"
+  resolved "git+https://github.com/frozeman/bignumber.js-nolookahead.git#57692b3ecfc98bbdd6b3a516cb2353652ea49934"
+
 bignumber.js@^2.3.0:
   version "2.4.0"
   resolved "https://registry.yarnpkg.com/bignumber.js/-/bignumber.js-2.4.0.tgz#838a992da9f9d737e0f4b2db0be62bb09dd0c5e8"
   integrity sha1-g4qZLan51zfg9LLbC+YrsJ3Qxeg=
-
-"bignumber.js@git+https://github.com/frozeman/bignumber.js-nolookahead.git":
-  version "2.0.7"
-  resolved "git+https://github.com/frozeman/bignumber.js-nolookahead.git#57692b3ecfc98bbdd6b3a516cb2353652ea49934"
 
 binary-extensions@^1.0.0:
   version "1.12.0"


### PR DESCRIPTION
For payable methods inside of the contract interatction section of cockpit, the value input has been updated to pass wei to the API. The input field now accepts value like `100 ether` or 25 szabo`. The value entered is automatically converted to wei and shown to the user in real time.

Additionally, the input is validated for a correct value, with an error shown to the user for incorrectly entered values.

A tooltip has been added to help the user enter correct values.

UI updates can be seen in video here: https://monosnap.com/file/642cHH2HxDeiFLzB2VLqHP9GuqoRfz