### PR TITLE
fix(@embark/cmd_controller): ensure blockchain module is started befo…

### DIFF
--- a/packages/embark/src/cmd/cmd_controller.js
+++ b/packages/embark/src/cmd/cmd_controller.js
@@ -183,8 +183,8 @@ class EmbarkController {
         const plugin = engine.plugins.createPlugin('cmdcontrollerplugin', {});
         plugin.registerActionForEvent("embark:engine:started", async (_params, cb) => {
           try {
+            await engine.events.request2("blockchain:node:start", engine.config.blockchainConfig);
             await Promise.all([
-              engine.events.request2("blockchain:node:start", engine.config.blockchainConfig),
               engine.events.request2("storage:node:start", engine.config.storageConfig),
               engine.events.request2("communication:node:start", engine.config.communicationConfig),
               engine.events.request2("namesystem:node:start", engine.config.namesystemConfig)


### PR DESCRIPTION
…re storage

This is crucial as the storage module tries to generate/eval artifacts that
depend on a `web3` object inside the VM scope. The registration of that object
can only be garuanteed when the `blockchain:started` event has been fired.

This commit ensures these modules are not spinned up in parallel as we're running
into race conditions.