### PR TITLE
refactor(@cockpit): Re-add APIs

### DIFF
--- a/packages/embark-accounts-manager/src/index.ts
+++ b/packages/embark-accounts-manager/src/index.ts
@@ -1,9 +1,9 @@
 import async from "async";
-import {Embark, Events, Logger} /* supplied by @types/embark in packages/embark-typings */ from "embark";
-import {__} from "embark-i18n";
-import {AccountParser, dappPath} from "embark-utils";
+import { Embark, Events, Logger } /* supplied by @types/embark in packages/embark-typings */ from "embark";
+import { __ } from "embark-i18n";
+import { AccountParser, dappPath } from "embark-utils";
 import Web3 from "web3";
-const {blockchain: blockchainConstants} = require("embark-core/constants");
+const { blockchain: blockchainConstants } = require("embark-core/constants");
 
 import fundAccount from "./fundAccount";
 
@@ -37,14 +37,14 @@ export default class AccountsManager {
     // Allow to run transaction in parallel by resolving the nonce manually.
     // For each transaction, resolve the nonce by taking the max of current transaction count and the cache we keep locally.
     // Update the nonce and sign it
-    this.signTransactionQueue = async.queue(({payload, account}, callback: (error: any, result: any) => void) => {
+    this.signTransactionQueue = async.queue(({ payload, account }, callback: (error: any, result: any) => void) => {
       this.getNonce(payload.from, async (err: any, newNonce: number) => {
         if (err) {
           return callback(err, null);
         }
         payload.nonce = newNonce;
         const web3 = await this.web3;
-        web3.eth.accounts.signTransaction(payload, account.privateKey , (signingError: any, result: any) => {
+        web3.eth.accounts.signTransaction(payload, account.privateKey, (signingError: any, result: any) => {
           if (signingError) {
             return callback(signingError, null);
           }
@@ -92,7 +92,7 @@ export default class AccountsManager {
       // Check if we have that account in our wallet
       const account = this.accounts.find((acc) => Web3.utils.toChecksumAddress(acc.address) === Web3.utils.toChecksumAddress(params.reqData.params[0].from));
       if (account && account.privateKey) {
-        return this.signTransactionQueue.push({payload: params.reqData.params[0], account}, (err: any, newPayload: any) => {
+        return this.signTransactionQueue.push({ payload: params.reqData.params[0], account }, (err: any, newPayload: any) => {
           if (err) {
             return callback(err, null);
           }
@@ -106,7 +106,13 @@ export default class AccountsManager {
   }
 
   private async checkBlockchainResponse(params: any, callback: (error: any, result: any) => void) {
+    if (params.reqData.method === "eth_accounts") {
+      console.dir("===== eth_accounts response, raw: " + JSON.stringify(params.respData.result));
+    }
     if (!this.ready) {
+      if (params.reqData.method === "eth_accounts") {
+        console.dir("===== eth_accounts response, UNmodified: " + JSON.stringify(params.respData.result));
+      }
       return callback(null, params);
     }
     if ((params.reqData.method === blockchainConstants.transactionMethods.eth_accounts ||
@@ -122,7 +128,13 @@ export default class AccountsManager {
         }
         return acc;
       });
+      if (params.reqData.method === "eth_accounts") {
+        console.dir("===== eth_accounts response, modified: " + JSON.stringify(params.respData.result));
+      }
       return callback(null, params);
+    }
+    if (params.reqData.method === "eth_accounts") {
+      console.dir("===== eth_accounts response, modified: " + JSON.stringify(params.respData.result));
     }
     callback(null, params);
   }
@@ -145,7 +157,7 @@ export default class AccountsManager {
         .map((account) => {
           return fundAccount(web3, account.address, coinbase, account.hexBalance);
       });
-      await Promise.all(fundingAccounts);
+      await Promise.all([fundingAccounts]);
     } catch (err) {
       this.logger.error(__("Error funding accounts"), err.message || err);
     }

--- a/packages/embark-accounts-manager/src/index.ts
+++ b/packages/embark-accounts-manager/src/index.ts
@@ -106,13 +106,7 @@ export default class AccountsManager {
   }
 
   private async checkBlockchainResponse(params: any, callback: (error: any, result: any) => void) {
-    if (params.reqData.method === "eth_accounts") {
-      console.dir("===== eth_accounts response, raw: " + JSON.stringify(params.respData.result));
-    }
     if (!this.ready) {
-      if (params.reqData.method === "eth_accounts") {
-        console.dir("===== eth_accounts response, UNmodified: " + JSON.stringify(params.respData.result));
-      }
       return callback(null, params);
     }
     if ((params.reqData.method === blockchainConstants.transactionMethods.eth_accounts ||
@@ -128,13 +122,7 @@ export default class AccountsManager {
         }
         return acc;
       });
-      if (params.reqData.method === "eth_accounts") {
-        console.dir("===== eth_accounts response, modified: " + JSON.stringify(params.respData.result));
-      }
       return callback(null, params);
-    }
-    if (params.reqData.method === "eth_accounts") {
-      console.dir("===== eth_accounts response, modified: " + JSON.stringify(params.respData.result));
     }
     callback(null, params);
   }

--- a/packages/embark-typings/src/embark.d.ts
+++ b/packages/embark-typings/src/embark.d.ts
@@ -9,7 +9,11 @@ export interface Events {
   once: any;
   setCommandHandler(
     name: string,
-    callback: (options: any, cb: () => void) => void,
+    callback: (options: any, cb: (...args: any[]) => void) => void,
+  ): void;
+  setCommandHandler(
+    name: string,
+    callback: (option: string, option2: string, cb: (...args: any[]) => void) => void,
   ): void;
 }
 
@@ -52,7 +56,7 @@ export interface Embark {
   env: string;
   events: Events;
   plugins: Plugins;
-  registerAPICall: any;
+  registerAPICall(method: string, endpoint: string, cb: (...args: any[]) => void): void;
   registerConsoleCommand: any;
   logger: Logger;
   fs: any;

--- a/packages/embark-ui/src/components/Contracts.js
+++ b/packages/embark-ui/src/components/Contracts.js
@@ -33,7 +33,7 @@ const Contracts = ({contracts, changePage, currentPage, numberOfPages, title = "
                   <Row>
                     <Col>
                       <strong>Address</strong>
-                      <div>{contract.address}</div>
+                      <div>{contract.deployedAddress}</div>
                     </Col>
                     <Col>
                       <strong>State</strong>

--- a/packages/embark-ui/src/components/ContractsDeployment.js
+++ b/packages/embark-ui/src/components/ContractsDeployment.js
@@ -42,7 +42,7 @@ const LayoutContract = ({contract, children, title = contract.className, isLoadi
   <Card>
     <CardHeader>
       <CardTitle>
-        <span className={orderClassName(contract.address)}>{contract.deployIndex + 1}</span>
+        <span className={orderClassName(contract.deployedAddress)}>{contract.deployIndex + 1}</span>
         {title}&nbsp;
         {isLoading && <FontAwesome name="spinner" spin />}
         {!isLoading && <span>{(isDeployed && deployedTitleSuffix) || notDeployedTitleSuffix}</span>}
@@ -205,12 +205,12 @@ Web3Contract.propTypes = {
 };
 
 const EmbarkContract = ({contract, toggleContractOverview}) => (
-  <LayoutContract contract={contract} 
-                  isDeployed={!!contract.address}
-                  deployedTitleSuffix={`deployed at ${contract.address}`}
-                  notDeployedTitleSuffix={'not deployed'}
-                  title={<a href='#toggleContract' onClick={() => toggleContractOverview(contract)}>{contract.className}</a>}>
-    {contract.address && <p><strong>Arguments:</strong> {JSON.stringify(contract.args)}</p>}
+  <LayoutContract contract={contract}
+    isDeployed={!!contract.deployedAddress}
+    deployedTitleSuffix={`deployed at ${contract.deployedAddress}`}
+    notDeployedTitleSuffix={'not deployed'}
+    title={<a href='#toggleContract' onClick={() => toggleContractOverview(contract)}>{contract.className}</a>}>
+    {contract.deployedAddress && <p><strong>Arguments:</strong> {JSON.stringify(contract.args)}</p>}
     {contract.transactionHash &&
     <React.Fragment>
       <p><strong>Transaction Hash:</strong> {contract.transactionHash}</p>
@@ -218,8 +218,8 @@ const EmbarkContract = ({contract, toggleContractOverview}) => (
         cost: <strong>{contract.gas * contract.gasPrice}</strong> Wei</p>
     </React.Fragment>
     }
-    {contract.address && !contract.transactionHash &&
-    <p><strong>Contract already deployed</strong></p>
+    {contract.deployedAddress && !contract.transactionHash &&
+      <p><strong>Contract already deployed</strong></p>
     }
   </LayoutContract>
 );

--- a/packages/embark-ui/src/components/ContractsList.js
+++ b/packages/embark-ui/src/components/ContractsList.js
@@ -27,7 +27,7 @@ const ContractsList = ({contracts, changePage, currentPage, numberOfPages}) => (
               return (
                 <tr key={contract.className} className={contractDisplay.stateColor}>
                   <td><Link to={`/explorer/contracts/${contract.className}`}>{contract.className}</Link></td>
-                  <td>{contractDisplay.address}</td>
+                  <td>{contractDisplay.deployedAddress}</td>
                   <td>{contractDisplay.state}</td>
                 </tr>
               );

--- a/packages/embark-ui/src/containers/EditorContainer.js
+++ b/packages/embark-ui/src/containers/EditorContainer.js
@@ -79,8 +79,8 @@ class EditorContainer extends React.Component {
       this.setState({currentFile: this.props.currentFile});
     }
 
-    if(this.props.contracts.length && this.props.transaction) {
-      const debuggingContract = this.props.contracts.find(contract => contract.address === this.props.transaction.to)
+    if (this.props.contracts.length && this.props.transaction) {
+      const debuggingContract = this.props.contracts.find(contract => contract.deployedAddress === this.props.transaction.to)
       if (debuggingContract && this.state.debuggingContract !== debuggingContract) {
         const editorWidth = this.getNewEditorWidth(OPERATIONS.LESS)
         this.setState({currentAsideTab: TextEditorToolbarTabs.Debugger, editorWidth, debuggingContract})

--- a/packages/embark-ui/src/sagas/searchSaga.js
+++ b/packages/embark-ui/src/sagas/searchSaga.js
@@ -37,7 +37,7 @@ export function *searchExplorer(entity, payload) {
   yield fetchContracts({});
   const contracts = yield select(getContracts);
   result = contracts.find(contract => {
-    return contract.address === searchValue || contract.className.toLowerCase() === searchValue.toLowerCase();
+    return contract.deployedAddress === searchValue || contract.className.toLowerCase() === searchValue.toLowerCase();
   });
 
   if (result) {

--- a/packages/embark-ui/src/utils/presentation.js
+++ b/packages/embark-ui/src/utils/presentation.js
@@ -2,7 +2,7 @@ import isToday from 'date-fns/is_today';
 import distanceInWordsToNow from 'date-fns/distance_in_words_to_now';
 
 export function formatContractForDisplay(contract) {
-  let address = (contract.address || contract.deployedAddress);
+  let address = (contract.deployedAddress || contract.deployedAddress);
   let state = 'Deployed';
   let stateColor = 'success';
   if (contract.deploy === false) {

--- a/packages/embark/package.json
+++ b/packages/embark/package.json
@@ -221,7 +221,7 @@
     "@types/async": "2.0.50",
     "@types/body-parser": "1.17.0",
     "@types/cors": "2.8.4",
-    "@types/express": "4.16.0",
+    "@types/express": "4.17.1",
     "@types/express-ws": "3.0.0",
     "@types/find-up": "2.1.0",
     "@types/globule": "1.1.3",

--- a/packages/embark/src/lib/core/engine.js
+++ b/packages/embark/src/lib/core/engine.js
@@ -215,6 +215,7 @@ class Engine {
     this.registerModulePackage('embark-accounts-manager');
     this.registerModulePackage('embark-specialconfigs', {plugins: this.plugins});
     this.registerModulePackage('embark-transaction-logger');
+    this.registerModulePackage('embark-transaction-tracker');
   }
 
   storageComponent() {

--- a/packages/embark/src/lib/modules/blockchain-client/index.js
+++ b/packages/embark/src/lib/modules/blockchain-client/index.js
@@ -2,7 +2,7 @@ const Web3 = require('web3');
 
 class BlockchainClient {
 
-  constructor(embark, _options) {
+  constructor(embark, options) {
     this.embark = embark;
     this.events = embark.events;
 

--- a/packages/embark/src/lib/modules/blockchain/api.ts
+++ b/packages/embark/src/lib/modules/blockchain/api.ts
@@ -1,0 +1,288 @@
+import { Embark, Events, Logger } from "embark";
+import { Request, Response } from "express";
+import Websocket from "ws";
+export default class BlockchainAPI {
+  private embark: Embark;
+  private logger: Logger;
+  private events: Events;
+  private apiPlugins: Map<string, Map<string, (...args: any[]) => void>> = new Map();
+  private requestPlugins: Map<string, Map<string, (...args: any[]) => any>> = new Map();
+  constructor(embark: Embark) {
+    this.embark = embark;
+    this.logger = embark.logger;
+    this.events = embark.events;
+
+    this.embark.events.setCommandHandler("blockchain:api:register", (blockchainName: string, callName: string, executionCb: () => void) => {
+      const apiPlugin = this.apiPlugins.get(blockchainName);
+      if (!apiPlugin) {
+        return;
+      }
+      if (apiPlugin.has(callName)) {
+        this.embark.logger.warn(`${blockchainName} blockchain API for call '${callName}' is being overwritten.`);
+      }
+      apiPlugin.set(callName, executionCb);
+    });
+    this.embark.events.setCommandHandler("blockchain:request:register", (blockchainName: string, requestName: string, executionCb: () => void) => {
+      const requestPlugin = this.requestPlugins.get(blockchainName);
+      if (!requestPlugin) {
+        return;
+      }
+      if (requestPlugin.has(requestName)) {
+        this.embark.logger.warn(`${blockchainName} blockchain request for '${requestName}' is being overwritten.`);
+      }
+      requestPlugin.set(requestName, executionCb);
+    });
+  }
+
+  private getCallForBlockchain(blockchainName: string, callName: string) {
+    const apiPlugin = this.apiPlugins.get(blockchainName);
+    if (!apiPlugin) {
+      throw new Error(`Blockchain '${blockchainName}' does not have any APIs registered.`);
+    }
+    const apiPluginExecCb = apiPlugin.get(callName);
+    if (!apiPluginExecCb) {
+      throw new Error(`API call '${callName}' is not registered as an API plugin for the '${blockchainName}' blockchain.`);
+    }
+    return apiPluginExecCb;
+  }
+
+  private getRequestForBlockchain(blockchainName: string, callName: string) {
+    const requestPlugin = this.requestPlugins.get(blockchainName);
+    if (!requestPlugin) {
+      throw new Error(`Blockchain '${blockchainName}' does not have any requests registered.`);
+    }
+    const requestPluginExecCb = requestPlugin.get(callName);
+    if (!requestPluginExecCb) {
+      throw new Error(`Request '${callName}' is not registered as a request plugin for the '${blockchainName}' blockchain.`);
+    }
+    return requestPluginExecCb;
+  }
+
+  protected registerRequests(blockchainName: string) {
+    // TODO: Re-add blockchain:reset for tests?
+    // this.events.setCommandHandler("blockchain:reset", async (cb) => {
+    //   const initWeb3 = this.getRequestForBlockchain(blockchainName, "initWeb3");
+    //   await initWeb3();
+    //   this.events.emit("blockchain:reseted");
+    //   cb();
+    // });
+
+    this.events.setCommandHandler("blockchain:get", async (cb) => {
+      const blockchainObject = await this.getRequestForBlockchain(blockchainName, "blockchainObject");
+      cb(blockchainObject);
+    });
+
+    this.events.setCommandHandler("blockchain:defaultAccount:get", (cb) => {
+      const getDefaultAccount = this.getRequestForBlockchain(blockchainName, "getDefaultAccount");
+      cb(getDefaultAccount);
+    });
+
+    this.events.setCommandHandler("blockchain:defaultAccount:set", (account, cb) => {
+      const setDefaultAccount = this.getRequestForBlockchain(blockchainName, "setDefaultAccount");
+      setDefaultAccount(account);
+      cb();
+    });
+
+    this.events.setCommandHandler("blockchain:getAccounts", (cb) => {
+      const getAccounts = this.getRequestForBlockchain(blockchainName, "getAccounts");
+      getAccounts(cb);
+    });
+
+    this.events.setCommandHandler("blockchain:getBalance", (address, cb) => {
+      const getBalance = this.getRequestForBlockchain(blockchainName, "getBalance");
+      getBalance(address, cb);
+    });
+
+    this.events.setCommandHandler("blockchain:block:byNumber", (blockNumber, cb) => {
+      const getBlock = this.getRequestForBlockchain(blockchainName, "getBlock");
+      getBlock(blockNumber, cb);
+    });
+
+    this.events.setCommandHandler("blockchain:block:byHash", (blockHash, cb) => {
+      const getBlock = this.getRequestForBlockchain(blockchainName, "getBlock");
+      getBlock(blockHash, cb);
+    });
+
+    this.events.setCommandHandler("blockchain:gasPrice", (cb) => {
+      const getGasPrice = this.getRequestForBlockchain(blockchainName, "getGasPrice");
+      getGasPrice(cb);
+    });
+
+    this.events.setCommandHandler("blockchain:networkId", async (cb) => {
+      const getNetworkId = await this.getRequestForBlockchain(blockchainName, "getNetworkId");
+      cb(getNetworkId);
+    });
+
+    this.events.setCommandHandler("blockchain:contract:create", (params, cb) => {
+      const contractObject = this.getRequestForBlockchain(blockchainName, "contractObject")(params);
+      cb(contractObject);
+    });
+  }
+
+  protected registerAPIs(blockchainName: string) {
+    this.embark.registerAPICall(
+      "get",
+      "/embark-api/blockchain/accounts",
+      (req, res) => {
+        try {
+          const getAccountsWithTransactionCount = this.getCallForBlockchain(blockchainName, "getAccountsWithTransactionCount");
+          getAccountsWithTransactionCount(res.send.bind(res));
+        } catch (error) {
+          res.status(500).send({ error });
+        }
+      },
+    );
+
+    this.embark.registerAPICall(
+      "get",
+      "/embark-api/blockchain/accounts/:address",
+      (req, res) => {
+        try {
+          const getAccount = this.getCallForBlockchain(blockchainName, "getAccount");
+          getAccount(req.params.address, res.send.bind(res));
+        } catch (error) {
+          res.status(500).send({ error });
+        }
+      },
+    );
+
+    this.embark.registerAPICall(
+      "get",
+      "/embark-api/blockchain/blocks",
+      (req, res) => {
+        try {
+          const getBlocks = this.getCallForBlockchain(blockchainName, "getBlocks");
+          const from = parseInt(req.query.from, 10);
+          const limit = req.query.limit || 10;
+          getBlocks(from, limit, !!req.query.txObjects, !!req.query.txReceipts, res.send.bind(res));
+        } catch (error) {
+          res.status(500).send({ error });
+        }
+      },
+    );
+
+    this.embark.registerAPICall(
+      "get",
+      "/embark-api/blockchain/blocks/:blockNumber",
+      (req, res) => {
+        try {
+          const getBlock = this.getCallForBlockchain(blockchainName, "getBlock");
+          getBlock(req.params.blockNumber, (err: Error, block: any) => {
+            if (err) {
+              this.logger.error(err.message);
+            }
+            res.send(block);
+          });
+        } catch (error) {
+          res.status(500).send({ error });
+        }
+      },
+    );
+
+    this.embark.registerAPICall(
+      "get",
+      "/embark-api/blockchain/transactions",
+      (req, res) => {
+        try {
+          const blockFrom = parseInt(req.query.blockFrom, 10);
+          const blockLimit = req.query.blockLimit || 10;
+          const getTransactions = this.getCallForBlockchain(blockchainName, "getTransactions");
+          getTransactions(blockFrom, blockLimit, res.send.bind(res));
+        } catch (error) {
+          res.status(500).send({ error });
+        }
+      },
+    );
+
+    this.embark.registerAPICall(
+      "get",
+      "/embark-api/blockchain/transactions/:hash",
+      (req, res) => {
+        try {
+          const getTransactionByHash = this.getCallForBlockchain(blockchainName, "getTransactionByHash");
+          const getTransactionByRawTransactionHash = this.getCallForBlockchain(blockchainName, "getTransactionByRawTransactionHash");
+          getTransactionByHash(req.params.hash, (err: Error, transaction: any) => {
+            if (!err) {
+              return res.send(transaction);
+            }
+
+            getTransactionByRawTransactionHash(req.params.hash, (errRaw: Error, transactionRaw: any) => {
+              if (errRaw) {
+                return res.send({ error: "Could not find or decode transaction hash" });
+              }
+              res.send(transactionRaw);
+            });
+          });
+        } catch (error) {
+          res.status(500).send({ error });
+        }
+      },
+    );
+
+    this.embark.registerAPICall(
+      "ws",
+      "/embark-api/blockchain/blockHeader",
+      (ws) => {
+        this.events.on("block:header", (block: any) => {
+          ws.send(JSON.stringify({ block }), () => { });
+        });
+      },
+    );
+
+    this.embark.registerAPICall(
+      "ws",
+      "/embark-api/blockchain/contracts/event",
+      (ws) => {
+        this.events.on("blockchain:contracts:event", (data: any) => {
+          ws.send(JSON.stringify(data), () => { });
+        });
+      },
+    );
+
+    this.embark.registerAPICall(
+      "get",
+      "/embark-api/blockchain/contracts/events",
+      (_req, res) => {
+        try {
+          const getEvents = this.getCallForBlockchain(blockchainName, "getEvents");
+          res.send(JSON.stringify(getEvents()));
+        } catch (error) {
+          res.status(500).send({ error });
+        }
+      },
+    );
+
+    this.embark.registerAPICall(
+      "post",
+      "/embark-api/messages/sign",
+      async (req, res) => {
+        try {
+          const signer = req.body.address;
+          const message = req.body.message;
+          const signMessage = this.getCallForBlockchain(blockchainName, "signMessage");
+          const signature = await signMessage(message, signer);
+          res.send({ signer, signature, message });
+        } catch (error) {
+          res.status(500).send({ error });
+        }
+      },
+    );
+
+    this.embark.registerAPICall(
+      "post",
+      "/embark-api/messages/verify",
+      async (req, res) => {
+        try {
+          const verifyMessage = this.getCallForBlockchain(blockchainName, "verifyMessage");
+          const signature = JSON.parse(req.body.message);
+          const address = await verifyMessage(signature.message, signature.signature);
+          res.send({ address });
+        } catch (error) {
+          res.status(500).send({ error });
+        }
+      },
+    );
+
+  }
+
+}

--- a/packages/embark/src/lib/modules/blockchain/api.ts
+++ b/packages/embark/src/lib/modules/blockchain/api.ts
@@ -13,9 +13,10 @@ export default class BlockchainAPI {
     this.events = embark.events;
 
     this.embark.events.setCommandHandler("blockchain:api:register", (blockchainName: string, callName: string, executionCb: () => void) => {
-      const apiPlugin = this.apiPlugins.get(blockchainName);
+      let apiPlugin = this.apiPlugins.get(blockchainName);
       if (!apiPlugin) {
-        return;
+        apiPlugin = new Map();
+        this.apiPlugins.set(blockchainName, apiPlugin);
       }
       if (apiPlugin.has(callName)) {
         this.embark.logger.warn(`${blockchainName} blockchain API for call '${callName}' is being overwritten.`);
@@ -23,9 +24,10 @@ export default class BlockchainAPI {
       apiPlugin.set(callName, executionCb);
     });
     this.embark.events.setCommandHandler("blockchain:request:register", (blockchainName: string, requestName: string, executionCb: () => void) => {
-      const requestPlugin = this.requestPlugins.get(blockchainName);
+      let requestPlugin = this.requestPlugins.get(blockchainName);
       if (!requestPlugin) {
-        return;
+        requestPlugin = new Map();
+        this.requestPlugins.set(blockchainName, requestPlugin);
       }
       if (requestPlugin.has(requestName)) {
         this.embark.logger.warn(`${blockchainName} blockchain request for '${requestName}' is being overwritten.`);

--- a/packages/embark/src/lib/modules/blockchain/index.js
+++ b/packages/embark/src/lib/modules/blockchain/index.js
@@ -35,8 +35,6 @@ class Blockchain {
     });
     this.blockchainApi.registerAPIs("ethereum");
     this.blockchainApi.registerRequests("ethereum");
-
-
   }
 
   addArtifactFile(_params, cb) {

--- a/packages/embark/src/lib/modules/blockchain/index.js
+++ b/packages/embark/src/lib/modules/blockchain/index.js
@@ -1,18 +1,19 @@
 import async from 'async';
 const {__} = require('embark-i18n');
 
+import BlockchainAPI from "./api";
 class Blockchain {
 
-  constructor(embark, options) {
+  constructor(embark) {
     this.embarkConfig = embark.config.embarkConfig;
     this.logger = embark.logger;
     this.events = embark.events;
     this.blockchainConfig = embark.config.blockchainConfig;
     this.contractConfig = embark.config.contractConfig;
-    this.plugins = options.plugins;
-    let plugin = this.plugins.createPlugin('web3plugin', {});
+    this.blockchainApi = new BlockchainAPI(embark);
 
-    plugin.registerActionForEvent("pipeline:generateAll:before", this.addArtifactFile.bind(this));
+
+    embark.registerActionForEvent("pipeline:generateAll:before", this.addArtifactFile.bind(this));
 
     this.blockchainNodes = {};
     this.events.setCommandHandler("blockchain:node:register", (clientName, startCb) => {
@@ -32,6 +33,10 @@ class Blockchain {
 
       client.apply(client, [onStart]);
     });
+    this.blockchainApi.registerAPIs("ethereum");
+    this.blockchainApi.registerRequests("ethereum");
+
+
   }
 
   addArtifactFile(_params, cb) {

--- a/packages/embark/src/lib/modules/ethereum-blockchain-client/api.js
+++ b/packages/embark/src/lib/modules/ethereum-blockchain-client/api.js
@@ -1,4 +1,5 @@
 import async from "async";
+import {dappPath} from 'embark-utils';
 const embarkJsUtils = require('embarkjs').Utils;
 const {bigNumberify} = require('ethers/utils/bignumber');
 const RLP = require('ethers/utils/rlp');
@@ -11,6 +12,8 @@ export default class EthereumAPI {
     this.embark = embark;
     this.blockchainName = blockchainName;
     this.web3 = web3;
+    this.fs = embark.fs;
+    this.logFile = dappPath(".embark", "contractEvents.json");
   }
 
   registerAPIs() {

--- a/packages/embark/src/lib/modules/ethereum-blockchain-client/api.js
+++ b/packages/embark/src/lib/modules/ethereum-blockchain-client/api.js
@@ -1,0 +1,407 @@
+import async from "async";
+const embarkJsUtils = require('embarkjs').Utils;
+const {bigNumberify} = require('ethers/utils/bignumber');
+const RLP = require('ethers/utils/rlp');
+const ethUtil = require('ethereumjs-util');
+
+const BLOCK_LIMIT = 100;
+
+export default class EthereumAPI {
+  constructor(embark, web3, blockchainName) {
+    this.embark = embark;
+    this.blockchainName = blockchainName;
+    this.web3 = web3;
+  }
+
+  registerAPIs() {
+    this.embark.events.request("blockchain:api:register", this.blockchainName, "getAccountsWithTransactionCount", this.getAccountsWithTransactionCount.bind(this));
+    this.embark.events.request("blockchain:api:register", this.blockchainName, "getAccount", this.getAccount.bind(this));
+    this.embark.events.request("blockchain:api:register", this.blockchainName, "getBlocks", this.getBlocks.bind(this));
+    this.embark.events.request("blockchain:api:register", this.blockchainName, "getBlock", this.getBlock.bind(this));
+    this.embark.events.request("blockchain:api:register", this.blockchainName, "getTransactions", this.getTransactions.bind(this));
+    this.embark.events.request("blockchain:api:register", this.blockchainName, "getTransactionByHash", this.getTransactionByHash.bind(this));
+    this.embark.events.request("blockchain:api:register", this.blockchainName, "getTransactionByRawTransactionHash", this.getTransactionByRawTransactionHash.bind(this));
+    this.embark.events.request("blockchain:api:register", this.blockchainName, "getEvents", this.getEvents.bind(this));
+    this.embark.events.request("blockchain:api:register", this.blockchainName, "signMessage", this.signMessage.bind(this));
+    this.embark.events.request("blockchain:api:register", this.blockchainName, "verifyMessage", this.verifyMessage.bind(this));
+  }
+
+  registerRequests() {
+    this.embark.events.request("blockchain:request:register", this.blockchainName, "blockchainObject", async () => {
+      return this.web3;
+    });
+    // TODO: Re-add init web3? The initWeb3 method should come from the legacy embark-blockchain-connector
+    // this.embark.events.request("blockchain:request:register", this.blockchainName, "initWeb3", this.initWeb3.bind(this));
+    this.embark.events.request("blockchain:request:register", this.blockchainName, "getDefaultAccount", this.defaultAccount.bind(this));
+    this.embark.events.request("blockchain:request:register", this.blockchainName, "setDefaultAccount", this.setDefaultAccount.bind(this));
+    this.embark.events.request("blockchain:request:register", this.blockchainName, "getAccounts", this.getAccounts.bind(this));
+    this.embark.events.request("blockchain:request:register", this.blockchainName, "getBalance", this.getBalance.bind(this));
+    this.embark.events.request("blockchain:request:register", this.blockchainName, "getBlock", this.getBlock.bind(this));
+    this.embark.events.request("blockchain:request:register", this.blockchainName, "getGasPrice", this.getGasPrice.bind(this));
+    this.embark.events.request("blockchain:request:register", this.blockchainName, "getNetworkId", this.getNetworkId.bind(this));
+    this.embark.events.request("blockchain:request:register", this.blockchainName, "contractObject", this.contractObject.bind(this));
+  }
+
+  getAccountsWithTransactionCount(callback) {
+    let self = this;
+    self.getAccounts((err, addresses) => {
+      let accounts = [];
+      async.eachOf(addresses, (address, index, eachCb) => {
+        let account = {address, index};
+        async.waterfall([
+          function (callback) {
+            self.getTransactionCount(address, (err, count) => {
+              if (err) {
+                self.logger.error(err);
+                account.transactionCount = 0;
+              } else {
+                account.transactionCount = count;
+              }
+              callback(null, account);
+            });
+          },
+          function (account, callback) {
+            self.getBalance(address, (err, balance) => {
+              if (err) {
+                self.logger.error(err);
+                account.balance = 0;
+              } else {
+                account.balance = self.web3.utils.fromWei(balance);
+              }
+              callback(null, account);
+            });
+          }
+        ], function (_err, account) {
+          accounts.push(account);
+          eachCb();
+        });
+      }, function () {
+        callback(accounts);
+      });
+    });
+  }
+
+  getAccount(address, callback) {
+    let self = this;
+    async.waterfall([
+      function (next) {
+        self.getAccountsWithTransactionCount((accounts) => {
+          let account = accounts.find((a) => a.address === address);
+          if (!account) {
+            return next("No account found with this address");
+          }
+          next(null, account);
+        });
+      },
+      function (account, next) {
+        self.getBlockNumber((err, blockNumber) => {
+          if (err) {
+            self.logger.error(err);
+            next(err);
+          } else {
+            next(null, blockNumber, account);
+          }
+        });
+      },
+      function (blockNumber, account, next) {
+        self.getTransactions(blockNumber - BLOCK_LIMIT, BLOCK_LIMIT, (transactions) => {
+          account.transactions = transactions.filter((transaction) => transaction.from === address);
+          next(null, account);
+        });
+      }
+    ], function (err, result) {
+      if (err) {
+        callback();
+      }
+      callback(result);
+    });
+  }
+
+  getTransactions(blockFrom, blockLimit, callback) {
+    this.getBlocks(blockFrom, blockLimit, true, true, (blocks) => {
+      let transactions = blocks.reduce((acc, block) => {
+        if (!block || !block.transactions) {
+          return acc;
+        }
+        return acc.concat(block.transactions);
+      }, []);
+      callback(transactions);
+    });
+  }
+
+  getBlocks(from, limit, returnTransactionObjects, includeTransactionReceipts, callback) {
+    let self = this;
+    let blocks = [];
+    async.waterfall([
+      function (next) {
+        if (!isNaN(from)) {
+          return next();
+        }
+        self.getBlockNumber((err, blockNumber) => {
+          if (err) {
+            self.logger.error(err);
+            from = 0;
+          } else {
+            from = blockNumber;
+          }
+          next();
+        });
+      },
+      function (next) {
+        async.times(limit, function (n, eachCb) {
+          self.web3.eth.getBlock(from - n, returnTransactionObjects, function (err, block) {
+            if (err) {
+              // FIXME Returns an error because we are too low
+              return eachCb();
+            }
+            if (!block) {
+              return eachCb();
+            }
+            if (!(returnTransactionObjects && includeTransactionReceipts) ||
+              !(block.transactions && block.transactions.length)) {
+              blocks.push(block);
+              return eachCb();
+            }
+            return Promise.all(block.transactions.map(tx => (
+              self.web3.eth.getTransactionReceipt(tx.hash)
+            )))
+              .then(receipts => {
+                block.transactions.forEach((tx, index) => {
+                  tx['receipt'] = receipts[index];
+                  tx['timestamp'] = block.timestamp;
+                });
+                blocks.push(block);
+                eachCb();
+              })
+              .catch((err) => {
+                self.logger.error(err.message || err);
+                eachCb();
+              });
+          });
+        }, next);
+      }
+    ], function () {
+      callback(blocks);
+    });
+  }
+
+  defaultAccount() {
+    return this.web3.eth.defaultAccount;
+  }
+
+  getBlockNumber(cb) {
+    return this.web3.eth.getBlockNumber(cb);
+  }
+
+  setDefaultAccount(account) {
+    this.web3.eth.defaultAccount = account;
+  }
+
+  getAccounts(cb) {
+    this.web3.eth.getAccounts(cb);
+  }
+
+  getTransactionCount(address, cb) {
+    this.web3.eth.getTransactionCount(address, cb);
+  }
+
+  getBalance(address, cb) {
+    this.web3.eth.getBalance(address, cb);
+  }
+
+  getCode(address, cb) {
+    this.web3.eth.getCode(address, cb);
+  }
+
+  getBlock(blockNumber, cb) {
+    this.web3.eth.getBlock(blockNumber, true, (err, block) => {
+      if (err) return cb(err);
+      if (block.transactions && block.transactions.length) {
+        block.transactions.forEach(tx => {
+          tx.timestamp = block.timestamp;
+        });
+      }
+      cb(null, block);
+    });
+  }
+
+  getTransactionByHash(hash, cb) {
+    this.web3.eth.getTransaction(hash, cb);
+  }
+
+  getTransactionByRawTransactionHash(hash, cb) {
+    let rawData, decoded;
+
+    try {
+      rawData = Buffer.from(ethUtil.stripHexPrefix(hash), 'hex');
+      decoded = RLP.decode(rawData);
+    } catch (e) {
+      return cb("could not decode transaction");
+    }
+
+    const [
+      nonce,
+      gasPrice,
+      gasLimit,
+      to,
+      value,
+      data,
+      v,
+      r,
+      s
+    ] = decoded;
+
+    const transaction = {
+      nonce: bigNumberify(nonce).toNumber(),
+      gasPrice: bigNumberify(gasPrice).toNumber(),
+      gasLimit: bigNumberify(gasLimit).toNumber(),
+      data: data,
+      v: `0x${v.toString('hex').toLowerCase()}`,
+      r: `0x${r.toString('hex').toLowerCase()}`,
+      s: `0x${s.toString('hex').toLowerCase()}`,
+      value: value.toString('utf8'),
+      to: `0x${to.toString('hex').toLowerCase()}`
+    };
+
+    cb(null, transaction);
+  }
+
+  getGasPrice(cb) {
+    const self = this;
+    this.onReady(() => {
+      self.web3.eth.getGasPrice(cb);
+    });
+  }
+
+  getClientVersion(cb) {
+    this.web3._requestManager.send({method: 'web3_clientVersion', params: []}, cb);
+  }
+
+  getNetworkId() {
+    return this.web3.eth.net.getId();
+  }
+
+  getTransaction(hash, cb) {
+    return this.web3.eth.getTransaction(hash, cb);
+  }
+
+  contractObject(params) {
+    return new this.web3.eth.Contract(params.abi, params.address);
+  }
+
+  deployContractObject(contractObject, params) {
+    return contractObject.deploy({arguments: params.arguments, data: params.data});
+  }
+
+  estimateDeployContractGas(deployObject, cb) {
+    return deployObject.estimateGas().then((gasValue) => {
+      cb(null, gasValue);
+    }).catch(cb);
+  }
+
+  deployContractFromObject(deployContractObject, params, cb, hashCb) {
+    embarkJsUtils.secureSend(this.web3, deployContractObject, {
+      from: params.from, gas: params.gas, gasPrice: params.gasPrice
+    }, true, cb, hashCb);
+  }
+
+  determineDefaultAccount(cb) {
+    const self = this;
+    self.getAccounts(function (err, accounts) {
+      if (err) {
+        self.logger.error(err);
+        return cb(new Error(err));
+      }
+      let accountConfig = self.config.blockchainConfig.account;
+      let selectedAccount = accountConfig && accountConfig.address;
+      const defaultAccount = selectedAccount || accounts[0];
+      self.setDefaultAccount(defaultAccount);
+      cb(null, defaultAccount);
+    });
+  }
+
+  registerWeb3Object(cb = () => {}) {
+    // doesn't feel quite right, should be a cmd or plugin method
+    // can just be a command without a callback
+    this.events.emit("runcode:register", "web3", this.web3, cb);
+  }
+
+  subscribeToPendingTransactions() {
+    const self = this;
+    this.onReady(() => {
+      if (self.logsSubscription) {
+        self.logsSubscription.unsubscribe();
+      }
+      self.logsSubscription = self.web3.eth
+        .subscribe('newBlockHeaders', () => {})
+        .on("data", function (blockHeader) {
+          self.events.emit('block:header', blockHeader);
+        });
+
+      if (self.pendingSubscription) {
+        self.pendingSubscription.unsubscribe();
+      }
+      self.pendingSubscription = self.web3.eth
+        .subscribe('pendingTransactions', function (error, transaction) {
+          if (!error) {
+            self.events.emit('block:pending:transaction', transaction);
+          }
+        });
+    });
+  }
+
+  subscribeToContractEvents(callback) {
+    this.contractsSubscriptions.forEach((eventEmitter) => {
+      const reqMgr = eventEmitter.options.requestManager;
+      // attempting an eth_unsubscribe when not connected throws an
+      // "connection not open on send()" error
+      if (reqMgr && reqMgr.provider && reqMgr.provider.connected) {
+        eventEmitter.unsubscribe();
+      }
+    });
+    this.contractsSubscriptions = [];
+    this.events.request("contracts:list", (_err, contractsList) => {
+      contractsList.forEach(contractObject => {
+        if (!contractObject.deployedAddress) {
+          return;
+        }
+
+        const contract = this.contractObject({abi: contractObject.abiDefinition, address: contractObject.deployedAddress});
+        const eventEmitter = contract.events.allEvents();
+        this.contractsSubscriptions.push(eventEmitter);
+        eventEmitter.on('data', (data) => {
+          const dataWithName = Object.assign(data, {name: contractObject.className});
+          this.contractsEvents.push(dataWithName);
+          this.events.emit('blockchain:contracts:event', dataWithName);
+        });
+      });
+      callback();
+    });
+  }
+
+  getEvents() {
+    const data = this.readEvents();
+    return Object.values(data).reverse();
+  }
+
+  saveEvent(event) {
+    this.writeLogFile.push(event);
+  }
+
+  readEvents() {
+    this.fs.ensureFileSync(this.logFile);
+    try {
+      return JSON.parse(this.fs.readFileSync(this.logFile));
+    } catch (_error) {
+      return {};
+    }
+  }
+
+  async signMessage(message, signer) {
+    return this.web3.eth.sign(message, signer);
+  }
+
+  async verifyMessage(message, signature) {
+    return this.web3.eth.personal.ecRecover(signature.message, signature.signature);
+  }
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -2983,10 +2983,19 @@
     "@types/express-serve-static-core" "*"
     "@types/ws" "*"
 
-"@types/express@*", "@types/express@4.16.0":
+"@types/express@*":
   version "4.16.0"
   resolved "https://registry.yarnpkg.com/@types/express/-/express-4.16.0.tgz#6d8bc42ccaa6f35cf29a2b7c3333cb47b5a32a19"
   integrity sha512-TtPEYumsmSTtTetAPXlJVf3kEqb6wZK0bZojpJQrnD/djV4q1oB6QQ8aKvKqwNPACoe02GNiy5zDzcYivR5Z2w==
+  dependencies:
+    "@types/body-parser" "*"
+    "@types/express-serve-static-core" "*"
+    "@types/serve-static" "*"
+
+"@types/express@4.17.1":
+  version "4.17.1"
+  resolved "https://registry.yarnpkg.com/@types/express/-/express-4.17.1.tgz#4cf7849ae3b47125a567dfee18bfca4254b88c5c"
+  integrity sha512-VfH/XCP0QbQk5B5puLqTLEeFgR8lfCJHZJKkInZ9mkYd+u8byX0kztXEQxEk4wZXJs8HI+7km2ALXjn4YKcX9w==
   dependencies:
     "@types/body-parser" "*"
     "@types/express-serve-static-core" "*"


### PR DESCRIPTION
APIs for Cockpit have been re-added.

The bulk of the work is split in to two parts
1. Contracts APIs (in `embark-contracts-manager`) have been refactored a bit to add status codes to most responses (`express` is deprecating responses without status codes)
2. Remainder of the blockchain APIs and commands have been refactored so that they are registered in the blockchain stack component (`lib/modules/blockchain`), which is agnostic to the blockchain-specific implementation. The low-level implementation methods have been abstracted out from web3 by way of this registration. It is the job of the `ethereum-blockchain-client` (plugin) to register the API methods and command functions, which -- being ethereum -- can use `web3` in the methods.

### TODO
There is an event `blockchain:reset` that was used in the test runner in v4. This has been added to the refactor, but has been commented out as the event eventually runs `initWeb3` in the legacy `embark-blockchain-connector` which may no longer be needed. Looking for some clarity and additional PR if possible please @andremedeiros.

### Known issue
As part of the proxy refactor, `eth_getTransactionReceipt` is being logged in the proxy logger (`embark-console-listener`), and when Cockpit lists blocks in the explorer, transactions contained in the blocks are being logged: ![Imgur](https://i.imgur.com/bweIqI6.png). This can be replicated by loading up Cockpit and clicking the Explorer tab.

This can be handled in a future PR as this is already large enough.