### PR TITLE
feat(@embark/compiler): support :before and :after hooks on event compiler:contracts:compile

### DIFF
--- a/package.json
+++ b/package.json
@@ -75,19 +75,19 @@
     "packages": [
       "dapps/templates/*",
       "dapps/tests/*",
-      "packages/core/*",
-      "packages/plugins/*",
-      "packages/stack/*",
-      "packages/embarkjs/*",
+      "packages/*",
       "packages/cockpit/*",
-      "packages/*"
+      "packages/core/*",
+      "packages/embarkjs/*",
+      "packages/plugins/*",
+      "packages/stack/*"
     ],
     "nohoist": [
-      "embark/embark-test-contract-0",
-      "embark/embark-test-contract-1",
       "embark-dapp-template-demo/bootstrap",
       "embark-dapp-test-app/embark-dapp-test-service",
-      "embark-dapp-test-app/zeppelin-solidity"
+      "embark-dapp-test-app/zeppelin-solidity",
+      "embark/embark-test-contract-0",
+      "embark/embark-test-contract-1"
     ]
   }
 }

--- a/packages/core/typings/src/plugins.d.ts
+++ b/packages/core/typings/src/plugins.d.ts
@@ -1,3 +1,5 @@
+import {Callback} from "./callbacks";
+
 export interface Plugin {
   dappGenerators: any;
 }
