### PR TITLE
refactor(@embark): template generator should use npm if downloaded template has package-lock.json

### DIFF
--- a/packages/embark/src/lib/utils/template_generator.js
+++ b/packages/embark/src/lib/utils/template_generator.js
@@ -233,7 +233,12 @@ class TemplateGenerator {
         }
       }
 
-      const installCmd = this.monorepoRootPath ? 'yarn install' : 'npm install';
+      let installCmd;
+      if (this.monorepoRootPath && !fs.existsSync('package-lock.json')) {
+        installCmd = 'yarn install';
+      } else {
+        installCmd = 'npm install';
+      }
 
       runCmd(installCmd, {exitOnError: false}, (err) => {
         if (err) {


### PR DESCRIPTION
Previously, when using "development embark" (i.e. `embark` command in the monorepo) the template generator would always use `yarn install` to install a template's dependencies. However, if a template relies on `package-lock.json`, as is the case for `embark-create-react-dapp-template`, that behvaior can cause serious problems. So, have the choice of install command depend not only on whether we're using "development embark" but also whether the template has a `package-lock.json` file.

NOTE: this change can probably result in problems given that `yarn install` and `npm install` behave differently re: symlinks in `node_modules`. However, such problems would never show up with production installs of the `embark` packaage. Moreover, after dropping `embarkjs-connector-web3` we don't presently have a situation where a monorepo package would be `yarn link`ed into an instantiated template's `node_modules`. So, in effect, the changes introduced in this PR allow existing templates to work correctly whether using production or monorepo embark. The impending embark v5 refactor should deprecate `embark new` in favor of the yet unfinished `embark init`.