### PR TITLE
Fix whisper callback and start

### DIFF
--- a/packages/embark/src/lib/modules/geth/whisperClient.js
+++ b/packages/embark/src/lib/modules/geth/whisperClient.js
@@ -50,7 +50,7 @@ class WhisperGethClient {
   }
 
   commonOptions() {
-    return [];
+    return ['--ipcdisable'];
   }
 
   getMiner() {

--- a/packages/embarkjs/whisper/src/index.js
+++ b/packages/embarkjs/whisper/src/index.js
@@ -46,7 +46,7 @@ __embarkWhisperNewWeb3.setProvider = function(options) {
   });
 };
 
-__embarkWhisperNewWeb3.sendMessage = function(options, callback) {
+__embarkWhisperNewWeb3.sendMessage = function(options) {
   const data = options.data || options.payload;
   if (!data) {
     throw new Error("missing option: data");
@@ -60,12 +60,7 @@ __embarkWhisperNewWeb3.sendMessage = function(options, callback) {
     data
   });
 
-  this.real_sendMessage(options, (err) => {
-    if (err) {
-      throw new Error(err);
-    }
-    callback();
-  });
+  return this.real_sendMessage(options);
 };
 
 __embarkWhisperNewWeb3.listenTo = function (options) {


### PR DESCRIPTION
Fix whisper node start (at least on Windows) by putting `--ipcdisable` because ipc is not needed for whisper and also, it made it so that the Whisper node didn't start correctly.

Also, remove the callback from the `send` function in EmbarkJS for Whisper, as it's not needed and also, we can use the promise instead
