### PR TITLE
test(@embark/stack/test-runner): enable test-runner's test suite

### DIFF
--- a/packages/stack/test-runner/package.json
+++ b/packages/stack/test-runner/package.json
@@ -33,7 +33,7 @@
     "ci": "npm run qa",
     "clean": "npm run reset",
     "lint": "eslint src/",
-    "qa": "npm-run-all lint _build",
+    "qa": "npm-run-all lint _build test",
     "reset": "npx rimraf .nyc_output dist embark-*.tgz package",
     "solo": "embark-solo",
     "test": "nyc --reporter=html --reporter=json mocha \"dist/test/**/*.js\" --exit --no-timeouts --require source-map-support/register"

--- a/packages/stack/test-runner/src/lib/index.js
+++ b/packages/stack/test-runner/src/lib/index.js
@@ -22,6 +22,7 @@ class TestRunner {
     this.logger = embark.logger;
     this.events = embark.events;
     this.plugins = options.plugins;
+    this.stdout = options.stdout || process.stdout;
     this.fs = embark.fs;
     this.runners = [];
     this.files = [];
@@ -46,7 +47,7 @@ class TestRunner {
   }
 
   run(options, cb) {
-    const reporter = new Reporter(this.embark);
+    const reporter = new Reporter(this.embark, {stdout: this.stdout});
     const testPath = options.file || "test";
 
     this.setupGlobalVariables();

--- a/packages/stack/test-runner/src/lib/reporter.js
+++ b/packages/stack/test-runner/src/lib/reporter.js
@@ -1,8 +1,9 @@
 const chalk = require('chalk');
 
 class Reporter {
-  constructor(embark) {
+  constructor(embark, options) {
     this.embark = embark;
+    this.stdout = options.stdout || process.stdout;
 
     this.passes = 0;
     this.fails = 0;
@@ -36,9 +37,9 @@ class Reporter {
   footer() {
     const total = this.passes + this.fails;
     if (this.fails > 0) {
-      process.stdout.write(chalk`{red Failed ${this.fails} / ${total} test(s).}\n`);
+      this.stdout.write(chalk`{red Failed ${this.fails} / ${total} test(s).}\n`);
     } else {
-      process.stdout.write(chalk`{green Passed ${this.passes} test(s).}\n`);
+      this.stdout.write(chalk`{green Passed ${this.passes} test(s).}\n`);
 
     }
   }
@@ -55,10 +56,10 @@ class Reporter {
 
     if (passed) {
       this.passes++;
-      process.stdout.write(chalk`{bgGreen.white.bold ${' PASS '}} {underline ${test}} {bold >} {${timeFormat} ${time}s} {bold >} {bold ${formattedGas} gas}\n`);
+      this.stdout.write(chalk`{bgGreen.white.bold ${' PASS '}} {underline ${test}} {bold >} {${timeFormat} ${time}s} {bold >} {bold ${formattedGas} gas}\n`);
     } else {
       this.fails++;
-      process.stdout.write(chalk`{bgRed.white.bold ${' FAIL '}} {underline ${test}} {bold >} {${timeFormat} ${time}s} {bold >} {bold ${formattedGas} gas} > {red ${message || 'no error message'}}\n`);
+      this.stdout.write(chalk`{bgRed.white.bold ${' FAIL '}} {underline ${test}} {bold >} {${timeFormat} ${time}s} {bold >} {bold ${formattedGas} gas} > {red ${message || 'no error message'}}\n`);
     }
 
     this.resetGas();

--- a/packages/stack/test-runner/src/test/test_runner_test.js
+++ b/packages/stack/test-runner/src/test/test_runner_test.js
@@ -11,9 +11,13 @@ describe('Test Runner', () => {
   let instance;
 
   beforeEach(() => {
-    const { embark } = fakeEmbark();
+    const { embark } = fakeEmbark({ contractsConfig: {} });
+    embark.events.setCommandHandler('config:contractsConfig:set', (config, cb) => {
+      embark.config.contractsConfig = config;
+      cb(null);
+    });
     _embark = embark;
-    instance = new TestRunner(embark, {});
+    instance = new TestRunner(embark, {stdout: {write: () => {}}});
   });
 
   describe('command handlers', () => {


### PR DESCRIPTION
Introduce some light refactoring related to embark-testing facilities, and also a configurable stdout option so the output of the reporter implemented in this package isn't confusingly mixed into unit test reporting for this package.