### PR TITLE
fix(@embark/pipeline): check if config arg of writeStats is falsy

### DIFF
--- a/packages/embark-pipeline/.babelrc.js
+++ b/packages/embark-pipeline/.babelrc.js
@@ -10,8 +10,8 @@ module.exports = (api) => {
   const node = cloneDeep(base);
   Object.assign(node, {
     ignore: [
-      'src/lib/modules/pipeline/babel-loader-overrides.js',
-      'src/lib/modules/pipeline/webpack.config.js'
+      'src/babel-loader-overrides.js',
+      'src/webpack.config.js'
     ]
   });
 

--- a/packages/embark-pipeline/src/webpackProcess.js
+++ b/packages/embark-pipeline/src/webpackProcess.js
@@ -61,7 +61,7 @@ class WebpackProcess extends ProcessWrapper {
   }
 
   async writeStats(config, stats, callback){
-    if (!config.stats || config.stats === 'none') {
+    if (!config || !config.stats || config.stats === 'none') {
       return callback();
     }
     try {


### PR DESCRIPTION
When passing the name of a build pipeline that doesn't exist, e.g. `embark run|build --pipeline foo`, `writeStats` would cause an unhandled promise rejection because its `config` argument is falsy. Checking for that and returning early from `writeStats` allows the `"no webpack config has the name 'foo'"` error to be reported correctly.

-------

Also fixed in this PR: the ignore paths for the default webpack config and babel-loader-overrides helper script weren't properly adjusted after the legacy pipeline was split-out into its own package in the monorepo.