@@ -7,6 +9,7 @@ export interface Plugins {
   loadInternalPlugin(name: string, options: any): void;
   getPluginsProperty(pluginType: string, property: string, sub_property?: string): any[];
   plugins: Plugin[];
+  runActionsForEvent(event: string, args: any, cb: Callback<any>): void;
 }
 
 export interface Plugin {

--- a/packages/stack/compiler/README.md
+++ b/packages/stack/compiler/README.md
@@ -62,5 +62,3 @@ arguments:
   * `callback(error, compiledObject)`
 
 ## Dependencies
-
-* async.eachObject

--- a/packages/stack/compiler/package.json
+++ b/packages/stack/compiler/package.json
@@ -43,7 +43,8 @@
   "dependencies": {
     "@babel/runtime-corejs2": "7.3.1",
     "embark-async-wrapper": "^4.1.1",
-    "embark-i18n": "^4.1.1"
+    "embark-i18n": "^4.1.1",
+    "embark-utils": "^4.1.1"
   },
   "devDependencies": {
     "@babel/cli": "7.2.3",

--- a/packages/stack/compiler/package.json
+++ b/packages/stack/compiler/package.json
@@ -41,8 +41,7 @@
     "watch:typecheck": "npm run typecheck -- --preserveWatchOutput --watch"
   },
   "dependencies": {
-    "@babel/runtime-corejs2": "7.3.1",
-    "embark-async-wrapper": "^4.1.1",
+    "@babel/runtime-corejs2": "7.6.0",
     "embark-i18n": "^4.1.1",
     "embark-utils": "^4.1.1"
   },

--- a/packages/stack/compiler/src/index.ts
+++ b/packages/stack/compiler/src/index.ts
@@ -1,7 +1,9 @@
 import {Callback, CompilerPluginObject, Embark, Plugins} /* supplied by @types/embark in packages/embark-typings */ from "embark";
 import { __ } from "embark-i18n";
+import * as fs from "fs-extra";
 
 const async = require("embark-async-wrapper");
+const { File, Types } = require("embark-utils");
 
 class Compiler {
   private logger: any;
@@ -14,75 +16,166 @@ class Compiler {
     this.isCoverage = options.isCoverage;
 
     // embark.events.setCommandHandler("compiler:contracts", this.compile_contracts.bind(this));
-    embark.events.setCommandHandler("compiler:contracts:compile", this.compile_contracts.bind(this));
+    embark.events.setCommandHandler(
+      "compiler:contracts:compile",
+      this.compile_contracts.bind(this),
+    );
   }
 
-  private compile_contracts(contractFiles: any[], cb: any) {
+  private compile_contracts(contractFiles: any[], cb: Callback<any>) {
     if (contractFiles.length === 0) {
       return cb(null, {});
     }
 
-    const compiledObject: {[index: string]: any} = {};
+    async.waterfall(
+      [
+        (next: Callback<any[]>) => {
+          this.plugins.runActionsForEvent(
+            "compiler:contracts:compile:before",
+            contractFiles,
+            (err?: Error | null, files: any[] = []) => {
+              if (err) {
+                return next(err);
+              }
+              next(
+                null,
+                files.map((file: any) =>
+                  file instanceof File
+                    ? file
+                    : new File({
+                        originalPath: file.path,
+                        path: file.path,
+                        resolver: (callback: Callback<any>) => {
+                          fs.readFile(
+                            file.path,
+                            { encoding: "utf-8" },
+                            callback,
+                          );
+                        },
+                        type: Types.dappFile,
+                      }),
+                ),
+              );
+            },
+          );
+        },
+        (files: any[], next: Callback<any>) => {
+          const compiledObject: { [index: string]: any } = {};
 
-    const compilerOptions = {
-      isCoverage: this.isCoverage,
-    };
+          const compilerOptions = {
+            isCoverage: this.isCoverage,
+          };
 
-    async.eachObject(this.getAvailableCompilers(),
-      (extension: string, compilers: any, next: any) => {
-        const matchingFiles = contractFiles.filter(this.filesMatchingExtension(extension));
-        if (matchingFiles.length === 0) {
-          return next();
+          async.eachObject(
+            this.getAvailableCompilers(),
+            (extension: string, compilers: any, nextObj: any) => {
+              const matchingFiles = files.filter(
+                this.filesMatchingExtension(extension),
+              );
+              if (matchingFiles.length === 0) {
+                return nextObj();
+              }
+
+              async.someLimit(
+                compilers,
+                1,
+                (compiler: any, someCb: Callback<boolean>) => {
+                  compiler.call(
+                    compiler,
+                    matchingFiles,
+                    compilerOptions,
+                    (err: any, compileResult: any) => {
+                      if (err) {
+                        return someCb(err);
+                      }
+                      if (compileResult === false) {
+                        // Compiler not compatible, trying the next one
+                        return someCb(null, false);
+                      }
+                      Object.assign(compiledObject, compileResult);
+                      someCb(null, true);
+                    },
+                  );
+                },
+                (err: Error, result: boolean) => {
+                  if (err) {
+                    return nextObj(err);
+                  }
+                  if (!result) {
+                    // No compiler was compatible
+                    return nextObj(
+                      new Error(
+                        __(
+                          "No installed compiler was compatible with your version of %s files",
+                          extension,
+                        ),
+                      ),
+                    );
+                  }
+                  nextObj();
+                },
+              );
+            },
+            (err?: Error | null) => {
+              if (err) {
+                return next(err);
+              }
+
+              files
+                .filter((f: any) => !f.compiled)
+                .forEach((file: any) => {
+                  this.logger.warn(
+                    __(
+                      "%s doesn't have a compatible contract compiler. Maybe a plugin exists for it.",
+                      file.path,
+                    ),
+                  );
+                });
+              next(null, compiledObject);
+            },
+          );
+        },
+        (compiledObject: any, next: Callback<any>) => {
+          this.plugins.runActionsForEvent(
+            "compiler:contracts:compile:after",
+            compiledObject,
+            (err?: Error | null, compiledObj: any = {}) => {
+              if (err) {
+                return next(err);
+              }
+              next(null, compiledObj);
+            },
+          );
+        },
+      ],
+      (err?: Error | null, compiledObject?: any) => {
+        if (err) {
+          return cb(err);
         }
-
-        async.someLimit(compilers, 1, (compiler: any, someCb: Callback<boolean>) => {
-          compiler.call(compiler, matchingFiles, compilerOptions, (err: any, compileResult: any) => {
-            if (err) {
-              return someCb(err);
-            }
-            if (compileResult === false) {
-              // Compiler not compatible, trying the next one
-              return someCb(null, false);
-            }
-            Object.assign(compiledObject, compileResult);
-            someCb(null, true);
-          });
-        }, (err: Error, result: boolean) => {
-          if (err) {
-            return next(err);
-          }
-          if (!result) {
-            // No compiler was compatible
-            return next(new Error(__("No installed compiler was compatible with your version of %s files", extension)));
-          }
-          next();
-        });
-      },
-      (err: any) => {
-        contractFiles.filter((f: any) => !f.compiled).forEach((file: any) => {
-          this.logger.warn(__("%s doesn't have a compatible contract compiler. Maybe a plugin exists for it.", file.path));
-        });
-
-        cb(err, compiledObject);
+        cb(null, compiledObject || {});
       },
     );
   }
 
   private getAvailableCompilers() {
     const available_compilers: { [index: string]: any } = {};
-    this.plugins.getPluginsProperty("compilers", "compilers").forEach((compilerObject: CompilerPluginObject) => {
-      if (!available_compilers[compilerObject.extension]) {
-        available_compilers[compilerObject.extension] = [];
-      }
-      available_compilers[compilerObject.extension].unshift(compilerObject.cb);
-    });
+    this.plugins
+      .getPluginsProperty("compilers", "compilers")
+      .forEach((compilerObject: CompilerPluginObject) => {
+        if (!available_compilers[compilerObject.extension]) {
+          available_compilers[compilerObject.extension] = [];
+        }
+        available_compilers[compilerObject.extension].unshift(
+          compilerObject.cb,
+        );
+      });
     return available_compilers;
   }
 
   private filesMatchingExtension(extension: string) {
     return (file: any) => {
       const fileMatch = file.path.match(/\.[0-9a-z]+$/);
-      if (fileMatch && (fileMatch[0] === extension)) {
+      if (fileMatch && fileMatch[0] === extension) {
         file.compiled = true;
         return true;
       }

--- a/packages/stack/compiler/src/index.ts
+++ b/packages/stack/compiler/src/index.ts
@@ -27,13 +27,13 @@ class Compiler {
     async.waterfall(
       [
         (next: Callback<any[]>) => {
-          this.plugins.runActionsForEvent("compiler:contracts:compile:before", contractFiles, (err?: Error | null, files: any[] = []) => {
+          this.plugins.runActionsForEvent("compiler:contracts:compile:before", contractFiles, (err?: Error | null, contractFilesArr: any[] = []) => {
             if (err) {
               return next(err);
             }
             next(
               null,
-              files.map((file: any) =>
+              contractFilesArr.map((file: any) =>
                 file instanceof File
                   ? file
                   : new File({
@@ -48,7 +48,7 @@ class Compiler {
             );
           });
         },
-        (files: any[], next: Callback<any>) => {
+        (contractFilesArr: any[], next: Callback<any>) => {
           const compiledObject: { [index: string]: any } = {};
 
           const compilerOptions = {
@@ -58,7 +58,7 @@ class Compiler {
           async.eachObject(
             this.getAvailableCompilers(),
             (extension: string, compilers: any, nextObj: any) => {
-              const matchingFiles = files.filter(this.filesMatchingExtension(extension));
+              const matchingFiles = contractFilesArr.filter(this.filesMatchingExtension(extension));
               if (matchingFiles.length === 0) {
                 return nextObj();
               }
@@ -96,7 +96,7 @@ class Compiler {
                 return next(err);
               }
 
-              files
+              contractFilesArr
                 .filter((f: any) => !f.compiled)
                 .forEach((file: any) => {
                   this.logger.warn(__("%s doesn't have a compatible contract compiler. Maybe a plugin exists for it.", file.path));

--- a/packages/stack/compiler/src/index.ts
+++ b/packages/stack/compiler/src/index.ts
@@ -2,8 +2,8 @@ import { Callback, CompilerPluginObject, Embark, Plugins /* supplied by @types/e
 import { __ } from "embark-i18n";
 import * as os from "os";
 import * as path from "path";
+import { promisify } from "util";
 
-const async = require("embark-async-wrapper");
 const { File, Types, dappPath } = require("embark-utils");
 
 class Compiler {
@@ -19,125 +19,95 @@ class Compiler {
     embark.events.setCommandHandler("compiler:contracts:compile", this.compileContracts.bind(this));
   }
 
-  private compileContracts(contractFiles: any[], cb: Callback<any>) {
-    if (contractFiles.length === 0) {
+  private async runAfterActions(compiledObject: any): Promise<any> {
+    return (((await promisify(this.plugins.runActionsForEvent.bind(this.plugins, "compiler:contracts:compile:after"))(compiledObject)) as unknown) as any) || {};
+  }
+
+  private async runBeforeActions(contractFiles: any[]): Promise<any[]> {
+    return (((await promisify(this.plugins.runActionsForEvent.bind(this.plugins, "compiler:contracts:compile:before"))(contractFiles)) as unknown) as any[]) || [];
+  }
+
+  private *callCompilers(compilers: any, matchingFiles: any[], compilerOptions: object) {
+    for (const compiler of compilers) {
+      yield promisify(compiler)(matchingFiles, compilerOptions);
+    }
+  }
+
+  private checkContractFiles(contractFiles: any[]) {
+    const _dappPath = dappPath();
+    const osTmpDir = os.tmpdir();
+
+    return contractFiles.map((file) => {
+      if (file instanceof File) {
+        return file;
+      }
+
+      if (!file.path) {
+        throw new TypeError("path property was missing on contract file object");
+      }
+
+      let filePath: string;
+      if (!path.isAbsolute(file.path)) {
+        filePath = dappPath(file.path);
+      } else {
+        filePath = path.normalize(file.path);
+      }
+
+      if (![_dappPath, osTmpDir].some((dir) => filePath.startsWith(dir))) {
+        throw new Error("path must be within the DApp project or the OS temp directory");
+      }
+
+      return new File({
+        originalPath: file.path,
+        path: file.path,
+        resolver: (callback: Callback<any>) => {
+          this.fs.readFile(file.path, { encoding: "utf-8" }, callback);
+        },
+        type: Types.dappFile,
+      });
+    });
+  }
+
+  private async compileContracts(contractFiles: any[], cb: Callback<any>) {
+    if (!contractFiles.length) {
       return cb(null, {});
     }
 
-    async.waterfall(
-      [
-        (next: Callback<any[]>) => {
-          this.plugins.runActionsForEvent("compiler:contracts:compile:before", contractFiles, (err?: Error | null, contractFilesArr: any[] = []) => {
-            if (err) {
-              return next(err);
+    const compiledObject: { [index: string]: any } = {};
+    const compilerOptions = {};
+
+    try {
+      contractFiles = this.checkContractFiles(await this.runBeforeActions(contractFiles));
+
+      await Promise.all(
+        Object.entries(this.getAvailableCompilers()).map(async ([extension, compilers]: [string, any]) => {
+          const matchingFiles = contractFiles.filter(this.filesMatchingExtension(extension));
+          if (!matchingFiles.length) {
+            return;
+          }
+
+          for await (const compileResult of this.callCompilers(compilers, matchingFiles, compilerOptions)) {
+            if (compileResult === false) {
+              continue;
             }
+            Object.assign(compiledObject, compileResult);
+            return;
+          }
 
-            const _contractFilesArr: any[] = [];
-            const _dappPath = dappPath();
-            const osTmpDir = os.tmpdir();
+          throw new Error(__("No installed compiler was compatible with your version of %s files", extension));
+        }),
+      );
 
-            for (const file of contractFilesArr) {
-              if (file instanceof File) {
-                _contractFilesArr.push(file);
-                continue;
-              }
+      contractFiles
+        .filter((f: any) => !f.compiled)
+        .forEach((file: any) => {
+          this.logger.warn(__("%s doesn't have a compatible contract compiler. Maybe a plugin exists for it.", file.path));
+        });
 
-              if (!file.path) {
-                err = new TypeError("path property was missing on contract file object");
-                break;
-              }
-
-              let filePath: string;
-              if (!path.isAbsolute(file.path)) {
-                filePath = dappPath(file.path);
-              } else {
-                filePath = path.normalize(file.path);
-              }
-
-              if (![_dappPath, osTmpDir].some((dir) => filePath.startsWith(dir))) {
-                err = new Error("path must be within the DApp project or the OS temp directory");
-                break;
-              }
-
-              _contractFilesArr.push(
-                new File({
-                  originalPath: file.path,
-                  path: file.path,
-                  resolver: (callback: Callback<any>) => {
-                    this.fs.readFile(file.path, { encoding: "utf-8" }, callback);
-                  },
-                  type: Types.dappFile,
-                }),
-              );
-            }
-
-            next(err || null, _contractFilesArr);
-          });
-        },
-        (contractFilesArr: any[], next: Callback<any>) => {
-          const compiledObject: { [index: string]: any } = {};
-
-          const compilerOptions = {};
-
-          async.eachObject(
-            this.getAvailableCompilers(),
-            (extension: string, compilers: any, nextObj: any) => {
-              const matchingFiles = contractFilesArr.filter(this.filesMatchingExtension(extension));
-              if (matchingFiles.length === 0) {
-                return nextObj();
-              }
-
-              async.someLimit(
-                compilers,
-                1,
-                (compiler: any, someCb: Callback<boolean>) => {
-                  compiler.call(compiler, matchingFiles, compilerOptions, (err: any, compileResult: any) => {
-                    if (err) {
-                      return someCb(err);
-                    }
-                    if (compileResult === false) {
-                      // Compiler not compatible, trying the next one
-                      return someCb(null, false);
-                    }
-                    Object.assign(compiledObject, compileResult);
-                    someCb(null, true);
-                  });
-                },
-                (err: Error, result: boolean) => {
-                  if (err) {
-                    return nextObj(err);
-                  }
-                  if (!result) {
-                    // No compiler was compatible
-                    return nextObj(new Error(__("No installed compiler was compatible with your version of %s files", extension)));
-                  }
-                  nextObj();
-                },
-              );
-            },
-            (err?: Error | null) => {
-              if (err) {
-                return next(err);
-              }
-
-              contractFilesArr
-                .filter((f: any) => !f.compiled)
-                .forEach((file: any) => {
-                  this.logger.warn(__("%s doesn't have a compatible contract compiler. Maybe a plugin exists for it.", file.path));
-                });
-
-              next(null, compiledObject);
-            },
-          );
-        },
-        (compiledObject: any, next: Callback<any>) => {
-          this.plugins.runActionsForEvent("compiler:contracts:compile:after", compiledObject, next);
-        },
-      ],
-      (err?: Error | null, compiledObject?: any) => {
-        cb(err || null, compiledObject || {});
-      },
-    );
+      cb(null, await this.runAfterActions(compiledObject));
+    } catch (err) {
+      cb(err);
+    }
   }
 
   private getAvailableCompilers() {

--- a/packages/stack/compiler/src/index.ts
+++ b/packages/stack/compiler/src/index.ts
@@ -106,12 +106,7 @@ class Compiler {
           );
         },
         (compiledObject: any, next: Callback<any>) => {
-          this.plugins.runActionsForEvent("compiler:contracts:compile:after", compiledObject, (err?: Error | null, compiledObj: any = {}) => {
-            if (err) {
-              return next(err);
-            }
-            next(null, compiledObj);
-          });
+          this.plugins.runActionsForEvent("compiler:contracts:compile:after", compiledObject, next);
         },
       ],
       (err?: Error | null, compiledObject?: any) => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1047,6 +1047,14 @@
     core-js "^2.5.7"
     regenerator-runtime "^0.12.0"
 
+"@babel/runtime-corejs2@7.6.0":
+  version "7.6.0"
+  resolved "https://registry.yarnpkg.com/@babel/runtime-corejs2/-/runtime-corejs2-7.6.0.tgz#6fcd37c2580070817d62f219db97f67e26f50f9c"
+  integrity sha512-zbPQzlbyJab2xCYb6VaESn8Tk/XiVpQJU7WvIKiQCwlFyc2NSCzKjqtBXCvpZBbiTOHCx10s2656REVnySwb+A==
+  dependencies:
+    core-js "^2.6.5"
+    regenerator-runtime "^0.13.2"
+
 "@babel/runtime-corejs2@^7.0.0":
   version "7.5.5"
   resolved "https://registry.yarnpkg.com/@babel/runtime-corejs2/-/runtime-corejs2-7.5.5.tgz#c3214c08ef20341af4187f1c9fbdc357fbec96b2"


### PR DESCRIPTION
This supports in v5 how `embark-snark` needs to hook into contracts compilation but is implemented in a generic way that can be made use of by any plugin.

To see it in use have a look at https://github.com/embark-framework/embark-snark/pull/2, more specifically:

https://github.com/embark-framework/embark-snark/pull/2/files#diff-1fdf421c05c1140f6d71444ea2b27638R43.