### PR TITLE
Make gas oracle API work again and fix small API problems

### DIFF
--- a/packages/embark/src/lib/core/engine.js
+++ b/packages/embark/src/lib/core/engine.js
@@ -211,6 +211,7 @@ class Engine {
     this.registerModulePackage('embark-accounts-manager');
     this.registerModulePackage('embark-specialconfigs', {plugins: this.plugins});
     this.registerModulePackage('embark-console-listener');
+    this.registerModulePackage('embark-transaction-tracker');
   }
 
   storageComponent() {

--- a/packages/embark/src/lib/modules/blockchain/api.ts
+++ b/packages/embark/src/lib/modules/blockchain/api.ts
@@ -13,9 +13,10 @@ export default class BlockchainAPI {
     this.events = embark.events;
 
     this.embark.events.setCommandHandler("blockchain:api:register", (blockchainName: string, callName: string, executionCb: () => void) => {
-      const apiPlugin = this.apiPlugins.get(blockchainName);
+      let apiPlugin = this.apiPlugins.get(blockchainName);
       if (!apiPlugin) {
-        return;
+        this.apiPlugins.set(blockchainName, new Map());
+        apiPlugin = this.apiPlugins.get(blockchainName);
       }
       if (apiPlugin.has(callName)) {
         this.embark.logger.warn(`${blockchainName} blockchain API for call '${callName}' is being overwritten.`);
@@ -23,9 +24,10 @@ export default class BlockchainAPI {
       apiPlugin.set(callName, executionCb);
     });
     this.embark.events.setCommandHandler("blockchain:request:register", (blockchainName: string, requestName: string, executionCb: () => void) => {
-      const requestPlugin = this.requestPlugins.get(blockchainName);
+      let requestPlugin = this.requestPlugins.get(blockchainName);
       if (!requestPlugin) {
-        return;
+        this.requestPlugins.set(blockchainName, new Map());
+        requestPlugin = this.requestPlugins.get(blockchainName);
       }
       if (requestPlugin.has(requestName)) {
         this.embark.logger.warn(`${blockchainName} blockchain request for '${requestName}' is being overwritten.`);

--- a/packages/embark/src/lib/modules/blockchain/index.js
+++ b/packages/embark/src/lib/modules/blockchain/index.js
@@ -35,8 +35,6 @@ class Blockchain {
     });
     this.blockchainApi.registerAPIs("ethereum");
     this.blockchainApi.registerRequests("ethereum");
-
-
   }
 
   addArtifactFile(_params, cb) {

--- a/packages/embark/src/lib/modules/ethereum-blockchain-client/api.js
+++ b/packages/embark/src/lib/modules/ethereum-blockchain-client/api.js
@@ -1,4 +1,5 @@
 import async from "async";
+import {dappPath} from 'embark-utils';
 const embarkJsUtils = require('embarkjs').Utils;
 const {bigNumberify} = require('ethers/utils/bignumber');
 const RLP = require('ethers/utils/rlp');
@@ -11,6 +12,8 @@ export default class EthereumAPI {
     this.embark = embark;
     this.blockchainName = blockchainName;
     this.web3 = web3;
+    this.fs = embark.fs;
+    this.logFile = dappPath(".embark", "contractEvents.json");
   }
 
   registerAPIs() {


### PR DESCRIPTION
Branched off @emizzle's great API refactor. This adds back the gas oracle API, because otherwise it was impossible to use the contracts pages where there were transactions (`send`s)

Also fixed a small error in the API, see line 18 and others for api.ts.
The plugins were never set so the API never returned.

Just repeating, this merges in @emizzle's branch whch in turn, is based off refactor_5_0_0