### PR TITLE
fix(@embark/test-runner): make `--tx-details` option work again

### DIFF
--- a/packages/embark-test-runner/src/reporter.js
+++ b/packages/embark-test-runner/src/reporter.js
@@ -55,7 +55,14 @@ class EmbarkSpec extends Base {
       if (self.txDetails) {
         self.embarkEvents.request('contracts:contract', receipt.className, (contract) => {
           if (contract) {
-            self.contracts.push(contract);
+            let index = self.contracts.findIndex(c => c.className === contract.className);
+            // It's possible to deploy the same contract multiple times per test, so we need
+            // to make sure we replace the existing one with the new one.
+            if (index > -1) {
+              self.contracts[index] = contract;
+            } else {
+              self.contracts.push(contract);
+            }
             self.addressToContract = getAddressToContract(self.contracts, self.addressToContract);
           }
         });
@@ -145,7 +152,6 @@ class EmbarkSpec extends Base {
 
     runner.on('test', function() {
       self.stats.test.gasUsed = 0;
-      self.contracts = [];
     });
 
     runner.on('pass', function(test) {


### PR DESCRIPTION
In https://github.com/embark-framework/embark/commit/87d92b6091 we've introduced a feature in our test runner
to report exact gas costs used when calling Smart Contract methods that
cause computation.

Embark keeps a list of deployed contracts in memory and for all transactions
happening during tests, it'll match them to the contracts that performed them
to produce the report logs.

Unfortunately, we've been [resetting that memory](https://github.com/embark-framework/embark/commit/87d92b6091#diff-92b4f79a0473160fe700440b1ced5204R140) of deployed contracts
after every test, making it practically impossible for Embark to find
matching contracts for any transactions, because contracts aren't necessarily
redeployed per spec, resulting in no additional transaction logs whatsoever.

This commit ensures that the memory is never erased and at the same time
ensures it's not leaking infinitely in case multiple contracts are
deployed multiple times in the same process over several specs.