### PR TITLE
feat(@embark/blockchain): Add support for blockchain plugins

### DIFF
--- a/packages/embark-blockchain-process/index.d.ts
+++ b/packages/embark-blockchain-process/index.d.ts
@@ -1,0 +1,146 @@
+import { Environment } from "embark";
+
+declare module "embark-blockchain-process" {
+
+  /**
+   * Node account settings in the blockchain config.
+   */
+  export interface NodeAccountSetting {
+    /**
+     * Number of node accounts to create if they don't already exist.
+     */
+    numAccounts: Number;
+    /**
+     * Password for creating and unlocking node accounts
+     */
+    password: String;
+    /**
+     * Balance to send to each of the node accounts (development only)
+     */
+    balance: String;
+  }
+  export interface Config {
+    silent: boolean;
+    client: string;
+    ethereumClientBin: string;
+    networkType: string;
+    networkId: number;
+    genesisBlock: string | boolean;
+    datadir: string;
+    mineWhenNeeded: boolean;
+    rpcHost: string;
+    rpcPort: number;
+    rpcCorsDomain: string;
+    rpcApi: Array<String>;
+    port: number;
+    nodiscover: boolean;
+    mine: boolean;
+    account: NodeAccountSetting;
+    whisper: boolean;
+    maxpeers: number;
+    bootnodes: string;
+    wsRPC: boolean;
+    wsHost: string;
+    wsPort: number;
+    wsOrigins: string | boolean;
+    wsApi: Array<string>;
+    vmdebug: boolean;
+    targetGasLimit: number;
+    syncMode: string;
+    verbosity: number;
+    proxy: boolean;
+  }
+  /**
+   * Options passed in to the blockchain plugin client
+   */
+  export interface BaseBlockchainClientOptions {
+    /**
+     * Blockchain client config
+     */
+    config: Config;
+    /**
+     * The current runtime environment of Embark, set by running `embark run <environment>`.
+     */
+    env: Environment;
+    /**
+     * Determined by whether the current runtime environment is development or not.
+     */
+    isDev: boolean;
+    /**
+     * Name of blockchain client - used in the blockchain config "client" property
+     */
+    name: string;
+    /**
+     * Pretty name of blockchain client
+     */
+    prettyName: string;
+    /**
+     * Default client configuration options
+     */
+    defaults: BlockchainClientDefaults;
+    /**
+     * Mimimum client version supported, ie ">=1.3.0"
+     */
+    versSupported: string;
+    /**
+     * Regex used to parse the version from the version command (returned from determineVersionCommand())
+     */
+    versionRegex: string;
+    /**
+     * Absolute path to the blockchain client class
+     * @example
+     * require.resolve("./client")
+     */
+    clientPath: string;
+  }
+
+  /**
+   * Options to pass to the base class and to the blockchain client.
+   */
+  export interface BlockchainClientDefaults {
+    /**
+     * CLI binary to run the blockchain client
+     * @example
+     * geth
+     * @example
+     * lightchain
+     */
+    bin: string;
+    /**
+     * Network type. This can be used in the blockchain client to run differently for different networks.
+     * @example
+     * standalone
+     * @example
+     * sirius
+     */
+    networkType?: string;
+    /**
+     * RPC APIs to expose in the blockchain client
+     * @example
+     * ['eth', 'web3', 'net', 'debug', 'personal']
+     */
+    rpcApi: Array<string>;
+    /**
+     * Websockets APIs to expose in the blockchain client
+     * @example
+     * ['eth', 'web3', 'net', 'debug', 'pubsub', 'personal']
+     */
+    wsApi: Array<string>;
+    /**
+     * Websockets APIs to expose in the blockchain client when running in development mode.
+     * @example
+     * ['eth', 'web3', 'net', 'debug', 'pubsub', 'personal']
+     */
+    devWsApi: Array<string>;
+    /**
+     * Network ID of the network connected to by the blockchain client. The network connection
+     * can be determined in the blockchain client, based on config settings like networkType and
+     * runtime environment.
+     */
+    networkId?: number;
+    /**
+     * Target gas limit for the blockchain client.
+     */
+    targetGasLimit?: number;
+  }
+}

