### PR TITLE
feat(@embark/specialconfigs): introduce dynamic addresses

### DIFF
--- a/packages/embark-contracts-manager/src/index.js
+++ b/packages/embark-contracts-manager/src/index.js
@@ -323,7 +323,10 @@ class ContractsManager {
           contract.type = 'file';
           contract.className = className;
 
-          if (contract.address) {
+          if (contract.address && typeof contract.address === 'function') {
+            contract.addressHandler = contract.address;
+            delete contract.addres;
+          } else if (contract.address && typeof contract.address === 'string') {
             contract.deployedAddress = contract.address;
           }
 

--- a/packages/embark-deployment/src/index.js
+++ b/packages/embark-deployment/src/index.js
@@ -66,6 +66,19 @@ class Deployment {
     Object.values(contracts).forEach((contract) => {
       function deploy(result, callback) {
         if (typeof result === 'function') callback = result;
+        if (contract.addressHandler) {
+          return self.events.request('deployment:contract:address', {contract}, (err, address) => {
+            if (err) {
+              errors.push(err);
+            } else {
+              contract.address = address;
+              contract.deployedAddress = address;
+              self.logger.info(__('{{contractName}} already deployed at {{address}}', {contractName: contract.className.bold.cyan, address: contract.address.bold.cyan}));
+              self.events.emit("deployment:contract:deployed", contract);
+            }
+            callback();
+          });
+        }
         self.deployContract(contract, (err) => {
           if (err) {
             errors.push(err);

--- a/packages/embark-specialconfigs/src/index.js
+++ b/packages/embark-specialconfigs/src/index.js
@@ -15,11 +15,16 @@ class SpecialConfigs {
     this.listConfigs = new ListConfigs(embark);
     this.functionConfigs = new FunctionConfigs(embark);
 
+    this.events.setCommandHandler('deployment:contract:address', this.executeAddressHandlerForContract.bind(this));
     this.embark.registerActionForEvent('deployment:deployContracts:beforeAll', this.beforeAllDeployAction.bind(this));
     this.embark.registerActionForEvent('deployment:deployContracts:afterAll', this.afterAllDeployAction.bind(this));
     this.embark.registerActionForEvent("deployment:contract:deployed", this.doOnDeployAction.bind(this));
     this.embark.registerActionForEvent("deployment:contract:shouldDeploy", this.deployIfAction.bind(this));
     this.embark.registerActionForEvent('deployment:contract:beforeDeploy', this.beforeDeployAction.bind(this));
+  }
+
+  async executeAddressHandlerForContract(params, cb) {
+    return this.functionConfigs.executeContractAddressHandler(params.contract, cb);
   }
 
   async beforeAllDeployAction(_params, cb) {

--- a/packages/embark-utils/src/index.js
+++ b/packages/embark-utils/src/index.js
@@ -183,7 +183,7 @@ function prepareContractsConfig(config) {
       config.contracts[contractName].gasPrice = getWeiBalanceFromString(gasPrice);
     }
 
-    if (address) {
+    if (address && typeof address === 'string') {
       config.contracts[contractName].address = extendZeroAddressShorthand(address);
     }
 

--- a/packages/embark/src/cmd/cmd_controller.js
+++ b/packages/embark/src/cmd/cmd_controller.js
@@ -160,6 +160,9 @@ class EmbarkController {
 
         engine.registerModuleGroup("coreComponents");
         engine.registerModuleGroup("stackComponents");
+        engine.registerModuleGroup("namesystem");
+
+        engine.registerModule('embark-embarkjs', {plugins: engine.plugins});
 
         // TODO: replace with individual plugins
         engine.registerModuleGroup("namesystem");

--- a/packages/embark/src/cmd/cmd_controller.js
+++ b/packages/embark/src/cmd/cmd_controller.js
@@ -160,9 +160,6 @@ class EmbarkController {
 
         engine.registerModuleGroup("coreComponents");
         engine.registerModuleGroup("stackComponents");
-        engine.registerModuleGroup("namesystem");
-
-        engine.registerModule('embark-embarkjs', {plugins: engine.plugins});
 
         // TODO: replace with individual plugins
         engine.registerModuleGroup("namesystem");

--- a/site/source/docs/contracts_configuration.md
+++ b/site/source/docs/contracts_configuration.md
@@ -131,7 +131,7 @@ production: {
 
 In order to give users full control over which Smart Contracts should be deployed, Embark comes with a configuration feature called "deployment strategies". Deployment strategies tell Embark whether it should deploy all of the user's Smart Contracts (and its (3rd-party) dependencies, or just deploy individual Smart Contracts.
 
-There are two possible strategy options: 
+There are two possible strategy options:
 
 - **implicit** - This is the default. Using the `implicit` strategy, Embark tries to deploy all Smart Contracts configured in the `deploy` configuration, including its (3rd-party) dependencies.
 - **explicit** - Setting this option to `explicit` tells Embark to deploy the Smart Contracts specified in the `deploy` configuration without their dependencies. This can be combined with [disabling deployment](#Disabling-deployment) of individual Smart Contracts for fine control.
@@ -201,6 +201,29 @@ module.exports = {
   }
 }
 ```
+
+## Dynamic Addresses
+
+There are scenarios in which we want to configure a Smart Contract that is already deployed by a third-party, but its address can only be computed at run-time. For such cases, Embark supports specifying a function as `address`, which returns the address we're interested in. Usually, other Smart Contract instances are needed to perform that computation, so the [`deps` configuration](#Deployment-hooks) comes in handy as well:
+
+```
+deploy: {
+  SimpleStorage: {
+    fromIndex: 0,
+    args: [100],
+  },
+  OtherContract: {
+    deps: ['SimpleStorage'],
+    address: async (deps) => {
+      // use `deps.contracts.SimpleStorage` to determine and return address
+    },
+    abiDefinition: ABI
+  },
+}
+```
+
+In the example above, `OtherContract` will be deployed after `SimpleStorage` because it uses the `deps` property to define Smart Contracts that it depends on. All dependencies are exposed on the `address` function parameter similar to [deployment hooks](#Deployment-hooks). Also, notice that the `abiDefinition` is only needed if the Smart Contracts bytecode isn't already on disk.
+
 
 ## Configuring source files
 
@@ -541,7 +564,7 @@ deploy: {
 }
 ```
 
-Which will result in 
+Which will result in
 
 ```
 SimpleStorage > onDeploy > Hello from onDeploy!


### PR DESCRIPTION
This commit introduces a new Smart Contract configuration addressHandler
that lets users define a function to "lazily" compute the address of the
Smart Contract in question.

This is useful when a third-party takes care of deploying a dependency
Smart Contract, but the address of that Smart Contract only being available
at run-time.

Example:
```
deploy: {
  SimpleStorage: {
    fromIndex: 0,
    args: [100],
  },
  OtherContract: {
    deps: ['SimpleStorage'],
    address: async (deps) => {
      // use `deps.contracts.SimpleStorage` to determine address
    },
    abiDefinition: ABI
  },
}
```

In the example above, OtherContract will be deployed after SimpleStorage
because it uses the deps property to define Smart Contracts that it depends
on. All dependencies are exposed on the addressHandler function parameter
similar to deployment hooks.

Closes #1690