### PR TITLE
fix(@embark/deploy-tracker): continue if getting block fails

### DIFF
--- a/packages/embark-deploy-tracker/src/index.js
+++ b/packages/embark-deploy-tracker/src/index.js
@@ -86,7 +86,12 @@ class DeployTracker {
     getBlock(0, (err) => {
       if (err) {
         // Retry with block 1 (Block 0 fails with Ganache-cli using the --fork option)
-        return getBlock(1, callback);
+        return getBlock(1, (err) => {
+          if (err) {
+            self.logger.error(__('Error getting block data. The deploy-tracker will not work'), err);
+          }
+          callback();
+        });
       }
       callback();
     });


### PR DESCRIPTION
This is another fix for using Ganche with the --fork option.

This time, a user was trying to use ganache with the --fork option with mainnet. Somehow, no block functions work (I tried getBlock and getBlockNumber and they both return`invalid argument 0: json: cannot unmarshal hex string of odd length into Go value of type common.Hash`)

This just puts an error, but it continues.

The real fix would be to not start the deploy-tracker in the tests, but since we are already refactoring all of this in v5, I didn't feel like doing it in v4.1 was worth it.