### PR TITLE
fix(@embark/deploy-tracker): fix contract always re-deploying

### DIFF
--- a/packages/embark-deploy-tracker/src/deploymentChecks.js
+++ b/packages/embark-deploy-tracker/src/deploymentChecks.js
@@ -80,7 +80,7 @@ export default class DeploymentChecks {
     catch (err) {
       return cb(err);
     }
-    if (codeInChain.length > 3) { // it is "0x" or "0x0" for empty code, depending on web3 version
+    if (codeInChain.length > 3 && codeInChain.substring(2) === contract.runtimeBytecode) { // it is "0x" or "0x0" for empty code, depending on web3 version
       contract.deployedAddress = trackedContract.address;
       contract.log(contract.className.bold.cyan + __(" already deployed at ").green + contract.deployedAddress.bold.cyan);
       params.shouldDeploy = false;

--- a/packages/embark-deploy-tracker/src/test/deploymentChecksSpec.js
+++ b/packages/embark-deploy-tracker/src/test/deploymentChecksSpec.js
@@ -164,6 +164,8 @@ describe('embark.deploymentChecks', function () {
       });
     });
     it("should not deploy if contract is tracked, but bytecode exists on chain", async function () {
+      trackingFunctions._web3.eth.getCode = () => "0x0123";
+      params.contract.runtimeBytecode = '0123';
       return deploymentChecks.checkIfAlreadyDeployed(params, (err, params) => {
         expect(err).to.be(null);
         expect(params.shouldDeploy).to.be(false);
@@ -180,6 +182,8 @@ describe('embark.deploymentChecks', function () {
     it("should update tracked contract in chains.json when contract.track !== false", async function () {
       const trackAndSaveContract = sinon.stub(trackingFunctions, "trackAndSaveContract");
       const {contract} = params;
+      trackingFunctions._web3.eth.getCode = () => "0x0123";
+      params.contract.runtimeBytecode = '0123';
       return deploymentChecks.checkIfAlreadyDeployed(params, (err, params) => {
         expect(err).to.be(null);
         expect(params.shouldDeploy).to.be(false);

--- a/packages/embark-solidity/src/index.js
+++ b/packages/embark-solidity/src/index.js
@@ -3,6 +3,7 @@ let SolcW = require('./solcW.js');
 const path = require('path');
 import { __ } from 'embark-i18n';
 import {normalizePath} from 'embark-utils';
+const cloneDeep = require('lodash.clonedeep');
 
 class Solidity {
 
@@ -196,6 +197,8 @@ class Solidity {
     let self = this;
     let input = {};
     let originalFilepath = {};
+
+    contractFiles = cloneDeep(contractFiles);
 
     async.waterfall([
       function prepareInput(callback) {


### PR DESCRIPTION
This was caused by two factors:
1. We didn't check the contract's bytecode, so as soon as we had an address, we assumed it was deployed, but it often could be the old address
2. The bytecode didn't change, because the prepare script for contracts modified the `contractFile` object, so the path of the contract files became the `.embark/` one.
  - fixed by deep cloning the contrractFiles object.