### PR TITLE
refactor(@embark/blockchain): Move check for blockchain started

### DIFF
--- a/packages/plugins/geth/src/index.js
+++ b/packages/plugins/geth/src/index.js
@@ -1,8 +1,8 @@
 import { __ } from 'embark-i18n';
-const {normalizeInput} = require('embark-utils');
-import {BlockchainProcessLauncher} from './blockchainProcessLauncher';
-import {BlockchainClient} from './blockchain';
-import {ws, rpc} from './check.js';
+const { normalizeInput } = require('embark-utils');
+import { BlockchainProcessLauncher } from './blockchainProcessLauncher';
+import { BlockchainClient } from './blockchain';
+import { ws, rpc } from './check.js';
 const constants = require('embark-core/constants');
 
 class Geth {
@@ -23,6 +23,11 @@ class Geth {
     }
 
     this.events.request("blockchain:node:register", constants.blockchain.clients.geth, {
+      isStartedFn: (isStartedCb) => {
+        this._doCheck((state) => {
+          return isStartedCb(null, state.status === "on");
+        });
+      },
       launchFn: (readyCb) => {
         this.events.request('processes:register', 'blockchain', {
           launchFn: (cb) => {
@@ -73,22 +78,30 @@ class Geth {
   }
 
   _getNodeState(err, version, cb) {
-    if (err) return cb({name: "Ethereum node not found", status: 'off'});
+    if (err) return cb({ name: "Ethereum node not found", status: 'off' });
 
     let nodeName = "go-ethereum";
     let versionNumber = version.split("-")[0];
     let name = nodeName + " " + versionNumber + " (Ethereum)";
-    return cb({name, status: 'on'});
+    return cb({ name, status: 'on' });
+  }
+
+  _doCheck(cb) {
+    const { rpcHost, rpcPort, wsRPC, wsHost, wsPort } = this.blockchainConfig;
+    if (wsRPC) {
+      return ws(wsHost, wsPort, (err, version) => this._getNodeState(err, version, cb));
+    }
+    rpc(rpcHost, rpcPort, (err, version) => this._getNodeState(err, version, cb));
   }
 
   // TODO: need to get correct port taking into account the proxy
   registerServiceCheck() {
     this.events.request("services:register", 'Ethereum', (cb) => {
-      const {rpcHost, rpcPort, wsRPC, wsHost, wsPort} = this.blockchainConfig;
+      const { rpcHost, rpcPort, wsRPC, wsHost, wsPort } = this.blockchainConfig;
       if (wsRPC) {
-        return ws(wsHost, wsPort + 10, (err, version) => this._getNodeState(err, version, cb));
+        return ws(wsHost, wsPort, (err, version) => this._getNodeState(err, version, cb));
       }
-      rpc(rpcHost, rpcPort + 10, (err, version) => this._getNodeState(err, version, cb));
+      rpc(rpcHost, rpcPort, (err, version) => this._getNodeState(err, version, cb));
     }, 5000, 'off');
   }
 


### PR DESCRIPTION
The blockchain module should not contain any ethereum-specific code, and currently it contains a check to see if the blockchain has already been started.

This PR moves this check to blockchain client (ie geth or parity). This check function is registered along with the started callback.