### PR TITLE
Fix cb already called in test app

### DIFF
--- a/packages/plugins/ens/src/index.js
+++ b/packages/plugins/ens/src/index.js
@@ -389,10 +389,16 @@ class ENS {
   }
 
   ensResolve(name, cb) {
+    if (!this.ensContract) {
+      return cb(__('ENS not registered for this configuration'));
+    }
     ENSFunctions.resolveName(name, this.ensContract, this.createResolverContract.bind(this), cb, namehash);
   }
 
   ensLookup(address, cb) {
+    if (!this.ensContract) {
+      return cb(__('ENS not registered for this configuration'));
+    }
     ENSFunctions.lookupAddress(address, this.ensContract, namehash, this.createResolverContract.bind(this), cb);
   }
 

--- a/packages/plugins/geth/src/check.js
+++ b/packages/plugins/geth/src/check.js
@@ -4,7 +4,15 @@ const http = require("http");
 const LIVENESS_CHECK=`{"jsonrpc":"2.0","method":"web3_clientVersion","params":[],"id":42}`;
 
 const parseAndRespond = (data, cb) => {
-  const resp = JSON.parse(data);
+  let resp;
+  try {
+    resp = JSON.parse(data);
+  } catch (e) {
+    return cb('Version data is not valid JSON');
+  }
+  if (!resp || !resp.result) {
+    return cb('No version returned');
+  }
   const [_, version, __] = resp.result.split('/');
   cb(null, version);
 };

--- a/packages/plugins/parity/src/check.js
+++ b/packages/plugins/parity/src/check.js
@@ -4,7 +4,15 @@ const http = require("http");
 const LIVENESS_CHECK=`{"jsonrpc":"2.0","method":"web3_clientVersion","params":[],"id":42}`;
 
 const parseAndRespond = (data, cb) => {
-  const resp = JSON.parse(data);
+  let resp;
+  try {
+    resp = JSON.parse(data);
+  } catch (e) {
+    return cb('Version data is not valid JSON');
+  }
+  if (!resp || !resp.result) {
+    return cb('No version returned');
+  }
   const [_, version, __] = resp.result.split('/');
   cb(null, version);
 };


### PR DESCRIPTION
This error was caused because the test app has `.eth` names in it's onDeploys, but when using an environment different than development, ENS was not registered (no rootDomain, etc), so the resolve threw without a catch.
Now, it checks for the ENS contract before trying to resolve.

Also found a weird problem when the Geth version call didn't return a result, so now it will handle it