### PR TITLE
Enable changing node from test to test

### DIFF
--- a/dapps/templates/demo/test/simple_storage_spec.js
+++ b/dapps/templates/demo/test/simple_storage_spec.js
@@ -5,7 +5,7 @@ let accounts;
 
 // For documentation please see https://embark.status.im/docs/contracts_testing.html
 config({
-  //deployment: {
+  //blockchain: {
   //  accounts: [
   //    // you can configure custom accounts with a custom balance
   //    // see https://embark.status.im/docs/contracts_testing.html#Configuring-accounts

--- a/packages/embark-mocha-tests/package.json
+++ b/packages/embark-mocha-tests/package.json
@@ -44,19 +44,27 @@
   "eslintConfig": {
     "extends": "../../.eslintrc.json"
   },
+  "dependencies": {
+    "@babel/runtime-corejs2": "7.3.1",
+    "async": "3.1.0",
+    "embark-i18n": "^4.1.1",
+    "embark-utils": "^4.1.1",
+    "fs-extra": "7.0.1",
+    "mocha": "6.2.0",
+    "solc": "0.5.0",
+    "uuid": "3.3.2",
+    "web3": "1.2.1"
+  },
   "devDependencies": {
     "@babel/cli": "7.2.3",
     "@babel/core": "7.2.2",
     "@types/async": "2.0.50",
-    "async": "3.1.0",
     "cross-env": "5.2.0",
     "eslint": "5.7.0",
-    "mocha": "6.2.0",
     "npm-run-all": "4.1.5",
     "rimraf": "3.0.0",
     "tslint": "5.16.0",
-    "typescript": "3.4.5",
-    "web3": "1.2.1"
+    "typescript": "3.4.5"
   },
   "engines": {
     "node": ">=8.12.0 <12.0.0",

--- a/packages/embark-mocha-tests/src/lib/index.js
+++ b/packages/embark-mocha-tests/src/lib/index.js
@@ -1,3 +1,6 @@
+import {__} from 'embark-i18n';
+import {deconstructUrl, buildUrl} from 'embark-utils';
+
 const assert = require('assert').strict;
 const async = require('async');
 const Mocha = require('mocha');
@@ -6,13 +9,19 @@ const Web3 = require('web3');
 const Reporter = require('./reporter');
 
 const JAVASCRIPT_TEST_MATCH = /^.+\.js$/i;
-const TEST_TIMEOUT = 15000; // 15 seconds in milliseconds
+const TEST_TIMEOUT = 0; // 15 seconds in milliseconds
 
 class MochaTestRunner {
   constructor(embark, _options) {
     this.embark = embark;
+    this.logger = embark.logger;
+    this.events = embark.events;
+    this.configObj = embark.config;
 
     this.files = [];
+    this.simOptions = {};
+    this.options = {};
+    this.web3 = null;
 
     const { events } = embark;
     events.request('tests:runner:register',
@@ -35,19 +44,87 @@ class MochaTestRunner {
     return JAVASCRIPT_TEST_MATCH.test(path);
   }
 
-  run(options, cb) {
+  async checkDeploymentOptions(options) {
+    let resetServices = false;
+    const blockchainConfig = options.blockchain || {};
+    const {host, port, type, protocol} = blockchainConfig.endpoint ? deconstructUrl(blockchainConfig.endpoint) : {};
+    const accounts = blockchainConfig.accounts;
+
+    if (host && port && !['rpc', 'ws'].includes(type)) {
+      throw new Error(__("contracts config error: unknown deployment type %s", type));
+    }
+
+    if (this.options.coverage && type === 'rpc') {
+      this.logger.warn(__('Coverage does not work with an RPC node'));
+      this.logger.warn(__('You can change to a WS node (`"type": "ws"`) or use the simulator (no node or `"type": "vm"`)'));
+    }
+
+    if (accounts || (port && port !== this.simOptions.port) || (type && type !== this.simOptions.type) ||
+      (host && host !== this.simOptions.host)) {
+      resetServices = true;
+    }
+
+    Object.assign(this.simOptions, {host, port, type, protocol});
+    this.simOptions.accounts = accounts;
+
+    if (!resetServices) {
+      return;
+    }
+
+    await this.startBlockchainNode();
+  }
+
+  async startBlockchainNode() {
+    let node = this.options.node;
+    if (!this.simOptions.host && (node && node === 'vm')) {
+      this.simOptions.type = 'vm';
+    } else if (this.simOptions.host || (node && node !== 'vm')) {
+      let options = this.simOptions;
+      if (node && node !== 'vm') {
+        options = deconstructUrl(node);
+      }
+
+      if (!options.protocol) {
+        options.protocol = (options.type === "rpc") ? 'http' : 'ws';
+      }
+      Object.assign(this.simOptions, options);
+      node = null;
+    }
+
+    this.configObj.blockchainConfig.endpoint = this.simOptions.host ? buildUrl(this.simOptions.protocol, this.simOptions.host, this.simOptions.port, this.simOptions.type) : null;
+    this.configObj.blockchainConfig.type = this.simOptions.type;
+    this.configObj.blockchainConfig.accounts = this.simOptions.accounts;
+    this.configObj.blockchainConfig.coverage = this.options.coverage;
+    // TODO fix this be there by default
+    this.configObj.blockchainConfig.isDev = true;
+    this.logger.trace('Setting blockchain configs:', this.configObj.blockchainConfig);
+    await this.events.request2('config:blockchainConfig:set', this.configObj.blockchainConfig);
+    await this.events.request2("blockchain:node:start", this.configObj.blockchainConfig, node);
+    const provider = await this.events.request2("blockchain:client:provider", "ethereum");
+    if (!this.web3) {
+      this.web3 = new Web3();
+    }
+    this.web3.setProvider(provider);
+  }
+
+  async run(options, cb) {
     const {events} = this.embark;
+    this.options = options;
 
     const Module = require("module");
     const originalRequire = require("module").prototype.require;
 
     let accounts = [];
     let compiledContracts = {};
-    let web3;
 
     const config = (cfg, acctCb) => {
       global.before((done) => {
         async.waterfall([
+          (next) => {
+            this.checkDeploymentOptions(cfg)
+              .then(next)
+              .catch(next);
+          },
           (next) => {
             events.request("contracts:build", cfg, compiledContracts, next);
           },
@@ -60,7 +137,7 @@ class MochaTestRunner {
           (contracts, next) => {
             for(const contract of contracts) {
               const instance = compiledContracts[contract.className];
-              const contractObj = new web3.eth.Contract(instance.abiDefinition, contract.deployedAddress);
+              const contractObj = new this.web3.eth.Contract(instance.abiDefinition, contract.deployedAddress);
               Object.setPrototypeOf(compiledContracts[contract.className], contractObj);
             }
 
@@ -76,80 +153,50 @@ class MochaTestRunner {
       });
     };
 
-    async.waterfall([
-      (next) => { // request provider
-        events.request("blockchain:client:provider", "ethereum", next);
-      },
-      (bcProvider, next) => { // set provider
-        web3 = new Web3(bcProvider);
-        next();
-      },
-      (next) => { // get accounts
-        web3.eth.getAccounts((err, accts) => {
-          if (err) {
-            return next(err);
-          }
+    await this.startBlockchainNode();
+    accounts = await this.web3.eth.getAccounts();
+    await events.request2("contracts:reset");
+    const contractFiles = await events.request2("config:contractsFiles");
+    compiledContracts = await events.request2("compiler:contracts:compile", contractFiles);
 
-          accounts = accts;
-          next();
-        });
-      },
-      (next) => { // reset contracts as we might have state leakage from other plugins
-        events.request("contracts:reset", next);
-      },
-      (next) => { // get contract files
-        events.request("config:contractsFiles", next);
-      },
-      (cf, next) => { // compile contracts
-        events.request("compiler:contracts:compile", cf, next);
-      },
-      (cc, next) => { // override require
-        compiledContracts = cc;
-
-        Module.prototype.require = function(req) {
-          const prefix = "Embark/contracts/";
-          if (!req.startsWith(prefix)) {
-            return originalRequire.apply(this, arguments);
-          }
-
-          const contractClass = req.replace(prefix, "");
-          const instance = compiledContracts[contractClass];
-
-          if (!instance) {
-            throw new Error(`Cannot find module '${req}'`);
-          }
-
-          return instance;
-        };
-        next();
-      },
-      (next) => { // initialize Mocha
-        const mocha = new Mocha();
-
-        mocha.reporter(Reporter, { reporter: options.reporter });
-        const describeWithAccounts = (scenario, cb) => {
-          Mocha.describe(scenario, cb.bind(mocha, accounts));
-        };
-
-        mocha.suite.on('pre-require', () => {
-          global.describe = describeWithAccounts;
-          global.contract = describeWithAccounts;
-          global.assert = assert;
-          global.config = config;
-        });
-
-        mocha.suite.timeout(TEST_TIMEOUT);
-        for(const file of this.files) {
-          mocha.addFile(file);
-        }
-
-        mocha.run((failures) => {
-          next(null, failures);
-        });
+    Module.prototype.require = function(req) {
+      const prefix = "Embark/contracts/";
+      if (!req.startsWith(prefix)) {
+        return originalRequire.apply(this, arguments);
       }
-    ], (err, failures) => {
+
+      const contractClass = req.replace(prefix, "");
+      const instance = compiledContracts[contractClass];
+
+      if (!instance) {
+        throw new Error(`Cannot find module '${req}'`);
+      }
+
+      return instance;
+    };
+
+    const mocha = new Mocha();
+
+    mocha.reporter(Reporter, { reporter: options.reporter });
+    const describeWithAccounts = (scenario, cb) => {
+      Mocha.describe(scenario, cb.bind(mocha, accounts));
+    };
+
+    mocha.suite.on('pre-require', () => {
+      global.describe = describeWithAccounts;
+      global.contract = describeWithAccounts;
+      global.assert = assert;
+      global.config = config;
+    });
+
+    mocha.suite.timeout(TEST_TIMEOUT);
+    for(const file of this.files) {
+      mocha.addFile(file);
+    }
+
+    mocha.run((failures) => {
       Module.prototype.require = originalRequire;
-      cb(err, failures);
+      cb(null, failures);
     });
   }
 }

--- a/packages/embark-mocha-tests/src/lib/index.js
+++ b/packages/embark-mocha-tests/src/lib/index.js
@@ -66,8 +66,7 @@ class MochaTestRunner {
       resetServices = true;
     }
 
-    Object.assign(this.simOptions, {host, port, type, protocol});
-    this.simOptions.accounts = accounts;
+    Object.assign(this.simOptions, {host, port, type, protocol, accounts, client: options.blockchain && options.blockchain.client});
 
     if (!resetServices) {
       return;
@@ -80,6 +79,7 @@ class MochaTestRunner {
     let node = this.options.node;
     if (!this.simOptions.host && (node && node === 'vm')) {
       this.simOptions.type = 'vm';
+      this.simOptions.client = 'vm';
     } else if (this.simOptions.host || (node && node !== 'vm')) {
       let options = this.simOptions;
       if (node && node !== 'vm') {
@@ -99,6 +99,9 @@ class MochaTestRunner {
       accounts: this.simOptions.accounts,
       coverage: this.options.coverage
     });
+    if (this.simOptions.client) {
+      this.configObj.blockchainConfig.client = this.simOptions.client;
+    }
     this.logger.trace('Setting blockchain configs:', this.configObj.blockchainConfig);
     await this.events.request2('config:blockchainConfig:set', this.configObj.blockchainConfig);
 
@@ -108,7 +111,7 @@ class MochaTestRunner {
       // Nothing to do here, the node probably wasn't even started
     }
 
-    await this.events.request2("blockchain:node:start", this.configObj.blockchainConfig, node);
+    await this.events.request2("blockchain:node:start", this.configObj.blockchainConfig);
     const provider = await this.events.request2("blockchain:client:provider", "ethereum");
     if (!this.web3) {
       this.web3 = new Web3();

--- a/packages/embark-proxy/src/index.ts
+++ b/packages/embark-proxy/src/index.ts
@@ -26,8 +26,8 @@ export default class ProxyManager {
 
     this.host = "localhost";
 
-    this.events.on("blockchain:started", async (clientName: string, node?: string) => {
-      await this.setupProxy(clientName, node);
+    this.events.on("blockchain:started", async (clientName: string) => {
+      await this.setupProxy(clientName);
       this.ready = true;
       this.events.emit("proxy:ready");
     });
@@ -65,7 +65,7 @@ export default class ProxyManager {
     });
   }
 
-  private async setupProxy(clientName: string, node?: string) {
+  private async setupProxy(clientName: string) {
     if (!this.embark.config.blockchainConfig.proxy) {
       return;
     }
@@ -81,7 +81,7 @@ export default class ProxyManager {
     this.proxy = await new Proxy({events: this.events, plugins: this.plugins, logger: this.logger});
 
     await this.proxy.serve(
-      node || this.embark.config.blockchainConfig.endpoint,
+      clientName === constants.blockchain.vm ? constants.blockchain.vm : this.embark.config.blockchainConfig.endpoint,
       this.host,
       this.isWs ? this.wsPort : this.rpcPort,
       this.isWs,

--- a/packages/embark-proxy/src/proxy.js
+++ b/packages/embark-proxy/src/proxy.js
@@ -17,6 +17,7 @@ export class Proxy {
     this.timeouts = {};
     this.plugins = options.plugins;
     this.logger = options.logger;
+    this.vms = options.vms;
     this.app = null;
     this.server = null;
   }
@@ -46,8 +47,7 @@ export class Proxy {
     }
 
     if (endpoint === constants.blockchain.vm) {
-      const ganache = require('ganache-cli');
-      endpoint = ganache.provider(); // Change the endpoint to the Ganache provider
+      endpoint = this.vms[this.vms.length - 1]();
     }
     const requestManager = new Web3RequestManager.Manager(endpoint);
 

--- a/packages/embark-test-runner/src/index.js
+++ b/packages/embark-test-runner/src/index.js
@@ -1,8 +1,11 @@
 import { __ } from 'embark-i18n';
+import {buildUrl, deconstructUrl, recursiveMerge} from "embark-utils";
 const async = require('async');
 const path = require('path');
 import fs from 'fs';
+import cloneDeep from "lodash.clonedeep";
 import { COVERAGE_GAS_LIMIT, GAS_LIMIT } from './constants';
+const constants = require('embark-core/constants');
 
 const Reporter = require('./reporter');
 
@@ -17,6 +20,10 @@ class TestRunner {
     this.gasLimit = options.coverage ? COVERAGE_GAS_LIMIT : GAS_LIMIT;
     this.files = [];
 
+    this.configObj = embark.config;
+    this.originalConfigObj = cloneDeep(embark.config);
+    this.simOptions = {};
+
     this.events.setCommandHandler('tests:run', (options, callback) => {
       this.run(options, callback);
     });
@@ -27,6 +34,9 @@ class TestRunner {
       // like Jest tests and such.
       this.runners.unshift({name, matchFn, addFn, runFn});
     });
+
+    this.events.setCommandHandler('tests:deployment:check', this.checkDeploymentOptions.bind(this));
+    this.events.setCommandHandler('tests:blockchain:start', this.startBlockchainNode.bind(this));
   }
 
   run(options, cb) {
@@ -91,6 +101,82 @@ class TestRunner {
       }
       cb(null, [filePath]);
     });
+  }
+
+  async checkDeploymentOptions(config, options, cb = () => {}) {
+    let resetServices = false;
+    const blockchainConfig = config.blockchain || {};
+    let {host, port, type, protocol} = blockchainConfig.endpoint ? deconstructUrl(blockchainConfig.endpoint) : {};
+    const accounts = blockchainConfig.accounts;
+
+    if (host && port && !['rpc', 'ws'].includes(type)) {
+      return cb(__("contracts config error: unknown deployment type %s", type));
+    }
+
+    if (options.coverage && type === 'rpc') {
+      this.logger.warn(__('Coverage does not work with an RPC node'));
+      this.logger.warn(__('You can change to a WS node (`"type": "ws"`) or use the simulator (no node or `"type": "vm"`)'));
+    }
+
+    if (!type) {
+      type = constants.blockchain.vm;
+    }
+
+    if (accounts || port !== this.simOptions.port || type !== this.simOptions.type || host !== this.simOptions.host) {
+      resetServices = true;
+    }
+
+    Object.assign(this.simOptions, {host, port, type, protocol, accounts, client: config.blockchain && config.blockchain.client});
+
+    if (!resetServices) {
+      return cb();
+    }
+
+    const provider = await this.startBlockchainNode(options);
+    cb(null, provider);
+    return provider;
+  }
+
+  async startBlockchainNode(options, cb = () => {}) {
+    let node = options.node;
+    if (!this.simOptions.host && (node && node === constants.blockchain.vm)) {
+      this.simOptions.type = constants.blockchain.vm;
+      this.simOptions.client = constants.blockchain.vm;
+    } else if (this.simOptions.host || (node && node !== constants.blockchain.vm)) {
+      let options = this.simOptions;
+      if (node && node !== constants.blockchain.vm) {
+        options = deconstructUrl(node);
+      }
+
+      if (!options.protocol) {
+        options.protocol = (options.type === "rpc") ? 'http' : 'ws';
+      }
+      Object.assign(this.simOptions, options);
+      node = null;
+    }
+
+    this.configObj.blockchainConfig = recursiveMerge({}, this.originalConfigObj.blockchainConfig, {
+      endpoint: this.simOptions.host ? buildUrl(this.simOptions.protocol, this.simOptions.host, this.simOptions.port, this.simOptions.type) : null,
+      type: this.simOptions.type,
+      accounts: this.simOptions.accounts,
+      coverage: options.coverage
+    });
+    if (this.simOptions.client) {
+      this.configObj.blockchainConfig.client = this.simOptions.client;
+    }
+    this.logger.trace('Setting blockchain configs:', this.configObj.blockchainConfig);
+    await this.events.request2('config:blockchainConfig:set', this.configObj.blockchainConfig);
+
+    try {
+      await this.events.request2("blockchain:node:stop");
+    } catch (e) {
+      // Nothing to do here, the node probably wasn't even started
+    }
+
+    await this.events.request2("blockchain:node:start", this.configObj.blockchainConfig);
+    const provider = await this.events.request2("blockchain:client:provider", "ethereum");
+    cb(null, provider);
+    return provider;
   }
 }
 

--- a/packages/embark/src/cmd/cmd_controller.js
+++ b/packages/embark/src/cmd/cmd_controller.js
@@ -886,9 +886,7 @@ class EmbarkController {
 
     const Engine = require('../lib/core/engine.js');
     const engine = new Engine({
-      // TODO: this should not be necessary
-      env: "development",
-      //env: options.env,
+      env: options.env,
       client: options.client,
       locale: options.locale,
       version: this.version,
@@ -920,17 +918,6 @@ class EmbarkController {
         engine.registerModuleGroup("contracts");
         engine.registerModuleGroup("pipeline");
         engine.registerModuleGroup("tests");
-
-        let plugin = engine.plugins.createPlugin('cmdcontrollerplugin', {});
-        plugin.registerActionForEvent("embark:engine:started", async (_params, cb) => {
-          try {
-            await engine.events.request2("blockchain:node:start", engine.config.blockchainConfig, options.node);
-          } catch (e) {
-            return cb(e);
-          }
-
-          cb();
-        });
 
         engine.startEngine(next);
       },

--- a/packages/embark/src/lib/core/configDefaults.js
+++ b/packages/embark/src/lib/core/configDefaults.js
@@ -22,7 +22,7 @@ export function getBlockchainDefaults(env) {
     wsHost: "localhost",
     wsPort: 8546,
     networkType: "custom",
-    miningMode: 'dev',
+    isDev: true,
     nodiscover: true,
     maxpeers: 0,
     targetGasLimit: 8000000,

--- a/packages/embark/src/lib/core/engine.js
+++ b/packages/embark/src/lib/core/engine.js
@@ -210,6 +210,7 @@ class Engine {
   //   });
 
     this.registerModule('ethereum-blockchain-client');
+    this.registerModule('ganache');
     // this.registerModule('web3', { plugins: this.plugins });
     this.registerModulePackage('embark-web3');
     this.registerModulePackage('embark-accounts-manager');

--- a/packages/embark/src/lib/modules/blockchain/index.js
+++ b/packages/embark/src/lib/modules/blockchain/index.js
@@ -21,16 +21,11 @@ class Blockchain {
       this.blockchainNodes[clientName] = startCb;
     });
 
-    this.events.setCommandHandler("blockchain:node:start", (blockchainConfig, node, cb) => {
-      if (typeof node === 'function') {
-        cb = node;
-        node = null;
-      }
+    this.events.setCommandHandler("blockchain:node:start", (blockchainConfig, cb) => {
       const clientName = blockchainConfig.client;
-      // const clientName = this.blockchainConfig.client;
-      if (node && node === constants.blockchain.vm) {
-        this.startedClient = constants.blockchain.vm;
-        this.events.emit("blockchain:started", clientName, node);
+      if (clientName === constants.blockchain.vm) {
+        this.startedClient = clientName;
+        this.events.emit("blockchain:started", clientName);
         return cb();
       }
       const clientFunctions = this.blockchainNodes[clientName];
@@ -39,7 +34,7 @@ class Blockchain {
       }
 
       let onStart = () => {
-        this.events.emit("blockchain:started", clientName, node);
+        this.events.emit("blockchain:started", clientName);
         cb();
       };
 

--- a/packages/embark/src/lib/modules/ganache/index.js
+++ b/packages/embark/src/lib/modules/ganache/index.js
@@ -1,0 +1,10 @@
+class Ganache {
+  constructor(embark) {
+    embark.events.request('proxy:vm:register', () => {
+      const ganache = require('ganache-cli');
+      return ganache.provider();
+    });
+  }
+}
+
+module.exports = Ganache;

--- a/packages/embark/src/lib/modules/geth/index.js
+++ b/packages/embark/src/lib/modules/geth/index.js
@@ -20,23 +20,28 @@ class Geth {
       return;
     }
 
-    this.events.request("blockchain:node:register", constants.blockchain.clients.geth, (readyCb) => {
-      this.events.request('processes:register', 'blockchain', {
-        launchFn: (cb) => {
-          // this.startBlockchainNode(readyCb);
-          this.startBlockchainNode(cb);
-        },
-        stopFn: (cb) => {
-          this.stopBlockchainNode(cb);
-        }
-      });
-      this.events.request("processes:launch", "blockchain", (err) => {
-        if (err) {
-          this.logger.error(`Error launching blockchain process: ${err.message || err}`);
-        }
-        readyCb();
-      });
-      this.registerServiceCheck();
+    this.events.request("blockchain:node:register", constants.blockchain.clients.geth, {
+      launchFn: (readyCb) => {
+        this.events.request('processes:register', 'blockchain', {
+          launchFn: (cb) => {
+            this.startBlockchainNode(cb);
+          },
+          stopFn: (cb) => {
+            this.stopBlockchainNode(cb);
+          }
+        });
+        this.events.request("processes:launch", "blockchain", (err) => {
+          if (err) {
+            this.logger.error(`Error launching blockchain process: ${err.message || err}`);
+          }
+          readyCb();
+        });
+        this.registerServiceCheck();
+      },
+      stopFn: async (cb) => {
+        await this.events.request("processes:stop", "blockchain");
+        cb();
+      }
     });
   }
 

--- a/packages/embark/src/lib/modules/geth/index.js
+++ b/packages/embark/src/lib/modules/geth/index.js
@@ -5,7 +5,6 @@ import {ws, rpc} from './check.js';
 const constants = require('embark-core/constants');
 
 class Geth {
-
   constructor(embark, options) {
     this.embark = embark;
     this.embarkConfig = embark.config.embarkConfig;


### PR DESCRIPTION
Makes it possible to change the change blockchain node from test to test, but defaults to the Ganache VM.

Based off https://github.com/embark-framework/embark/pull/1846