### PR TITLE
refactor(@embark/blockchain): support --simple dapps

### DIFF
--- a/packages/embark-blockchain-listener/src/dev_txs.js
+++ b/packages/embark-blockchain-listener/src/dev_txs.js
@@ -1,4 +1,4 @@
-import  { buildUrl } from 'embark-utils';
+import  { buildUrl, defaultHost, dockerHostSwap } from 'embark-utils';
 const Web3 = require('web3');
 const constants = require('embark-core/constants');
 
@@ -8,20 +8,20 @@ class DevTxs {
     this.networkId = null;
     if (options.provider) {
       this.provider = options.provider;
-    } else if (this.blockchainConfig.wsRPC) {
+    } else if (this.blockchainConfig.wsRPC !== false) {
       this.provider = new Web3.providers.WebsocketProvider(
         buildUrl(
           'ws',
-          this.blockchainConfig.wsHost,
-          this.blockchainConfig.wsPort
+          dockerHostSwap(this.blockchainConfig.wsHost) || defaultHost,
+          this.blockchainConfig.wsPort || constants.blockchain.defaults.wsPort
         ),
         {headers: {Origin: constants.embarkResourceOrigin}});
     } else {
       this.provider = new Web3.providers.HttpProvider(
         buildUrl(
           'http',
-          this.blockchainConfig.rpcHost,
-          this.blockchainConfig.rpcPort
+          dockerHostSwap(this.blockchainConfig.rpcHost) || defaultHost,
+          this.blockchainConfig.rpcPort || constants.blockchain.defaults.rpcPort
         )
       );
     }

--- a/packages/embark-blockchain-process/src/proxy.js
+++ b/packages/embark-blockchain-process/src/proxy.js
@@ -235,7 +235,18 @@ export class Proxy {
       });
     }());
 
-    const web3 = new Web3(`${ws ? 'ws' : 'http'}://${canonicalHost(host)}:${port}`);
+    const web3 = new Web3();
+    if (ws) {
+      web3.setProvider(new Web3.providers.WebsocketProvider(
+        `ws://${canonicalHost(host)}:${port}`,
+        {headers: {Origin: constants.embarkResourceOrigin}}
+      ));
+    } else {
+      web3.setProvider(new Web3.providers.HttpProvider(
+        `http://${canonicalHost(host)}:${port}`
+      ));
+    }
+
     accounts = (await web3.eth.getAccounts() || []).concat(accounts || []);
     accounts = [...new Set(accounts.map(ethUtil.toChecksumAddress))];
 

--- a/packages/embark-core/constants.json
+++ b/packages/embark-core/constants.json
@@ -42,6 +42,10 @@
     },
     "blockchainReady": "blockchainReady",
     "blockchainExit": "blockchainExit",
+    "defaults": {
+      "rpcPort": 8545,
+      "wsPort": 8546
+    },
     "init": "init",
     "initiated": "initiated",
     "servicePortOnProxy": 10,


### PR DESCRIPTION
DApps generated with `new --simple` don't have a blockchain config so ensure that the blockchain proxy and listener (dev_txs) use appropriate provider settings when setting up web3.

Without these changes, in a fresh `embark new --simple` project the `embark blockchain` command will encounter unhandled promise rejection with respect to the proxy; `embark run` will encounter the same with respect to dev_txs.