### PR TITLE
refactor(@embark/template_generator): account for prerelease in embark version

### DIFF
--- a/packages/embark/src/lib/utils/template_generator.js
+++ b/packages/embark/src/lib/utils/template_generator.js
@@ -125,8 +125,13 @@ class TemplateGenerator {
         () => (pkgJsonPath) => normalize(pkgJsonPath).includes(normalize('dapps/templates'))
       );
     } else {
-      const version = fs.readJSONSync(embarkPath('package.json')).version;
-      templateSpecifier = `${templatePkg}@${semver(version).major}.x`;
+      const version = semver(fs.readJSONSync(embarkPath('package.json')).version);
+      if (!version.prerelease.length) {
+        templateSpecifier = `${templatePkg}@${version.major}.x`;
+      } else {
+        const majorMinorPatch = `${version.major}.${version.minor}.${version.patch}`;
+        templateSpecifier = `"${templatePkg}@^${majorMinorPatch}- <${majorMinorPatch}"`;
+      }
     }
 
     const tmpDir = require('fs-extra').mkdtempSync(


### PR DESCRIPTION
If the version in the embark package's own `package.json` has a prerelease identifier then appending `.x` to the major version isn't viable for resolving the latest version of the template package that's in the same prerelease line; a more complex semver range must be used:

```
"${pkg}@^${major}.${minor}.${patch}- <${major}.${minor}.${patch}"
```