### PR TITLE
fix(@cockpit/ens) show error message when ENS registration fails

### DIFF
--- a/packages/embark-ui/src/components/EnsRegister.js
+++ b/packages/embark-ui/src/components/EnsRegister.js
@@ -36,8 +36,8 @@ class EnsRegister extends Component {
   }
 
   showResult() {
-    if (this.props.ensErrors) {
-      return <Alert className="mt-3" color="danger">An error happened: {this.props.ensErrors}</Alert>;
+    if (this.props.errorMessage) {
+      return <Alert className="mt-3" color="danger">An error happened: {this.props.errorMessage}</Alert>;
     } else {
       return <Alert className="mt-3" color="success">Successfully registered</Alert>;
     }

--- a/packages/embark-ui/src/containers/EnsContainer.js
+++ b/packages/embark-ui/src/containers/EnsContainer.js
@@ -19,7 +19,7 @@ class EnsContainer extends Component {
           <Col xs="12" sm="9" lg="6">
             <EnsLookup lookup={this.props.lookup} ensRecords={this.props.ensRecords}/>
             <EnsResolve resolve={this.props.resolve} ensRecords={this.props.ensRecords}/>
-            <EnsRegister register={this.props.register} ensRecords={this.props.ensRecords} ensErrors={this.props.ensErrors}/>
+            <EnsRegister register={this.props.register} ensRecords={this.props.ensRecords} ensErrors={this.props.ensErrors} errorMessage={this.props.errorMessage}/>
           </Col>
         </Row>
       </React.Fragment>
@@ -52,7 +52,8 @@ function mapStateToProps(state) {
   return {
     ensRecords: getEnsRecords(state),
     ensErrors: getEnsErrors(state),
-    isEnsEnabled: isEnsEnabled(state)
+    isEnsEnabled: isEnsEnabled(state),
+    errorMessage: state.errorMessage,
   };
 }
 


### PR DESCRIPTION
Turns out Cockpit doesn't handle errors not very well. In the ENS utilities
users can register a subdomain with an address. No matter what is entered
and sent to Embark, Cockpit will always show that the registration was successful.

The server sends an error message correctly, it's just not processed in the
front-end properly. This is due to how our reducers are implemented and in fact,
it looks like the `errorEntities()` reducer doesn't work at all. At least
I couldn't see a case where it would work.

The bottomline for this component is: it tries to read from `errorEntities.ensRecords`
but that state will never be set and in fact, it turns out to be hard to set
as well.

What does get set properly however is the `errorMessage` in the root state.
After trying for a long time to get a proper error state into our store I gave
up and decided to just pass down the `errorMessage` to the ENSRegister component
for now.

Hopefully someone who feels like digging down our reducer rabbit whole will
properly fix this and make all `FAILURE` cases in our reducers/store work.