### PR TITLE
test(@embark/communication): fix failing test

### DIFF
--- a/packages/stack/communication/test/communication.spec.js
+++ b/packages/stack/communication/test/communication.spec.js
@@ -42,7 +42,8 @@ describe('stack/communication', () => {
 
   test('it should register and start communication node', () => {
     const communicationConfig = {
-      provider: 'whisper'
+      provider: 'whisper',
+      enabled: true
     };
 
     const processRegisterHandler = sinon.spy((name, fns) => {});


### PR DESCRIPTION
In https://github.com/embark-framework/embark/commit/d6bf5c24b92c0d1a8bc7c0a28a0432e033d72e74 we've ensured that certain modules of
embark only executed if their functionality is actually enabled.
This broke one of our tests in the communication module.
This commit fixes the test by explicitly enabling the module's functionality.