### PR TITLE
Add option to contract config to reduce size of contracts

### DIFF
--- a/dapps/templates/boilerplate/config/contracts.js
+++ b/dapps/templates/boilerplate/config/contracts.js
@@ -52,7 +52,9 @@ module.exports = {
     //strategy: 'implicit',
 
     // minimalContractSize, when set to true, tells Embark to generate contract files without the heavy bytecodes
+    // Using filteredFields lets you customize which field you want to filter out of the contract file (requires minimalContractSize: true)
     // minimalContractSize: false,
+    // filteredFields: [],
 
     contracts: {
       // example:

--- a/dapps/templates/boilerplate/config/contracts.js
+++ b/dapps/templates/boilerplate/config/contracts.js
@@ -51,6 +51,9 @@ module.exports = {
     //            contracts section.
     //strategy: 'implicit',
 
+    // minimalContractSize, when set to true, tells Embark to generate contract files without the heavy bytecodes
+    // minimalContractSize: false,
+
     contracts: {
       // example:
       //SimpleStorage: {

--- a/dapps/templates/demo/config/contracts.js
+++ b/dapps/templates/demo/config/contracts.js
@@ -52,7 +52,9 @@ module.exports = {
     //strategy: 'implicit',
 
     // minimalContractSize, when set to true, tells Embark to generate contract files without the heavy bytecodes
+    // Using filteredFields lets you customize which field you want to filter out of the contract file (requires minimalContractSize: true)
     // minimalContractSize: false,
+    // filteredFields: [],
 
     contracts: {
       SimpleStorage: {

--- a/dapps/templates/demo/config/contracts.js
+++ b/dapps/templates/demo/config/contracts.js
@@ -51,6 +51,9 @@ module.exports = {
     //            contracts section.
     //strategy: 'implicit',
 
+    // minimalContractSize, when set to true, tells Embark to generate contract files without the heavy bytecodes
+    // minimalContractSize: false,
+
     contracts: {
       SimpleStorage: {
         fromIndex: 0,

--- a/dapps/templates/simple/contracts.js
+++ b/dapps/templates/simple/contracts.js
@@ -52,7 +52,9 @@ module.exports = {
     //strategy: 'implicit',
 
     // minimalContractSize, when set to true, tells Embark to generate contract files without the heavy bytecodes
+    // Using filteredFields lets you customize which field you want to filter out of the contract file (requires minimalContractSize: true)
     // minimalContractSize: false,
+    // filteredFields: [],
 
     contracts: {
       // example:

--- a/dapps/templates/simple/contracts.js
+++ b/dapps/templates/simple/contracts.js
@@ -51,6 +51,9 @@ module.exports = {
     //            contracts section.
     //strategy: 'implicit',
 
+    // minimalContractSize, when set to true, tells Embark to generate contract files without the heavy bytecodes
+    // minimalContractSize: false,
+
     contracts: {
       // example:
       //SimpleStorage: {

--- a/packages/embark-pipeline/src/index.js
+++ b/packages/embark-pipeline/src/index.js
@@ -341,6 +341,14 @@ class Pipeline {
       },
       function writeContractsJSON(contracts, next) {
         async.each(contracts, (contract, eachCb) => {
+          if (self.embark.config.contractsConfig.minimalContractSize) {
+            contract = Object.assign({}, contract);
+            delete contract.code;
+            delete contract.runtimeBytecode;
+            delete contract.realRuntimeBytecode;
+            delete contract.gasEstimates;
+            delete contract.swarmHash;
+          }
           self.fs.writeJson(dappPath(
             self.buildDir,
             'contracts', contract.className + '.json'

--- a/packages/embark-pipeline/src/index.js
+++ b/packages/embark-pipeline/src/index.js
@@ -343,11 +343,17 @@ class Pipeline {
         async.each(contracts, (contract, eachCb) => {
           if (self.embark.config.contractsConfig.minimalContractSize) {
             contract = Object.assign({}, contract);
-            delete contract.code;
-            delete contract.runtimeBytecode;
-            delete contract.realRuntimeBytecode;
-            delete contract.gasEstimates;
-            delete contract.swarmHash;
+
+            const filteredFields = self.embark.config.contractsConfig.filteredFields || [
+              'code',
+              'runtimeBytecode',
+              'realRuntimeBytecode',
+              'gasEstimates',
+              'swarmHash'
+            ];
+            filteredFields.forEach(filteredField => {
+              delete contract[filteredField];
+            });
           }
           self.fs.writeJson(dappPath(
             self.buildDir,

--- a/site/source/docs/contracts_configuration.md
+++ b/site/source/docs/contracts_configuration.md
@@ -354,7 +354,16 @@ To reduce the size of the contract JSON files that are included in the build dir
 When set to `true`, Embark will not put te bytecode, gas estimates and other big configurations in the JSON file.
 
 ```
-minimalContractSize: true
+minimalContractSize: true,
+```
+
+You can also have more control over the filtering by adding a `filteredFields` array. In the array, you can add the name of the fields you want to filter out.
+This is useful for when you want to reduce the size of the contract files, but might still need a certain field, or if you want to filter even more aggressively.
+Note that you need to have `minimalContractSize` set to `true`.
+
+```
+minimalContractSize: true,
+filteredFields: ['runtimeBytecode', 'realRuntimeBytecode'] // This will filter out only runtimeBytecode and realRuntimeBytecode
 ```
 
 

--- a/site/source/docs/contracts_configuration.md
+++ b/site/source/docs/contracts_configuration.md
@@ -347,6 +347,17 @@ tracking: 'path/to/some/file'
 
 Having the file referenced above under version control ensures that other users of our project don't redeploy the Smart Contracts on different platforms.
 
+
+### Reducing contract size
+
+To reduce the size of the contract JSON files that are included in the build directory, you can set `minimalContractSize` to `true`. It defaults to `false`.
+When set to `true`, Embark will not put te bytecode, gas estimates and other big configurations in the JSON file.
+
+```
+minimalContractSize: true
+```
+
+
 ## Deployment hooks
 
 Sometimes we want to execute certain logic when Smart Contracts are being deployed or after all of them have been deployed. In other cases, we'd even like to control whether a Smart Contract should be deployed in the first place. For those scenarios, Embark lets us define the deployment hooks `beforeDeploy`, `deployIf`, `onDeploy` and `afterDeploy`.


### PR DESCRIPTION
Adds `minimalContractSize` option in contract config to reduce the size of the files.

Fixes https://github.com/embark-framework/embark/issues/1712

Name of the option can change