### PR TITLE
fix(@embark/embark-deploy-tracker): Fix reading of empty file

### DIFF
--- a/packages/embark-deploy-tracker/src/index.js
+++ b/packages/embark-deploy-tracker/src/index.js
@@ -13,7 +13,6 @@ class DeployTracker {
     const trackingFunctions = new TrackingFunctions({config, fs, logger, events, env, trackContracts});
     const deploymentChecks = new DeploymentChecks({trackingFunctions, logger, events, plugins});
 
-    this.embark.events.on("blockchain:started", trackingFunctions.ensureChainTrackerFile.bind(trackingFunctions));
     this.embark.registerActionForEvent("deployment:contract:deployed", trackingFunctions.trackAndSaveContract.bind(trackingFunctions));
     this.embark.registerActionForEvent("deployment:contract:shouldDeploy", deploymentChecks.checkContractConfig.bind(deploymentChecks));
     this.embark.registerActionForEvent("deployment:contract:shouldDeploy", deploymentChecks.checkIfAlreadyDeployed.bind(deploymentChecks));

--- a/packages/embark-deploy-tracker/src/test/deploymentChecksSpec.js
+++ b/packages/embark-deploy-tracker/src/test/deploymentChecksSpec.js
@@ -18,6 +18,7 @@ describe('embark.deploymentChecks', function () {
   let contractInChainsFake;
   let chainsFake;
   let trackedContract;
+  let exists;
   let readJSON;
   let writeJSON;
   let _web3;
@@ -50,6 +51,7 @@ describe('embark.deploymentChecks', function () {
         }
       }
     };
+    exists = sinon.stub(fs, 'exists').returns(true);
     readJSON = sinon.stub(fs, 'readJSON').returns(chainsFake);
     writeJSON = sinon.stub(fs, 'writeJSON');
     trackingFunctions = new TrackingFunctions({
@@ -79,6 +81,7 @@ describe('embark.deploymentChecks', function () {
     deploymentChecks._web3 = _web3;
   });
   afterEach(() => {
+    exists.restore();
     readJSON.restore();
     writeJSON.restore();
   });
@@ -191,7 +194,7 @@ describe('embark.deploymentChecks', function () {
       });
     });
     it("should error (and not deploy) if tracked contract address is invalid", async function () {
-      trackingFunctions._web3.eth.getCode = () => { throw new Error(); };
+      trackingFunctions._web3.eth.getCode = () => {throw new Error();};
       return deploymentChecks.checkIfAlreadyDeployed(params, (err, _params) => {
         expect(err).to.not.be(null);
       });


### PR DESCRIPTION
There was an error that would display on the second+ run of embark, that was causing by trying to read JSON of an empty file.

The solution was a combination of ensuring the file existed with defaults when enabled, and also ensuring we await the saving of the file.

Included is a bit of a refactor of how the tracking functions handled the “current chain”. Hopefully, this should make things more clear.

Tests have been updated accordingly.