### PR TITLE
fix(@embark/test-runner): fix describe in describe tests

### DIFF
--- a/dapps/tests/app/test/token_spec.js
+++ b/dapps/tests/app/test/token_spec.js
@@ -50,46 +50,52 @@ config({
   }
 });
 
-describe("Token", function () {
+describe("Token", function() {
   this.timeout(0);
 
-  it("not deploy Token", function () {
-    assert.strictEqual(Token.address, undefined);
+  describe('Token Contract', function() {
+    it("not deploy Token", function() {
+      assert.strictEqual(Token.address, undefined);
+    });
   });
 
-  it("should deploy MyToken and MyToken2", function () {
-    assert.ok(MyToken.options.address);
-    assert.ok(MyToken2.options.address);
+  describe('MyToken Contracts', function() {
+    it("should deploy MyToken and MyToken2", function() {
+      assert.ok(MyToken.options.address);
+      assert.ok(MyToken2.options.address);
+    });
+
+    it("set MyToken Balance correctly", async function() {
+      let result = await MyToken.methods._supply().call();
+      assert.strictEqual(parseInt(result, 10), 1000);
+    });
+
+    it("set MyToken2 Balance correctly", async function() {
+      let result = await MyToken2.methods._supply().call();
+      assert.strictEqual(parseInt(result, 10), 2000);
+    });
   });
 
-  it("set MyToken Balance correctly", async function () {
-    let result = await MyToken.methods._supply().call();
-    assert.strictEqual(parseInt(result, 10), 1000);
-  });
+  describe('Other Contarcts', function() {
+    it("get right address", function() {
+      assert.strictEqual(AlreadyDeployedToken.options.address.toLowerCase(),
+        "0xCAFECAFECAFECAFECAFECAFECAFECAFECAFECAFE".toLowerCase());
+    });
 
-  it("set MyToken2 Balance correctly", async function () {
-    let result = await MyToken2.methods._supply().call();
-    assert.strictEqual(parseInt(result, 10), 2000);
-  });
+    it("should use onDeploy", async function() {
+      let result = await Test.methods.addr().call();
+      assert.strictEqual(result, MyToken.options.address);
+    });
 
-  it("get right address", function () {
-    assert.strictEqual(AlreadyDeployedToken.options.address.toLowerCase(),
-      "0xCAFECAFECAFECAFECAFECAFECAFECAFECAFECAFE".toLowerCase());
-  });
+    it("should not deploy if deployIf returns false", function() {
+      assert.ok(!SomeContract.options.address);
+    });
 
-  it("should use onDeploy", async function () {
-    let result = await Test.methods.addr().call();
-    assert.strictEqual(result, MyToken.options.address);
-  });
-
-  it("should not deploy if deployIf returns false", function() {
-    assert.ok(!SomeContract.options.address);
-  });
-
-  it("should set the ens attr to the address of embark.eth", async function() {
-    let result = await Test.methods.ens().call();
-    // Testing that it is an address as we don't really know the address
-    assert.strictEqual(web3.utils.isAddress(result), true);
-    assert.notStrictEqual(result, '0x0000000000000000000000000000000000000000');
+    it("should set the ens attr to the address of embark.eth", async function() {
+      let result = await Test.methods.ens().call();
+      // Testing that it is an address as we don't really know the address
+      assert.strictEqual(web3.utils.isAddress(result), true);
+      assert.notStrictEqual(result, '0x0000000000000000000000000000000000000000');
+    });
   });
 });

--- a/packages/embark-test-runner/src/index.js
+++ b/packages/embark-test-runner/src/index.js
@@ -235,9 +235,20 @@ class TestRunner {
                 if (global.embark.needConfig) {
                   global.config({});
                 }
-                global.embark.onReady((_err, accounts) => {
+
+                function runDescribe(accounts) {
                   self.ogMochaDescribe(describeName, callback.bind(mocha, accounts));
+                  setImmediate(() => {
+                    global.run(); // Call `run` in setImmediate to make sure tests with no `config()` don't hang
+                  });
                   global.run(); // This tells mocha that it can run the test (used in conjunction with `delay()`
+                }
+                if (global.embark.ready) {
+                  // Call describe straightaway otherwise `describe` inside `describe` end with 0 Passing
+                  return runDescribe(global.embark.accounts);
+                }
+                global.embark.onReady((_err, accounts) => {
+                  runDescribe(accounts);
                 });
               }
 


### PR DESCRIPTION
Discovered while running tests in Teller after updating to the latest 4.1 beta.
The tests would pass as `0 tests passed`. 
This was due to the fact that Teller has `describe` inside `describe`, which is a totally valid thing to do.
The problem is that evaluating those `describe`s is sync, but our code that waits for the `config()` to be finished is async. Even if the `config` already finished, the `setImmediate` makes it so that Mocha thinks there are no more tests because we don't call  `run` in the same loop.

The solution in this PR is not super pretty, but it works. Basically, if we see that `global.embark`(test.js) is ready, we don't wait for `onReady`, because otherwise, Mocha will skip the tests, so we call `global.run()` straightaway.
This leads to the other ugly fix, I need to run `global.run()` straightaway, but also run it inside a `setImmediate`, because tests that **don't** use `config()` would hang, because the `run` would happen too fast.

Anyway, let me know what you think. Is it too ugly? Do you think of  a better way? 
All in all, at least it works for "all" cases now.