### PR TITLE
Fix process logs not showing on errors and fix hang on wrong client

### DIFF
--- a/packages/core/utils/src/logHandler.js
+++ b/packages/core/utils/src/logHandler.js
@@ -45,6 +45,7 @@ class LogHandler {
    */
   handleLog(msg, alreadyLogged = false) {
     if (!msg) return;
+    msg.logLevel = msg.logLevel || msg.type;
 
     // Sometimes messages come in with line breaks, so we need to break them up accordingly.
     let processedMessages = [];
@@ -86,11 +87,11 @@ class LogHandler {
       }
       this.logs.push(log);
       this.events.emit(`process-log-${this.processName}`, log);
-      if ((this.silent && msg.type !== 'error') || alreadyLogged) {
+      if ((this.silent && msg.logLevel !== 'error') || alreadyLogged) {
         return;
       }
-      if (this.logger[msg.type]) {
-        return this.logger[msg.type](normalizeInput(message));
+      if (this.logger[msg.logLevel]) {
+        return this.logger[msg.logLevel](normalizeInput(message));
       }
       this.logger.debug(normalizeInput(message));
     });

--- a/packages/embark/src/cmd/cmd_controller.js
+++ b/packages/embark/src/cmd/cmd_controller.js
@@ -61,10 +61,15 @@ class EmbarkController {
       engine.registerModuleGroup("blockchain");
 
       engine.startEngine(async () => {
-        const alreadyStarted = await engine.events.request2("blockchain:node:start", Object.assign(engine.config.blockchainConfig, {isStandalone: true}));
-        if (alreadyStarted) {
-          engine.logger.warn(__('Blockchain process already started. No need to run `embark blockchain`'));
-          process.exit(0);
+        try {
+          const alreadyStarted = await engine.events.request2("blockchain:node:start", Object.assign(engine.config.blockchainConfig, {isStandalone: true}));
+          if (alreadyStarted) {
+            engine.logger.warn(__('Blockchain process already started. No need to run `embark blockchain`'));
+            process.exit(0);
+          }
+        } catch (e) {
+          engine.logger.error(e);
+          process.exit(1);
         }
       });
     });

--- a/packages/embark/src/lib/modules/blockchain/index.js
+++ b/packages/embark/src/lib/modules/blockchain/index.js
@@ -59,7 +59,7 @@ class Blockchain {
           }
           const clientFunctions = this.blockchainNodes[clientName];
           if (!clientFunctions) {
-            return cb(__("Client %s not found", clientName));
+            return cb(__("Client %s not found in registered plugins", clientName));
           }
 
           let onStart = () => {
@@ -91,7 +91,7 @@ class Blockchain {
 
       const clientFunctions = this.blockchainNodes[clientName];
       if (!clientFunctions) {
-        return cb(__("Client %s not found", clientName));
+        return cb(__("Client %s not found in registered plugins", clientName));
       }
 
       clientFunctions.stopFn.apply(clientFunctions, [

--- a/packages/embark/src/lib/modules/geth/blockchain.js
+++ b/packages/embark/src/lib/modules/geth/blockchain.js
@@ -199,8 +199,8 @@ Blockchain.prototype.run = function () {
     }
   ], function(err, cmd, args) {
     if (err) {
-      self.logger.error(err.message);
-      return;
+      self.logger.error(err.message || err);
+      process.exit(1);
     }
     args = compact(args);
 


### PR DESCRIPTION
When you didn't have the blockchain client installed or put in a bad path to the bin, it would hang.
Especially in `embark run`, you wouldn't even have the message.

That was because the log handler was looking at `msg.type` instead of `msg.logLevel` to check if it's an error. 
I'm not sure where `type` comes from, but I added a condition so that both `type` and `logLevel` work now.

Now, if the client doesn't exist, it will exit and users will get a message