### PR TITLE
refactor(@embark/embarkjs): Support for custom EmbarkJS plugins

### DIFF
--- a/packages/embark/src/cmd/cmd_controller.js
+++ b/packages/embark/src/cmd/cmd_controller.js
@@ -163,6 +163,9 @@ simulator(_options) {
         engine.registerModuleGroup("storage");
         engine.registerModuleGroup("cockpit");
         engine.registerModulePackage('embark-deploy-tracker', {plugins: engine.plugins});
+        
+        // load custom plugins
+        engine.config.plugins.loadPlugins();
 
         const plugin = engine.plugins.createPlugin('cmdcontrollerplugin', {});
         plugin.registerActionForEvent("embark:engine:started", async (_params, cb) => {

--- a/packages/embark/src/lib/core/config.js
+++ b/packages/embark/src/lib/core/config.js
@@ -138,7 +138,6 @@ Config.prototype.loadConfigFiles = function(options) {
     env: this.env,
     version: this.version
   });
-  this.plugins.loadPlugins();
 
   this.loadEmbarkConfigFile();
   this.loadBlockchainConfigFile();

--- a/packages/embark/src/lib/modules/embark-embarkjs/embarkjs-artifact.js.ejs
+++ b/packages/embark/src/lib/modules/embark-embarkjs/embarkjs-artifact.js.ejs
@@ -52,4 +52,13 @@ if (typeof WebSocket !== 'undefined') {
 }
 <% } %>
 
+<% for (let stackName in (customPlugins || [])) { %>
+  <% for (let pluginName in (customPlugins[stackName] || [])) { %>
+    let __embark<%- pluginName %> = require('<%- customPlugins[stackName][pluginName] %>');
+    __embark<%- pluginName %> = __embark<%- pluginName %>.default || __embark<%- pluginName %>;
+    const customPluginConfig = require('./config/<%- stackName %>.json');
+    EmbarkJS.<%- stackName %> = new __embark<%- pluginName %>({pluginConfig: customPluginConfig});
+  <% }; %>
+<% }; %>
+
 export default EmbarkJS;

--- a/packages/embark/src/lib/modules/embark-embarkjs/index.js
+++ b/packages/embark/src/lib/modules/embark-embarkjs/index.js
@@ -18,17 +18,27 @@ class EmbarkJS {
 
     this.events.request("runcode:whitelist", 'embarkjs', () => {
       this.registerEmbarkJS();
-     });
+    });
 
     this.embarkJSPlugins = {};
+    this.customEmbarkJSPlugins = {};
     this.events.setCommandHandler("embarkjs:plugin:register", (stackName, pluginName, packageName) => {
       this.embarkJSPlugins[stackName] = this.embarkJSPlugins[stackName] || {};
       this.embarkJSPlugins[stackName][pluginName] = packageName;
     });
+    this.events.setCommandHandler("embarkjs:plugin:register:custom", (stackName, pluginName, packageName) => {
+      this.customEmbarkJSPlugins[stackName] = this.customEmbarkJSPlugins[stackName] || {};
+      this.customEmbarkJSPlugins[stackName][pluginName] = packageName;
+    });
 
     this.events.setCommandHandler("embarkjs:console:register", (stackName, pluginName, packageName, cb) => {
-      this.events.request("runcode:whitelist", packageName, () => { });
+      this.events.request("runcode:whitelist", packageName, () => {});
       this.registerEmbarkJSPlugin(stackName, pluginName, packageName, cb || (() => {}));
+    });
+
+    this.events.setCommandHandler("embarkjs:console:regsiter:custom", (stackName, pluginName, packageName, options, cb) => {
+      this.events.request("runcode:whitelist", packageName, () => {});
+      this.registerCustomEmbarkJSPluginInVm(stackName, pluginName, packageName, options, cb || (() => {}));
     });
 
     this.events.setCommandHandler("embarkjs:console:setProvider", this.setProvider.bind(this));
@@ -65,8 +75,27 @@ class EmbarkJS {
     cb();
   }
 
+  async registerCustomEmbarkJSPluginInVm(stackName, pluginName, packageName, options, cb) {
+    await this.registerEmbarkJS();
+
+    const customPluginCode = `
+      let __embark${pluginName} = require('${packageName}');
+      __embark${pluginName} = __embark${pluginName}.default || __embark${pluginName};
+      const customPluginOptions = ${JSON.stringify(options)};
+      EmbarkJS.${stackName} = new __embark${pluginName}({pluginConfig: customPluginOptions});
+      EmbarkJS.${stackName}.init();
+    `;
+
+    await this.events.request2('runcode:eval', customPluginCode);
+    cb();
+  }
+
   addEmbarkJSArtifact(_params, cb) {
-    const embarkjsCode = Templates.embarkjs_artifact({ plugins: this.embarkJSPlugins, hasWebserver: this.embark.config.webServerConfig.enabled });
+    const embarkjsCode = Templates.embarkjs_artifact({
+      plugins: this.embarkJSPlugins,
+      hasWebserver: this.embark.config.webServerConfig.enabled,
+      customPlugins: this.customEmbarkJSPlugins
+    });
 
     // TODO: generate a .node file
     this.events.request("pipeline:register", {
@@ -137,10 +166,10 @@ class EmbarkJS {
       const result = await this.events.request2('runcode:eval', contract.className);
       result.currentProvider = provider;
       await this.events.request2("runcode:register", contract.className, result);
-      cb();
     } catch (err) {
-      cb(err);
+      return cb(err);
     }
+    cb();
   }
 
 }

--- a/packages/stack/proxy/src/index.ts
+++ b/packages/stack/proxy/src/index.ts
@@ -107,7 +107,9 @@ export default class ProxyManager {
       this.wsProxy.stop();
       this.wsProxy = null;
     }
-    this.httpProxy.stop();
-    this.httpProxy = null;
+    if (this.httpProxy) {
+      this.httpProxy.stop();
+      this.httpProxy = null;
+    }
   }
 }


### PR DESCRIPTION
Move loading of plugins to after core and stack components (in cmd_controller).

We should load custom Embark plugins LAST (ie after all core and stack components, and after all Embark plugins). To do this, we disable automatic loading of plugins in the config, and allow them to be loading explicitly in cmd_controller.

Create a system that allows registration of custom EmbarkJS plugins. Each plugin is generated in EmbarkJS by instantiating the registered class. For example, we can register a Plasma plugin and it will be generated in to EmbarkJS.Plasma with an instantiation of `embarkjs-plasma`. The DApp itself can then do what it wants with `EmbarkJS.Plasma` (ie call `EmbarkJS.Plasma.init()`.

**NOTE:** loading of custom Embark plugins needs to be applied to all other commands in `cmd_controller`. This PR only loads custom plugins for the `run` command.

**NOTE:** this branch is based off of `refactor/re-add-eth-sign_TypedData_v3`. 