### PR TITLE
fix: fix error logs in the cockpit due from negative blocks numbers

### DIFF
--- a/packages/embark/src/lib/modules/ethereum-blockchain-client/api.js
+++ b/packages/embark/src/lib/modules/ethereum-blockchain-client/api.js
@@ -153,11 +153,13 @@ export default class EthereumAPI {
         });
       },
       function (next) {
-        async.times(limit, function (n, eachCb) {
-          self.web3.eth.getBlock(from - n, returnTransactionObjects, function (err, block) {
+        if (from - limit < 0) {
+          limit = from + 1;
+        }
+        async.times(limit, (n, eachCb) => {
+          self.web3.eth.getBlock(from - n, returnTransactionObjects, (err, block) => {
             if (err) {
-              // FIXME Returns an error because we are too low
-              return eachCb();
+              return eachCb(err);
             }
             if (!block) {
               return eachCb();

--- a/packages/stack/proxy/src/proxy.js
+++ b/packages/stack/proxy/src/proxy.js
@@ -57,6 +57,7 @@ export class Proxy {
             // Send the possibly modified request to the Node
             requestManager.send(resp.reqData, (err, result) => {
               if (err) {
+                this.logger.debug(JSON.stringify(resp.reqData));
                 return this.logger.error(__('Error executing the request on the Node'), err.message || err);
               }
               this.emitActionsForResponse(resp.reqData, {jsonrpc: "2.0", id: resp.reqData.id, result}, (_err, resp) => {


### PR DESCRIPTION
The proxy was outputting logs about an error in request. That's because we were asking for a block with a number smaller than 0.