### PR TITLE
fix(@embark/embark-storage): Fix embark not running

### DIFF
--- a/packages/embark-storage/src/index.js
+++ b/packages/embark-storage/src/index.js
@@ -62,13 +62,13 @@ class Storage {
 
     async.parallel([
       (next) => {
-        if (!this.storageConfig.available_providers.includes('ipfs')) {
+        if (!this.embark.config.storageConfig.available_providers.includes('ipfs')) {
           return next();
         }
         this.embark.events.once('ipfs:process:started', next);
       },
       (next) => {
-        if (!this.storageConfig.available_providers.includes('swarm')) {
+        if (!this.embark.config.storageConfig.available_providers.includes('swarm')) {
           return next();
         }
         this.embark.events.once('swarm:process:started', next);


### PR DESCRIPTION
The Embark process was crashing due to an config object not existing on `this`.

This PR references the correct config object.

NOTE: This PR is required to get the v5 config updates changes to run without crashing embark, and is set to merge in to the `feat/new-config` branch.