### PR TITLE
fix(@embark/core): make blockchain command work again

### DIFF
--- a/packages/embark/src/lib/core/engine.js
+++ b/packages/embark/src/lib/core/engine.js
@@ -160,8 +160,8 @@ class Engine {
   }
 
   blockchainStackComponents() {
-    this.registerModule('blockchain', { plugins: this.plugins });
-    this.registerModule('blockchain-client');
+    this.registerModulePackage('embark-blockchain', { plugins: this.plugins });
+    this.registerModulePackage('embark-blockchain-client');
     this.registerModulePackage('embark-process-logs-api-manager');
   }
 


### PR DESCRIPTION
Running embark's `blockchain` command resulted in a runtime error where the `blockchain`
module couldn't be found. This is a bug introduced in https://github.com/embark-framework/embark/commit/ed0d3afb4ff11520e4a73d1318d1269c2e994c06 where
we forgot to update `blockchainStackComponents` in Embark's engine accordingly.

Fixing this results in `embark blockchain` hanging. This is because there's a similar bug
in `blockchainStackCopmnonents` introduced in https://github.com/embark-framework/embark/commit/3b8f8f9ea74a5c90d3a2c4a635b7b82841ff073f.

This commit fixes both bugs by ensuring `embark-blockchain` and `embark-blockchain-client`
packages are loaded using the correct APIs.