### PR TITLE
fix(@embark/embark-deployment): Undeployed contract artifacts

### DIFF
--- a/packages/embark-deployment/src/contract_deployer.js
+++ b/packages/embark-deployment/src/contract_deployer.js
@@ -32,8 +32,9 @@ class ContractDeployer {
       (params, next) => {
 
         if (!params.shouldDeploy) {
-          this.events.emit("deployment:contract:undeployed", contract);
-          return next(null, null);
+          return this.plugins.emitAndRunActionsForEvent('deployment:contract:undeployed', {contract}, (err, _params) => {
+            next(err, null);
+          });
         }
 
         // TODO: implement `blockchainType` a la `this.deployer[contract.blockchainType].apply(this.deployer, [contract, next])`

--- a/packages/embark-specialconfigs/src/index.js
+++ b/packages/embark-specialconfigs/src/index.js
@@ -70,7 +70,7 @@ class SpecialConfigs {
       return this.functionConfigs.deployIfAction(params, cb);
     }
     return this.listConfigs.deployIfAction(params, cb);
- }
+  }
 
 }
 

--- a/packages/embark-web3/src/index.js
+++ b/packages/embark-web3/src/index.js
@@ -25,9 +25,11 @@ class EmbarkWeb3 {
     this.events.on("blockchain:started", this.registerWeb3Object.bind(this));
     embark.registerActionForEvent("pipeline:generateAll:before", this.addWeb3Artifact.bind(this));
     embark.registerActionForEvent("deployment:contract:deployed", this.registerInVm.bind(this));
+    embark.registerActionForEvent("deployment:contract:undeployed", this.registerInVm.bind(this));
     embark.registerActionForEvent("deployment:contract:deployed", this.registerArtifact.bind(this));
+    embark.registerActionForEvent("deployment:contract:undeployed", this.registerArtifact.bind(this));
 
-    this.registerWeb3Help()
+    this.registerWeb3Help();
   }
 
   async registerWeb3Object() {

--- a/packages/embark/src/cmd/dashboard/dashboard.js
+++ b/packages/embark/src/cmd/dashboard/dashboard.js
@@ -69,7 +69,14 @@ class Dashboard {
     this.events.on("deployment:contract:deployed", (_contract) => {
       // self.events.emit('contractsState', self.contractsState());
       this.events.request("contracts:state", (err, contracts) => {
-        monitor.setContracts(contracts)
+        monitor.setContracts(contracts);
+      });
+    });
+
+    this.events.on("deployment:contract:undeployed", (_contract) => {
+      // self.events.emit('contractsState', self.contractsState());
+      this.events.request("contracts:state", (err, contracts) => {
+        monitor.setContracts(contracts);
       });
     });
 

--- a/packages/embark/src/lib/modules/ethereum-blockchain-client/index.js
+++ b/packages/embark/src/lib/modules/ethereum-blockchain-client/index.js
@@ -13,6 +13,7 @@ class EthereumBlockchainClient {
     this.events = embark.events;
     this.logger = embark.logger;
 
+    this.embark.registerActionForEvent("deployment:contract:undeployed", this.addContractJSONToPipeline.bind(this));
     this.embark.registerActionForEvent("deployment:contract:deployed", this.addContractJSONToPipeline.bind(this));
     this.embark.registerActionForEvent('deployment:contract:beforeDeploy', this.determineArguments.bind(this));
     this.embark.registerActionForEvent('deployment:contract:beforeDeploy', this.doLinking.bind(this));


### PR DESCRIPTION
Contract artifacts were not being generated nor run through the VM if the contracts/interfaces were not deployed. These features were executed as actions on the `deployment:contract:deployed` event.

This PR runs executes the same actions for `deployment:contract:undeployed` event as the `deployment:contract:deployed` event, which occurs when a contract is not deployed.