### PR TITLE
fix(@cockpit): don't send invalid value to Smart Contract methods

### DIFF
--- a/packages/embark-ui/src/components/ContractOverview.js
+++ b/packages/embark-ui/src/components/ContractOverview.js
@@ -37,7 +37,7 @@ class ContractFunction extends Component {
       optionsCollapse: false,
       functionCollapse: false,
       gasPriceCollapse: false,
-      value: -1,
+      value: 0,
       unitConvertError: null,
       unitConvertDirty: false
     };


### PR DESCRIPTION
We've introduced a regression in https://github.com/embark-framework/embark/commit/536a4029ba1f544c8050c42eefeb439ff028f2f9 where the default
`value` sent to payable Smart Contract methods is `-1`, resulting in errors as it's not
a valid value.

In fact, this value is sent to all methods called through Cockpit, breaking also non-payable methods.