### PR TITLE
Fix embark blockchain command + fix wss in Embark

### DIFF
--- a/packages/embark-proxy/src/index.ts
+++ b/packages/embark-proxy/src/index.ts
@@ -77,7 +77,6 @@ export default class ProxyManager {
         this.host,
         this.isWs ? this.wsPort : this.rpcPort,
         this.isWs,
-        null,
       );
     return;
   }

--- a/packages/embark-utils/src/index.js
+++ b/packages/embark-utils/src/index.js
@@ -154,7 +154,7 @@ function toposort(graph) {
 }
 
 function deconstructUrl(endpoint) {
-  const matches = endpoint.match(/(wss?|https?):\/\/([a-zA-Z0-9_.-]*):?([0-9]*)?/);
+  const matches = endpoint.match(/(wss?|https?):\/\/([a-zA-Z0-9_.\/-]*):?([0-9]*)?/);
   return {
     protocol: matches[1],
     host: matches[2],

--- a/packages/embark/src/lib/core/engine.js
+++ b/packages/embark/src/lib/core/engine.js
@@ -77,18 +77,19 @@ class Engine {
     let options = _options || {};
 
     let groups = {
-      "blockchain": this.blockchainComponents,
-      "coreComponents": this.coreComponents,
-      "stackComponents": this.stackComponents,
-      "compiler": this.compilerComponents,
-      "contracts": this.contractsComponents,
-      "pipeline": this.pipelineService,
-      "webserver": this.webserverService,
-      "storage": this.storageComponent,
-      "communication": this.communicationComponents,
-      "namesystem": this.namesystemComponents,
-      "filewatcher": this.filewatcherService,
-      "tests": this.testComponents,
+      blockchain: this.blockchainComponents,
+      coreComponents: this.coreComponents,
+      stackComponents: this.stackComponents,
+      blockchainStackComponents: this.blockchainStackComponents,
+      compiler: this.compilerComponents,
+      contracts: this.contractsComponents,
+      pipeline: this.pipelineService,
+      webserver: this.webserverService,
+      storage: this.storageComponent,
+      communication: this.communicationComponents,
+      namesystem: this.namesystemComponents,
+      filewatcher: this.filewatcherService,
+      tests: this.testComponents,
       cockpit: this.cockpitModules
     };
 
@@ -152,6 +153,12 @@ class Engine {
 
     // TODO: we shouldn't need useDashboard
     this.registerModulePackage('embark-library-manager', {useDashboard: this.useDashboard});
+  }
+
+  blockchainStackComponents() {
+    this.registerModule('blockchain', { plugins: this.plugins });
+    this.registerModule('blockchain-client');
+    this.registerModulePackage('embark-process-logs-api-manager');
   }
 
   stackComponents(options) {

--- a/packages/embark/src/lib/modules/blockchain/index.js
+++ b/packages/embark/src/lib/modules/blockchain/index.js
@@ -1,5 +1,6 @@
 import async from 'async';
 const {__} = require('embark-i18n');
+const Web3RequestManager = require('web3-core-requestmanager');
 
 import BlockchainAPI from "./api";
 class Blockchain {
@@ -20,18 +21,31 @@ class Blockchain {
       this.blockchainNodes[clientName] = startCb;
     });
 
-    this.events.setCommandHandler("blockchain:node:start", (blockchainConfig, cb) => {
-      const clientName = blockchainConfig.client;
-      // const clientName = this.blockchainConfig.client;
-      const client = this.blockchainNodes[clientName];
-      if (!client) return cb("client " + clientName + " not found");
+    this.events.setCommandHandler("blockchain:node:start", async (blockchainConfig, cb) => {
+      const requestManager = new Web3RequestManager.Manager(blockchainConfig.endpoint);
 
-      let onStart = () => {
-        this.events.emit("blockchain:started", clientName);
-        cb();
-      };
+      const ogConsoleError = console.error;
+      // TODO remove this once we update to web3 2.0
+      // TODO in web3 1.0, it console.errors "connection not open on send()" even if we catch the error
+      console.error = () => {};
+      requestManager.send({method: 'eth_accounts'}, (err, _accounts) => {
+        console.error = ogConsoleError;
+        if (!err) {
+          // Node is already started
+          this.events.emit("blockchain:started");
+          return cb(null, true);
+        }
+        const clientName = blockchainConfig.client;
+        const client = this.blockchainNodes[clientName];
+        if (!client) return cb("client " + clientName + " not found");
 
-      client.apply(client, [onStart]);
+        let onStart = () => {
+          this.events.emit("blockchain:started", clientName);
+          cb();
+        };
+
+        client.apply(client, [onStart]);
+      });
     });
     this.blockchainApi.registerAPIs("ethereum");
     this.blockchainApi.registerRequests("ethereum");

--- a/packages/embark/src/lib/modules/blockchain/index.js
+++ b/packages/embark/src/lib/modules/blockchain/index.js
@@ -27,7 +27,12 @@ class Blockchain {
       const ogConsoleError = console.error;
       // TODO remove this once we update to web3 2.0
       // TODO in web3 1.0, it console.errors "connection not open on send()" even if we catch the error
-      console.error = () => {};
+      console.error = (...args) => {
+        if (args[0].indexOf('connection not open on send()') > -1) {
+          return;
+        }
+        ogConsoleError(...args);
+      };
       requestManager.send({method: 'eth_accounts'}, (err, _accounts) => {
         console.error = ogConsoleError;
         if (!err) {

--- a/packages/embark/src/lib/modules/geth/index.js
+++ b/packages/embark/src/lib/modules/geth/index.js
@@ -1,6 +1,7 @@
 import { __ } from 'embark-i18n';
 const {normalizeInput} = require('embark-utils');
 import {BlockchainProcessLauncher} from './blockchainProcessLauncher';
+import {BlockchainClient} from './blockchain';
 import {ws, rpc} from './check.js';
 const constants = require('embark-core/constants');
 
@@ -69,6 +70,18 @@ class Geth {
   }
 
   startBlockchainNode(callback) {
+    if (this.blockchainConfig.isStandalone) {
+      return BlockchainClient(this.blockchainConfig, {
+        clientName: 'geth',
+        env: this.embark.env,
+        certOptions: this.embark.config.webServerConfig.certOptions,
+        logger: this.logger,
+        events: this.events,
+        isStandalone: true,
+        fs: this.embark.fs
+      }).run();
+    }
+
     this.blockchainProcess = new BlockchainProcessLauncher({
       events: this.events,
       logger: this.logger,

--- a/packages/embark/src/lib/modules/parity/index.js
+++ b/packages/embark/src/lib/modules/parity/index.js
@@ -1,4 +1,5 @@
 import { __ } from 'embark-i18n';
+import {BlockchainClient} from "../geth/blockchain";
 const {normalizeInput} = require('embark-utils');
 import {BlockchainProcessLauncher} from './blockchainProcessLauncher';
 import {ws, rpc} from './check.js';
@@ -70,6 +71,18 @@ class Parity {
   }
 
   startBlockchainNode(callback) {
+    if (this.blockchainConfig.isStandalone) {
+      return BlockchainClient(this.blockchainConfig, {
+        clientName: 'parity',
+        env: this.embark.env,
+        certOptions: this.embark.config.webServerConfig.certOptions,
+        logger: this.logger,
+        events: this.events,
+        isStandalone: true,
+        fs: this.embark.fs
+      }).run();
+    }
+
     this.blockchainProcess = new BlockchainProcessLauncher({
       events: this.events,
       logger: this.logger,


### PR DESCRIPTION
Fixes the `embark blockchain` command and also makes it so the running command check if the blockchain is already up before starting a node on itself.

The ping endpoint used there and for the proxy has also been changed to using web3 and checking with a basic rpc call (eth_accounts).
This was changed because our implementation of pingEndpoint was really limited and didn't work correctly for `ws` and especially not `wss`.