### PR TITLE
Fix VM as a client and cleanup template configs

### DIFF
--- a/dapps/templates/boilerplate/config/contracts.js
+++ b/dapps/templates/boilerplate/config/contracts.js
@@ -3,6 +3,7 @@ module.exports = {
   default: {
     // order of connections the dapp should connect to
     dappConnection: [
+      "$EMBARK",
       "$WEB3",  // uses pre existing web3 object if available (e.g in Mist)
       "ws://localhost:8546",
       "http://localhost:8545"
@@ -38,25 +39,11 @@ module.exports = {
 
   // default environment, merges with the settings in default
   // assumed to be the intended environment by `embark run`
-  development: {
-    dappConnection: [
-      "ws://localhost:8546",
-      "http://localhost:8545",
-      "$WEB3"  // uses pre existing web3 object if available (e.g in Mist)
-    ]
-  },
+  development: {},
 
   // merges with the settings in default
   // used with "embark run privatenet"
   privatenet: {},
-
-  // merges with the settings in default
-  // used with "embark run testnet"
-  testnet: {},
-
-  // merges with the settings in default
-  // used with "embark run livenet"
-  livenet: {}
 
   // you can name an environment with specific settings and then specify with
   // "embark run custom_name" or "embark blockchain custom_name"

--- a/dapps/templates/boilerplate/config/storage.js
+++ b/dapps/templates/boilerplate/config/storage.js
@@ -28,7 +28,6 @@ module.exports = {
   // default environment, merges with the settings in default
   // assumed to be the intended environment by `embark run`
   development: {
-    enabled: true,
     upload: {
       provider: "ipfs",
       host: "localhost",

--- a/dapps/templates/demo/config/contracts.js
+++ b/dapps/templates/demo/config/contracts.js
@@ -39,25 +39,11 @@ module.exports = {
 
   // default environment, merges with the settings in default
   // assumed to be the intended environment by `embark run`
-  development: {
-    dappConnection: [
-      "ws://localhost:8546",
-      "http://localhost:8545",
-      "$WEB3"  // uses pre existing web3 object if available (e.g in Mist)
-    ]
-  },
+  development: {},
 
   // merges with the settings in default
   // used with "embark run privatenet"
   privatenet: {},
-
-  // merges with the settings in default
-  // used with "embark run testnet"
-  testnet: {},
-
-  // merges with the settings in default
-  // used with "embark run livenet"
-  livenet: {}
 
   // you can name an environment with specific settings and then specify with
   // "embark run custom_name" or "embark blockchain custom_name"

--- a/dapps/templates/demo/config/storage.js
+++ b/dapps/templates/demo/config/storage.js
@@ -28,7 +28,6 @@ module.exports = {
   // default environment, merges with the settings in default
   // assumed to be the intended environment by `embark run`
   development: {
-    enabled: true,
     upload: {
       provider: "ipfs",
       host: "localhost",

--- a/packages/plugins/web3/src/index.js
+++ b/packages/plugins/web3/src/index.js
@@ -26,12 +26,12 @@ class EmbarkWeb3 {
   }
 
   async setupEmbarkJS() {
-    this.events.request("embarkjs:plugin:register", 'blockchain', 'web3', 'embarkjs-web3');
-    await this.events.request2("embarkjs:console:register", 'blockchain', 'web3', 'embarkjs-web3');
     this.events.on("blockchain:started", async () => {
       await this.registerWeb3Object();
       this.events.request("embarkjs:console:setProvider", 'blockchain', 'web3', '{web3}');
     });
+    this.events.request("embarkjs:plugin:register", 'blockchain', 'web3', 'embarkjs-web3');
+    await this.events.request2("embarkjs:console:register", 'blockchain', 'web3', 'embarkjs-web3');
   }
 
   async setupWeb3Api() {


### PR DESCRIPTION
Putting `client: vm` didn't work, because the web3 module only listened to `on('blockchain:started')` after an async call.