### PR TITLE
fix(@embark/embark-blockchain-process): Support WSS URLs

### DIFF
--- a/packages/embark-blockchain-process/src/utils.js
+++ b/packages/embark-blockchain-process/src/utils.js
@@ -44,7 +44,7 @@ export function pingEndpoint(host, port, type, protocol, origin, callback) {
   };
 
   if (type === "ws") {
-    const url = `${protocol === "https" ? "wss" : "ws"}://${_host}:${port}/`;
+    const url = `${protocol === "wss" ? "wss" : "ws"}://${_host}${port ? ":" + port : ""}/`;
     const req = new (require("ws"))(url, origin ? {origin} : {});
     handleRequest(req, "close", "open");
   } else {


### PR DESCRIPTION
Endpoints without ports were being built with “undefined” as the port, ie “https://node.sirius.lightstreams.io:undefined”. This has been fixed to add support for URLs without ports, ie “https://node.sirius.lightstreams.io”.

WSS endpoints were being forced in to using “ws://“ protocol in the URL. This has been fixed, so that WSS endpoints use “wss://“ in the URL.

NOTE: This is requested to merge in to the v5 config updates branch `feat/new-config`.