--- a/packages/embark-blockchain-process/package.json
+++ b/packages/embark-blockchain-process/package.json
@@ -26,21 +26,20 @@
   },
   "main": "./dist/index.js",
   "scripts": {
-    "build": "cross-env BABEL_ENV=node babel src --extensions \".js\" --out-dir dist --root-mode upward --source-maps",
+    "build": "cross-env BABEL_ENV=node babel src --extensions \".js,.ts\" --out-dir dist --root-mode upward --source-maps",
     "ci": "npm run qa",
     "clean": "npm run reset",
     "lint": "npm-run-all lint:*",
     "lint:js": "eslint src/",
-    "// lint:ts": "tslint -c tslint.json \"src/**/*.ts\"",
+    "lint:ts": "tslint -c tslint.json \"src/**/*.ts\"",
     "package": "npm pack",
-    "// qa": "npm-run-all lint typecheck build package",
-    "qa": "npm-run-all lint build package",
+    "qa": "npm-run-all lint typecheck build package",
     "reset": "npx rimraf dist embark-*.tgz package",
     "start": "npm run watch",
-    "// typecheck": "tsc",
+    "typecheck": "tsc",
     "watch": "run-p watch:*",
     "watch:build": "npm run build -- --verbose --watch",
-    "// watch:typecheck": "npm run typecheck -- --preserveWatchOutput --watch"
+    "watch:typecheck": "npm run typecheck -- --preserveWatchOutput --watch"
   },
   "eslintConfig": {
     "extends": "../../.eslintrc.json"

--- a/packages/embark-blockchain-process/src/baseBlockchainClient.ts
+++ b/packages/embark-blockchain-process/src/baseBlockchainClient.ts
@@ -1,0 +1,191 @@
+import { Callback, Environment } from "embark";
+import { BaseBlockchainClientOptions, BlockchainClientDefaults, Config } from "../index";
+const semver = require("semver");
+
+const NOT_IMPLEMENTED_EXCEPTION = "This method has not been implemented";
+
+/**
+ * Base blockchain client. Extend this class in your custom blockchain client.
+ */
+export class BaseBlockchainClient {
+  /**
+   * Blockchain client config
+   */
+  protected config: Config;
+  /**
+   * The current runtime environment of Embark, set by running `embark run <environment>`.
+   */
+  protected env: Environment;
+  /**
+   * Determined by whether the current runtime environment is development or not.
+   */
+  protected isDev: boolean;
+
+  /**
+   * Default client configuration options
+   */
+  public defaults: BlockchainClientDefaults = {
+    bin: "",
+    devWsApi: [],
+    networkType: "custom",
+    rpcApi: [],
+    wsApi: [],
+  };
+  /**
+   * Name of blockchain client - used in the blockchain config "client" property
+   */
+  public name: string = "baseclient";
+  /**
+   * Pretty name of blockchain client
+   */
+  public prettyName: string = "Base blockchain client";
+  /**
+   * Mimimum client version supported, ie ">=1.3.0"
+   */
+  public versSupported: string = ">=0.0.1";
+  /**
+   * Regex used to parse the version from the version command (returned from {@link determineVersionCommand})
+   */
+  protected versionRegex: string = "Version: ([0-9]\.[0-9]\.[0-9]).*?";
+
+  /**
+   * Creates an instance of base blockchain client.
+   * @param {BaseBlockchainClientOptions} options - used to configure the blockchain client.
+   */
+  constructor(options: BaseBlockchainClientOptions) {
+    this.env = options.env || "development";
+    this.isDev = options.isDev || (this.env === "development");
+
+    this.config = options.config as Config;
+    this.defaults = options.defaults;
+    let defaultWsApi = this.defaults.wsApi;
+    if (this.isDev) {
+      defaultWsApi = this.defaults.devWsApi;
+    }
+    if (this.defaults.networkType) {
+      this.config.networkType = this.config.networkType || this.defaults.networkType;
+    }
+    if (this.defaults.networkId) {
+      this.config.networkId = this.config.networkId || this.defaults.networkId;
+    }
+    this.config.rpcApi = this.config.rpcApi || this.defaults.rpcApi;
+    this.config.wsApi = this.config.wsApi || defaultWsApi;
+
+    this.name = options.name;
+    this.prettyName = options.prettyName;
+    this.versSupported = options.versSupported;
+    this.versionRegex = options.versionRegex;
+  }
+
+  /**
+   * Gets the CLI command to execute this blockchain client
+   */
+  get bin() {
+    return this.config.ethereumClientBin || this.defaults.bin;
+  }
+
+  //#region Overridable Methods
+  /**
+   * Determines whether the blockchain client is ready by examining the stdout output of the
+   * main command (determined by {@link mainCommand})
+   * @param {string} data stdout output of the CLI main command
+   */
+  public isReady(data: string) {
+    throw new Error(NOT_IMPLEMENTED_EXCEPTION);
+  }
+
+  /**
+   * Check if the client needs some sort of 'keep alive' transactions to avoid freezing by inactivity.
+   * If true, allows for txs to be sent at regular intervals via the `devtxs on` console command.
+   * @returns {boolean} if keep alive is needed
+   */
+  public needKeepAlive() {
+    throw new Error(NOT_IMPLEMENTED_EXCEPTION);
+  }
+
+  /**
+   * Gets path to a miner class. If a miner is not needed, override this method and log a warning.
+   */
+  public getMiner() {
+    throw new Error(NOT_IMPLEMENTED_EXCEPTION);
+  }
+
+  public getBinaryPath() {
+    return this.bin;
+  }
+
+  /**
+   * Command to execute in the CLI to determine the blockchain client version.
+   *
+   * @example
+   *
+   * determineVersionCommand() {
+   *   return this.bin + " version";
+   * }
+   */
+  public determineVersionCommand() {
+    throw new Error(NOT_IMPLEMENTED_EXCEPTION);
+  }
+
+  /**
+   * Parses a version from the output of the {@link determineVersionCommand}.
+   * @param rawVersionOutput
+   * @returns {string} string version of the blockchain client
+   */
+  public parseVersion(rawVersionOutput: string) {
+    let parsed = "0.0.0";
+    const match = rawVersionOutput.match(new RegExp(this.versionRegex));
+    if (match) {
+      parsed = match[1].trim();
+    }
+    return parsed;
+  }
+
+  /**
+   * Determines whether the current blockchain client installed on the machine is supported.
+   * The supported versions can be specified in the plugin constructor.
+   * @param {string} parsedVersion version parsed from the CLI vesrion command output
+   * @returns {boolean} true if the current blockchain client version is supported
+   */
+  public isSupportedVersion(parsedVersion: string) {
+    let test;
+    try {
+      let v = semver(parsedVersion);
+      v = `${v.major}.${v.minor}.${v.patch}`;
+      test = semver.Range(this.versSupported).test(semver(v));
+      if (typeof test !== "boolean") {
+        test = undefined;
+      }
+    } finally {
+      // eslint-disable-next-line no-unsafe-finally
+      // tslint:disable-next-line: no-unsafe-finally
+      return test;
+    }
+  }
+
+  /**
+   * Fired before the main blockchain command is run, the client should use this method to
+   * perform any initialization routine that it needs.
+   * @param {Callback<null>} callback Callback called after the initChain finishes its routine.
+   * @returns {void}
+   */
+  public initChain(callback: Callback<null>) {
+    throw new Error(NOT_IMPLEMENTED_EXCEPTION);
+  }
+
+  /**
+   * Main command to run in the CLI that starts up the blockchain client process
+   * @param {string} address this is not used, and will always be an empty string
+   * @param done callback to be called with arguments to run in the CLI.
+   * @example
+   *
+   * mainCommand(_address, done) {
+   *  done(this.bin, ["--rpc", "--ws"]);
+   * }
+   */
+  public mainCommand(address: string, done: (bin: string, args: string[]) => void) {
+    throw new Error(NOT_IMPLEMENTED_EXCEPTION);
+  }
+
+  //#endregion
+}

--- a/packages/embark-blockchain-process/src/baseBlockchainPlugin.ts
+++ b/packages/embark-blockchain-process/src/baseBlockchainPlugin.ts
@@ -1,0 +1,100 @@
+import { Embark, Events } from "embark";
+import Web3 from "web3";
+import { BaseBlockchainClientOptions } from "../index";
+
+const NOT_IMPLEMENTED_EXCEPTION = "This method has not been implemented";
+
+/**
+ * Base blockchain plugin. Extend this class in your custom blockchain client plugin.
+ */
+export class BaseBlockchainPlugin {
+  protected embark: Embark;
+  protected events: Events;
+  protected web3?: Web3;
+  protected blockchainClientOptions: BaseBlockchainClientOptions;
+  protected blockchainConfig: any;
+  /**
+   * Creates an instance of base blockchain plugin.
+   * @param {Embark} embark - Embark object, used to get the Events object.
+   * @param {BaseBlockchainClientOptions} blockchainClientOptions - options for the plugin name
+   * and version, and options that will be passed to the blockchain client.
+   */
+  constructor(embark: Embark, blockchainClientOptions: BaseBlockchainClientOptions) {
+    this.embark = embark;
+    this.events = embark.events;
+    this.blockchainClientOptions = blockchainClientOptions;
+
+    // gets hydrated blockchain config from embark, use it to init
+    this.events.once("config:load:blockchain", (blockchainConfig: any) => {
+      this.blockchainConfig = blockchainConfig;
+      // Only register the blockchain plugin and event actions if the current
+      // run time environment is using this blockchain plugin.
+      // Without this, registered and unfired event actions would cause the
+      // blockchain process to hang.
+      if (this.shouldInit(blockchainConfig)) {
+        this.registerBlockchain();
+        this.registerProviderReadyAction();
+      }
+    });
+  }
+
+  /**
+   * Registers provider ready action. This will be triggered by the blockchain connector
+   * and once registered, the blockchain connector will wait for these actions to
+   * complete before continuing.
+   *
+   * These actions occur prior to the "blockchain:ready" event and provide the perfect
+   * time to create and unlock accounts.
+   */
+  private registerProviderReadyAction() {
+    this.embark.registerActionForEvent("blockchain:provider:ready", async (cb) => {
+      if (!this.createAndUnlockAccounts) {
+        return cb();
+      }
+      this.events.request("blockchain:get", async (web3: Web3) => {
+        this.web3 = web3;
+        await this.createAndUnlockAccounts();
+        cb();
+      });
+    });
+  }
+
+  //#region Overridable Methods
+
+  /**
+   * Creates and unlocks accounts according to the blockchain configuration.
+   *
+   * Override this method to create a custom account management implementation.
+   *
+   * If you do not need to create and unlock accounts, override this method in
+   * your plugin class, and return immediately. Otherwise, an error will be thrown.
+   */
+  protected async createAndUnlockAccounts() {
+    throw new Error(`[BaseBlockchainPlugin.onProviderReady]: ${NOT_IMPLEMENTED_EXCEPTION}`);
+  }
+
+  /**
+   * Should init - prevents or enables Embark to consider this plugin as a valid plugin
+   * at run time. This can be overridden by your custom plugin if additional conditions
+   * are needed.
+   * @param {any} blockchainConfig Blockchain configuration object
+   * @returns {boolean} true if the run time client name (based on the "client"
+   * property in the current run time blockchain config) is set to the name of
+   * this blockchain client plugin.
+   */
+  protected shouldInit(blockchainConfig: any) {
+    return blockchainConfig.client === this.blockchainClientOptions.name;
+  }
+
+  /**
+   * Registers the blockchain client as a plugin in Embark.
+   */
+  protected registerBlockchain() {
+    this.embark.registerBlockchain(
+      this.blockchainClientOptions.name,
+      this.blockchainClientOptions.clientPath,
+      this.blockchainClientOptions,
+      this.shouldInit.bind(this));
+  }
+  //#endregion
+}

--- a/packages/embark-blockchain-process/src/blockchainProcess.js
+++ b/packages/embark-blockchain-process/src/blockchainProcess.js
@@ -25,7 +25,8 @@ class BlockchainProcess extends ProcessWrapper {
         certOptions: this.certOptions,
         onReadyCallback: this.blockchainReady.bind(this),
         onExitCallback: this.blockchainExit.bind(this),
-        logger: console
+        logger: console,
+        blockchainPlugins: options.blockchainPlugins
       }
     );
 

