### PR TITLE
fix(@embark): Fix race condition

### DIFF
--- a/packages/embark-code-runner/package.json
+++ b/packages/embark-code-runner/package.json
@@ -48,6 +48,7 @@
     "@babel/runtime-corejs2": "7.3.1",
     "async": "2.6.1",
     "colors": "1.3.2",
+    "embark-core": "^4.1.0-beta.4",
     "embark-utils": "^4.1.0-beta.4",
     "embarkjs": "^4.1.0-beta.3",
     "fs-extra": "7.0.1",

--- a/packages/embark-core/package.json
+++ b/packages/embark-core/package.json
@@ -28,21 +28,20 @@
   },
   "main": "./dist/index.js",
   "scripts": {
-    "build": "cross-env BABEL_ENV=node babel src --extensions \".js\" --out-dir dist --root-mode upward --source-maps",
+    "build": "cross-env BABEL_ENV=node babel src --extensions \".js,.ts\" --out-dir dist --root-mode upward --source-maps",
     "ci": "npm run qa",
     "clean": "npm run reset",
     "lint": "npm-run-all lint:*",
     "lint:js": "eslint process.js src/",
-    "// lint:ts": "tslint -c tslint.json \"src/**/*.ts\"",
+    "lint:ts": "tslint -c tslint.json \"src/**/*.ts\"",
     "package": "npm pack",
-    "// qa": "npm-run-all lint typecheck build package",
-    "qa": "npm-run-all lint build package",
+    "qa": "npm-run-all lint typecheck build package",
     "reset": "npx rimraf dist embark-*.tgz package",
     "start": "npm run watch",
-    "// typecheck": "tsc",
+    "typecheck": "tsc",
     "watch": "run-p watch:*",
     "watch:build": "npm run build -- --verbose --watch",
-    "// watch:typecheck": "npm run typecheck -- --preserveWatchOutput --watch"
+    "watch:typecheck": "npm run typecheck -- --preserveWatchOutput --watch"
   },
   "eslintConfig": {
     "extends": "../../.eslintrc.json"

--- a/packages/embark-core/src/enums.ts
+++ b/packages/embark-core/src/enums.ts
@@ -1,0 +1,4 @@
+export enum ProviderEventType {
+  ProviderRegistered = "providerRegistered",
+  ProviderSet = "providerSet",
+}

--- a/packages/embark-core/src/index.js
+++ b/packages/embark-core/src/index.js
@@ -3,3 +3,4 @@ export { ProcessManager } from './processes/processManager';
 export { ProcessWrapper } from './processes/processWrapper';
 
 export { IPC } from './ipc';
+export { ProviderEventType } from './enums';

--- a/packages/embark/src/lib/core/plugin.js
+++ b/packages/embark/src/lib/core/plugin.js
@@ -230,9 +230,12 @@ Plugin.prototype.registerUploadCommand = function(cmd, cb) {
 
 Plugin.prototype.addCodeToEmbarkJS = function(code) {
   this.addPluginType('embarkjsCode');
-  // TODO: what is this/why
+  // TODO: what is this/why - this was an attempt to prevent duplication of code in embarkjs
   if (!this.embarkjs_code.some((existingCode) => deepEqual(existingCode, code))) {
     this.embarkjs_code.push(code);
+    this.events.request('blockchain:ready', () => {
+      this.events.emit('runcode:embarkjs-code:updated', code, () => {});
+    });
   }
 };
 
@@ -253,6 +256,9 @@ Plugin.prototype.addConsoleProviderInit = function(providerType, code, initCondi
   const toAdd = [code, initCondition];
   if (!this.embarkjs_init_console_code[providerType].some((initConsoleCode) => deepEqual(initConsoleCode, toAdd))) {
     this.embarkjs_init_console_code[providerType].push(toAdd);
+    this.events.request('blockchain:ready', () => {
+      this.events.emit('runcode:init-console-code:updated', code, () => {});
+    });
   }
 };
 


### PR DESCRIPTION
There was a “regression” in https://github.com/embark-framework/embark/commit/7652e1d75cf8f778ccf44ee7b28e124e83b0a701 in that firing of module `registerProvider` and `setProvider` events were removed. This PR adds back in the firing of those events back in, so that we can properly check if a module has added it’s EmbarkJS code to EmbarkJS before considering the module “ready” (a more in-depth write can be found here: https://notes.status.im/DC8AUDK8RjWZBb2A1KfeLg.

More specifically, there was a race that was present on faster machines. It was found that storage code meant to run through the console was never fired. This line was never run: https://github.com/embark-framework/embark/blob/3590197c5548ab51eb346b49a4d2fee5530a5357/packages/embark-storage/src/index.js#L54. 

To emulate the race condition, wrap line https://github.com/embark-framework/embark/blob/3590197c5548ab51eb346b49a4d2fee5530a5357/packages/embark-storage/src/index.js#L23-L26 with
```javascript
setTimeout(() => {
  //  code here...
}, 5000);
```
This will delay the adding of `EmbarkJS.Storage.setProviders` in to EmbarkJS, and EmbarkJS is then built before this has had a chance to run. This PR fixes this race condition, by ensuring that all EmbarkJS.* modules have had their `.registerProvider` and `.setProvider`’s run before EmbarkJS is built.

Add condition that all EmbarkJS module’s `registerProvider` and `setProvider` have been fired before code generating `embarkjs.js`.