--- a/packages/embark-blockchain-process/src/blockchainProcessLauncher.js
+++ b/packages/embark-blockchain-process/src/blockchainProcessLauncher.js
@@ -1,11 +1,11 @@
-import { __ } from 'embark-i18n';
-import { ProcessLauncher } from 'embark-core';
-import { joinPath } from 'embark-utils';
+import {__} from 'embark-i18n';
+import {ProcessLauncher} from 'embark-core';
+import {joinPath} from 'embark-utils';
 const constants = require('embark-core/constants');
 
 export class BlockchainProcessLauncher {
 
-  constructor (options) {
+  constructor(options) {
     this.events = options.events;
     this.logger = options.logger;
     this.normalizeInput = options.normalizeInput;
@@ -32,6 +32,12 @@ export class BlockchainProcessLauncher {
       exitCallback: this.processEnded.bind(this),
       embark: this.embark
     });
+    const blockchainPlugins = this.embark.config.plugins.getPluginsProperty("blockchains", "blockchains")
+      .filter((blockchainPlugin) =>
+        blockchainPlugin.shouldInit.call(blockchainPlugin, this.blockchainConfig)
+      ).map((blockchainPlugin) =>
+        blockchainPlugin.config
+      );
     this.blockchainProcess.send({
       action: constants.blockchain.init, options: {
         blockchainConfig: this.blockchainConfig,
@@ -40,7 +46,8 @@ export class BlockchainProcessLauncher {
         isDev: this.isDev,
         locale: this.locale,
         certOptions: this.embark.config.webServerConfig.certOptions,
-        events: this.events
+        events: this.events,
+        blockchainPlugins
       }
     });
 
@@ -71,7 +78,7 @@ export class BlockchainProcessLauncher {
   }
 
   stopBlockchainNode(cb) {
-    if(this.blockchainProcess) {
+    if (this.blockchainProcess) {
       this.events.once(constants.blockchain.blockchainExit, cb);
       this.blockchainProcess.exitCallback = () => {}; // don't show error message as the process was killed on purpose
       this.blockchainProcess.send('exit');

--- a/packages/embark-blockchain-process/src/gethClient.js
+++ b/packages/embark-blockchain-process/src/gethClient.js
@@ -7,32 +7,35 @@ const GethMiner = require('./miner');
 const semver = require('semver');
 const constants = require('embark-core/constants');
 
-const DEFAULTS = {
-  "BIN": "geth",
-  "VERSIONS_SUPPORTED": ">=1.8.14",
-  "NETWORK_TYPE": "custom",
-  "NETWORK_ID": 1337,
-  "RPC_API": ['eth', 'web3', 'net', 'debug', 'personal'],
-  "WS_API": ['eth', 'web3', 'net', 'shh', 'debug', 'pubsub', 'personal'],
-  "DEV_WS_API": ['eth', 'web3', 'net', 'shh', 'debug', 'pubsub', 'personal'],
-  "TARGET_GAS_LIMIT": 8000000
-};
-
 // TODO: make all of this async
 class GethClient {
-
-  static get DEFAULTS() {
-    return DEFAULTS;
-  }
-
   constructor(options) {
+    this.defaults = {
+      "bin": "geth",
+      "versionsSupported": ">=1.8.14",
+      "networkType": "custom",
+      "networkId": 1337,
+      "rpcApi": ['eth', 'web3', 'net', 'debug', 'personal'],
+      "wsApi": ['eth', 'web3', 'net', 'shh', 'debug', 'pubsub', 'personal'],
+      "devWsApi": ['eth', 'web3', 'net', 'shh', 'debug', 'pubsub', 'personal'],
+      "targetGasLimit": 8000000
+    };
     this.config = options && options.hasOwnProperty('config') ? options.config : {};
     this.env = options && options.hasOwnProperty('env') ? options.env : 'development';
     this.isDev = options && options.hasOwnProperty('isDev') ? options.isDev : (this.env === 'development');
+    let defaultWsApi = this.defaults.wsApi;
+    if (this.isDev) {
+      defaultWsApi = this.defaults.devWsApi;
+    }
+    this.config = options && options.hasOwnProperty('config') ? options.config : {};
+    this.config.networkType = this.config.networkType || this.defaults.networkType;
+    this.config.networkId = this.config.networkId || this.defaults.networkId;
+    this.config.rpcApi = this.config.rpcApi || this.defaults.rpcApi;
+    this.config.wsApi = this.config.wsApi || defaultWsApi;
     this.name = constants.blockchain.clients.geth;
     this.prettyName = "Go-Ethereum (https://github.com/ethereum/go-ethereum)";
-    this.bin = this.config.ethereumClientBin || DEFAULTS.BIN;
-    this.versSupported = DEFAULTS.VERSIONS_SUPPORTED;
+    this.bin = this.config.ethereumClientBin || this.defaults.bin;
+    this.versSupported = this.defaults.versionsSupported;
     this.httpReady = false;
     this.wsReady = !this.config.wsRPC;
   }

--- a/packages/embark-blockchain-process/src/index.js
+++ b/packages/embark-blockchain-process/src/index.js
@@ -5,6 +5,8 @@ const constants = require('embark-core/constants');
 import { BlockchainProcessLauncher } from './blockchainProcessLauncher';
 import { pingEndpoint } from './utils';
 
+export { BaseBlockchainPlugin } from './baseBlockchainPlugin';
+export { BaseBlockchainClient } from './baseBlockchainClient';
 export { BlockchainClient } from './blockchain';
 export { Simulator } from './simulator';
 export { Proxy } from './proxy';

--- a/packages/embark-storage/src/index.js
+++ b/packages/embark-storage/src/index.js
@@ -62,13 +62,13 @@ class Storage {
 
     async.parallel([
       (next) => {
-        if (!this.storageConfig.available_providers.includes('ipfs')) {
+        if (!this.embark.config.storageConfig.available_providers.includes('ipfs')) {
           return next();
         }
         this.embark.events.once('ipfs:process:started', next);
       },
       (next) => {
-        if (!this.storageConfig.available_providers.includes('swarm')) {
+        if (!this.embark.config.storageConfig.available_providers.includes('swarm')) {
           return next();
         }
         this.embark.events.once('swarm:process:started', next);

--- a/packages/embark-typings/src/embark.d.ts
+++ b/packages/embark-typings/src/embark.d.ts
@@ -1,5 +1,6 @@
 import { Logger } from "./logger";
 import { Plugins } from "./plugins";
+import { BaseBlockchainClientOptions } from '../../embark-blockchain-process/index';
 
 export interface Events {
   on: any;
@@ -33,6 +34,7 @@ export interface Embark {
   events: Events;
   registerAPICall: any;
   registerConsoleCommand: any;
+  registerBlockchain: (name: string, clientPath: string, blockchainClientOptions: BaseBlockchainClientOptions, initCondition: (clientName: string) => boolean) => void;
   logger: Logger;
   fs: any;
   config: Config;
@@ -42,3 +44,5 @@ export interface Embark {
     action: (callback: () => void) => void,
   ): void;
 }
+
+export type Environment = String;

--- a/packages/embark/src/cmd/cmd_controller.js
+++ b/packages/embark/src/cmd/cmd_controller.js
@@ -44,7 +44,8 @@ class EmbarkController {
       logger: this.logger,
       events: this.events,
       isStandalone: true,
-      fs
+      fs,
+      blockchainPlugins: this.plugins.getPluginsProperty("blockchains", "blockchains")
     }).run();
   }
 

--- a/packages/embark/src/lib/core/plugin.js
+++ b/packages/embark/src/lib/core/plugin.js
@@ -1,12 +1,12 @@
 const utils = require('../utils/utils.js');
-import { __ } from 'embark-i18n';
-import { dappPath, embarkPath, isEs6Module, joinPath } from 'embark-utils';
+import {__} from 'embark-i18n';
+import {dappPath, embarkPath, isEs6Module, joinPath} from 'embark-utils';
 const constants = require('embark-core/constants');
 const fs = require('fs-extra');
 const deepEqual = require('deep-equal');
 
 // TODO: pass other params like blockchainConfig, contract files, etc..
-var Plugin = function(options) {
+var Plugin = function (options) {
   this.name = options.name;
   this.isInternal = options.isInternal;
   this.pluginModule = options.pluginModule;
@@ -28,6 +28,7 @@ var Plugin = function(options) {
   this.dappGenerators = [];
   this.pluginTypes = [];
   this.uploadCmds = [];
+  this.blockchains = [];
   this.apiCalls = [];
   this.imports = [];
   this.embarkjs_code = [];
@@ -61,7 +62,7 @@ var Plugin = function(options) {
 Plugin.prototype.dappPath = dappPath;
 Plugin.prototype.embarkPath = embarkPath;
 
-Plugin.prototype._log = function(type) {
+Plugin.prototype._log = function (type) {
   this._loggerObject[type](this.name + ':', ...[].slice.call(arguments, 1));
 };
 
@@ -77,7 +78,7 @@ Plugin.prototype.setUpLogger = function () {
   };
 };
 
-Plugin.prototype.isContextValid = function() {
+Plugin.prototype.isContextValid = function () {
   if (this.currentContext.includes(constants.contexts.any) || this.acceptedContext.includes(constants.contexts.any)) {
     return true;
   }
@@ -86,12 +87,12 @@ Plugin.prototype.isContextValid = function() {
   });
 };
 
-Plugin.prototype.hasContext = function(context) {
+Plugin.prototype.hasContext = function (context) {
   return this.currentContext.includes(context);
 };
 
-Plugin.prototype.loadPlugin = function() {
-  if (!this.isContextValid())  {
+Plugin.prototype.loadPlugin = function () {
+  if (!this.isContextValid()) {
     this.logger.warn(__('Plugin {{name}} can only be loaded in the context of "{{contexts}}"', {name: this.name, contexts: this.acceptedContext.join(', ')}));
     return false;
   }
@@ -108,7 +109,7 @@ Plugin.prototype.loadPlugin = function() {
   this.pluginModule.call(this, this);
 };
 
-Plugin.prototype.loadInternalPlugin = function() {
+Plugin.prototype.loadInternalPlugin = function () {
   if (isEs6Module(this.pluginModule)) {
     if (this.pluginModule.default) {
       this.pluginModule = this.pluginModule.default;
@@ -117,11 +118,11 @@ Plugin.prototype.loadInternalPlugin = function() {
   new this.pluginModule(this, this.pluginConfig); /*eslint no-new: "off"*/
 };
 
-Plugin.prototype.loadPluginFile = function(filename) {
+Plugin.prototype.loadPluginFile = function (filename) {
   return fs.readFileSync(this.pathToFile(filename)).toString();
 };
 
-Plugin.prototype.pathToFile = function(filename) {
+Plugin.prototype.pathToFile = function (filename) {
   if (!this.pluginPath) {
     throw new Error('pluginPath not defined for plugin: ' + this.name);
   }
@@ -129,12 +130,12 @@ Plugin.prototype.pathToFile = function(filename) {
 };
 
 // TODO: add deploy provider
-Plugin.prototype.registerClientWeb3Provider = function(cb) {
+Plugin.prototype.registerClientWeb3Provider = function (cb) {
   this.clientWeb3Providers.push(cb);
   this.addPluginType('clientWeb3Provider');
 };
 
-Plugin.prototype.registerContractsGeneration = function(cb) {
+Plugin.prototype.registerContractsGeneration = function (cb) {
   this.contractsGenerators.push(cb);
   this.addPluginType('contractGeneration');
 };
@@ -144,32 +145,32 @@ Plugin.prototype.registerCustomContractGenerator = function (cb) {
   this.addPluginType('customContractGeneration');
 };
 
-Plugin.prototype.registerTestContractFactory = function(cb) {
+Plugin.prototype.registerTestContractFactory = function (cb) {
   this.testContractFactory = cb;
   this.addPluginType('testContractFactory');
 };
 
-Plugin.prototype.registerPipeline = function(matcthingFiles, cb) {
+Plugin.prototype.registerPipeline = function (matcthingFiles, cb) {
   // TODO: generate error for more than one pipeline per plugin
   this.pipeline.push({matcthingFiles: matcthingFiles, cb: cb});
   this.addPluginType('pipeline');
 };
 
-Plugin.prototype.registerDappGenerator = function(framework, cb){
+Plugin.prototype.registerDappGenerator = function (framework, cb) {
   this.dappGenerators.push({framework: framework, cb: cb});
   this.pluginTypes.push('dappGenerator');
 };
 
-Plugin.prototype.registerCustomType = function(type){
+Plugin.prototype.registerCustomType = function (type) {
   this.pluginTypes.push(type);
 };
 
-Plugin.prototype.addFileToPipeline = function(file, intendedPath, options) {
+Plugin.prototype.addFileToPipeline = function (file, intendedPath, options) {
   this.pipelineFiles.push({file: file, intendedPath: intendedPath, options: options});
   this.addPluginType('pipelineFiles');
 };
 
-Plugin.prototype.addContractFile = function(file) {
+Plugin.prototype.addContractFile = function (file) {
   if (this.isInternal) {
     throw new Error("this API cannot work for internal modules. please use an event command instead: config:contractsFiles:add");
   }
@@ -177,7 +178,7 @@ Plugin.prototype.addContractFile = function(file) {
   this.addPluginType('contractFiles');
 };
 
-Plugin.prototype.registerConsoleCommand = function(optionsOrCb) {
+Plugin.prototype.registerConsoleCommand = function (optionsOrCb) {
   if (typeof optionsOrCb === 'function') {
     this.logger.warn(__('Registering console commands with function syntax is deprecated and will likely be removed in future versions of Embark'));
     this.logger.info(__('You can find the new API documentation here: %s', 'https://embark.status.im/docs/plugin_reference.html#registerConsoleCommand-options'.underline));
@@ -187,48 +188,56 @@ Plugin.prototype.registerConsoleCommand = function(optionsOrCb) {
 };
 
 // TODO: this only works for services done on startup
-Plugin.prototype.registerServiceCheck = function(checkName, checkFn, time) {
+Plugin.prototype.registerServiceCheck = function (checkName, checkFn, time) {
   this.serviceChecks.push({checkName: checkName, checkFn: checkFn, time: time});
   this.addPluginType('serviceChecks');
 };
 
-Plugin.prototype.has = function(pluginType) {
+Plugin.prototype.has = function (pluginType) {
   return this.pluginTypes.indexOf(pluginType) >= 0;
 };
 
-Plugin.prototype.addPluginType = function(pluginType) {
+Plugin.prototype.addPluginType = function (pluginType) {
   this.pluginTypes.push(pluginType);
   this.pluginTypes = Array.from(new Set(this.pluginTypes));
 };
 
-Plugin.prototype.generateProvider = function(args) {
-  return this.clientWeb3Providers.map(function(cb) {
+Plugin.prototype.generateProvider = function (args) {
+  return this.clientWeb3Providers.map(function (cb) {
     return cb.call(this, args);
   }).join("\n");
 };
 
-Plugin.prototype.generateContracts = function(args) {
-  return this.contractsGenerators.map(function(cb) {
+Plugin.prototype.generateContracts = function (args) {
+  return this.contractsGenerators.map(function (cb) {
     return cb.call(this, args);
   }).join("\n");
 };
 
-Plugin.prototype.registerContractConfiguration = function(config) {
+Plugin.prototype.registerContractConfiguration = function (config) {
   this.contractsConfigs.push(config);
   this.addPluginType('contractsConfig');
 };
 
-Plugin.prototype.registerCompiler = function(extension, cb) {
+Plugin.prototype.registerCompiler = function (extension, cb) {
   this.compilers.push({extension: extension, cb: cb});
   this.addPluginType('compilers');
 };
 
-Plugin.prototype.registerUploadCommand = function(cmd, cb) {
+Plugin.prototype.registerUploadCommand = function (cmd, cb) {
   this.uploadCmds.push({cmd: cmd, cb: cb});
   this.addPluginType('uploadCmds');
 };
 
-Plugin.prototype.addCodeToEmbarkJS = function(code) {
+Plugin.prototype.registerBlockchain = function (name, clientPath, blockchainClientConfig, initCondition) {
+  this.blockchains.push({
+    config: {name, clientPath, blockchainClientConfig},
+    shouldInit: initCondition
+  });
+  this.addPluginType('blockchains');
+};
+
+Plugin.prototype.addCodeToEmbarkJS = function (code) {
   this.addPluginType('embarkjsCode');
   // TODO: what is this/why
   if (!this.embarkjs_code.some((existingCode) => deepEqual(existingCode, code))) {
@@ -236,18 +245,18 @@ Plugin.prototype.addCodeToEmbarkJS = function(code) {
   }
 };
 
-Plugin.prototype.addGeneratedCode = function(codeCb) {
+Plugin.prototype.addGeneratedCode = function (codeCb) {
   this.addPluginType('generatedCode');
   this.generated_code.push(codeCb);
 };
 
-Plugin.prototype.addProviderInit = function(providerType, code, initCondition) {
+Plugin.prototype.addProviderInit = function (providerType, code, initCondition) {
   this.embarkjs_init_code[providerType] = this.embarkjs_init_code[providerType] || [];
   this.embarkjs_init_code[providerType].push([code, initCondition]);
   this.addPluginType('initCode');
 };
 
-Plugin.prototype.addConsoleProviderInit = function(providerType, code, initCondition) {
+Plugin.prototype.addConsoleProviderInit = function (providerType, code, initCondition) {
   this.embarkjs_init_console_code[providerType] = this.embarkjs_init_console_code[providerType] || [];
   this.addPluginType('initConsoleCode');
   const toAdd = [code, initCondition];
@@ -256,12 +265,12 @@ Plugin.prototype.addConsoleProviderInit = function(providerType, code, initCondi
   }
 };
 
-Plugin.prototype.registerImportFile = function(importName, importLocation) {
+Plugin.prototype.registerImportFile = function (importName, importLocation) {
   this.imports.push([importName, importLocation]);
   this.addPluginType('imports');
 };
 
-Plugin.prototype.registerActionForEvent = function(eventName, cb) {
+Plugin.prototype.registerActionForEvent = function (eventName, cb) {
   if (!this.eventActions[eventName]) {
     this.eventActions[eventName] = [];
   }
@@ -269,28 +278,28 @@ Plugin.prototype.registerActionForEvent = function(eventName, cb) {
   this.addPluginType('eventActions');
 };
 
-Plugin.prototype.registerAPICall = function(method, endpoint, cb) {
+Plugin.prototype.registerAPICall = function (method, endpoint, cb) {
   this.apiCalls.push({method, endpoint, cb});
   this.addPluginType('apiCalls');
   this.events.emit('plugins:register:api', {method, endpoint, cb});
 };
 
-Plugin.prototype.runFilePipeline = function() {
+Plugin.prototype.runFilePipeline = function () {
   var self = this;
 
-  return this.pipelineFiles.map(function(file) {
-      var obj = {};
-      obj.filename = file.file.replace('./','');
-      obj.content = self.loadPluginFile(file.file).toString();
-      obj.intendedPath = file.intendedPath;
-      obj.options = file.options;
-      obj.path = self.pathToFile(obj.filename);
+  return this.pipelineFiles.map(function (file) {
+    var obj = {};
+    obj.filename = file.file.replace('./', '');
+    obj.content = self.loadPluginFile(file.file).toString();
+    obj.intendedPath = file.intendedPath;
+    obj.options = file.options;
+    obj.path = self.pathToFile(obj.filename);
 
-      return obj;
+    return obj;
   });
 };
 
-Plugin.prototype.runPipeline = function(args) {
+Plugin.prototype.runPipeline = function (args) {
   // TODO: should iterate the pipelines
   var pipeline = this.pipeline[0];
   var shouldRunPipeline = utils.fileMatchesPattern(pipeline.matcthingFiles, args.targetFile);

--- a/packages/embark/src/lib/core/plugins.js
+++ b/packages/embark/src/lib/core/plugins.js
@@ -164,6 +164,7 @@ Plugins.prototype.getPluginsProperty = function(pluginType, property, sub_proper
 Plugins.prototype.runActionsForEvent = function(eventName, args, cb) {
   if (typeof (args) === 'function') {
     cb = args;
+    args = null;
   }
   let actionPlugins = this.getPluginsProperty('eventActions', 'eventActions', eventName);
 
@@ -172,7 +173,7 @@ Plugins.prototype.runActionsForEvent = function(eventName, args, cb) {
   }
 
   async.reduce(actionPlugins, args, function(current_args, plugin, nextEach) {
-    if (typeof (args) === 'function') {
+    if (!args) {
       plugin.call(plugin, (...params) => {
         nextEach(...params || current_args);
       });


### PR DESCRIPTION
Blockchain clients can be added as plugins now. Existing `geth` and `parity` clients are still supported, however additional blockchains can used in your DApp as a plugin.

The blockchain plugin API can be used in the following way:
```
this.embark.registerBlockchain("lightchain", require.resolve("./client"), {options});
```
When Embark attempts to start a blockchain process, we first check to see if we have installed a blockchain client plugin, and also check that it's `shouldInit` function resolves to `true`.

If the blockchain client plugin is configured in the DApp's blockchain config for the current environment, we create an instance of the client and then run through some initialisation. Before this PR, the initialisation would attempt to create and unlock node accounts *before* starting up the blockchain process. With this PR, we assume that the CLI for the blockchain client does not support creation and unlocking of accounts from the command line, and instead allow the client to run an init routine before the main process is started.

In addition, we have added a new event, `blockchain:provider:ready`, that is fired once Embark's web3 provider has been configured and set up. This event will run actions configured with `registerActionsForEvent("blockchain:provider:ready")` and wait for those actions to complete before continuing. This allows an opportunity for custom blockchain plugins to perform account management before kicking off the blockchain client process. After the actions are finished, the `blockchain:ready` event will be fired. Because of this, it is important that any blockchain plugins using this event (by default, any that impelement `BaseBlockchainPlugin`) have a valid `shouldInit` method that prevents registration of these actions when the blockchain client is not being used by Embark (ie the blockchain config `client` is not set to the blockchain plugin for the current environment), otherwise the blockchain process may hang.

## Implementing a blockchain plugin
This PR introduces two new base classes to assist developers in creating blockchain plugins.

### BaseBlockchainPlugin
`packages/embark-blockchain-process/baseBlockchainPlugin.ts` was implemented as a base class for the blockchain plugin itself. Developers should extend this class when creating blockchain plugins. For example,
```javascript=
import {BaseBlockchainPlugin} from 'embark-blockchain-process';

const BLOCKCHAIN_CLIENT_OPTIONS = {
  defaults: {
    bin: "lightchain",
    networkType: "standalone",
    rpcApi: ['eth', 'web3', 'net', 'debug', 'personal'],
    wsApi: ['eth', 'web3', 'net', 'debug', 'pubsub', 'personal'],
    devWsApi: ['eth', 'web3', 'net', 'debug', 'pubsub', 'personal']
  },
  versSupported: ">=1.3.0",
  versionRegex: "Version: ([0-9]\.[0-9]\.[0-9]).*?",
  name: "lightchain",
  prettyName: "Lightchain (https://github.com/lightstreams-network/lightchain)",
  clientPath: require.resolve("./client")
};

export default class EmbarkLightchain extends BaseBlockchainPlugin {
  constructor(embark) {
    super(embark, BLOCKCHAIN_CLIENT_OPTIONS);
    this.logger = embark.logger;
    this.isDev = embark.config.env === "development";
  }

  async createAndUnlockAccounts() {
    // do node account mgmt here
  }
}
```
Once extended, developers should override the following methods:
1. `protected async createAndUnlockAccounts()`: Creates and unlocks accounts according to the blockchain configuration. Override this method to create a custom account management implementation. If you do not need to create and unlock accounts, override this method in your plugin class, and return immediately. Otherwise, an error will be thrown. This method is fired automatically by the base class in between the `blockchain:provider:ready` and `blockchain:ready` events.
2. `protected shouldInit(blockchainConfig: any)`: Prevents or enables Embark to consider this plugin as a valid plugin at run time. Overridable if needed, the base class implements this method by returning true if the current run time environment's config is using this blockchain plugin's client.

### BaseBlockchainClient
`packages/embark-blockchain-process/baseBlockchainClient.ts` was implemented as a base class for the blockchain client. This class introduces several methods that need to be overridden by the extending class, as can be seen in the [`embark-lightchain` implementation](https://github.com/emizzle/embark-lightchain/blob/master/src/client.js):
1. `public isReady(data: string)`: Determines whether the blockchain client is ready by examining the stdout output of the main command (determined by {@link mainCommand})
2.  `public needKeepAlive()`: check if the client needs some sort of 'keep alive' transactions to avoid freezing by inactivity. If true, allows for txs to be sent at regular intervals via the `devtxs on` console command.
3.  `public getMiner()`: Gets path to a miner class. If a miner is not needed, override this method and log a warning.
4.  `public determineVersionCommand()`: Command to execute in the CLI to determine the blockchain client version.
5.  `public initChain(callback: Callback<null>)`: Fired before the main blockchain command is run, the client should use this method to perform any initialization routine that it needs.
6.  `public mainCommand(address: string, done: (bin: string, args: string[]) => void)`: Main command to run in the CLI that starts up the blockchain client process

## Events added
`blockchain:provider:ready`: Fired once Embark's web3 provider has been configured and setup. This is fired **before** `blockchain:ready`.

## Other notes
1. This PR is based on the v5 config changes (`feat/new-config` branch).
2. This PR will have some conflicts with the ongoing rebase and will need to be implemented slightly differently after the rebase lands.