### PR TITLE
fix(@embark/transaction-logger): don't show logs for stray receipts

### DIFF
--- a/packages/plugins/transaction-logger/src/index.js
+++ b/packages/plugins/transaction-logger/src/index.js
@@ -131,6 +131,9 @@ class TransactionLogger {
         // This is the normal case. If we don't get here, it's because we missed a TX
         dataObject = Object.assign(dataObject, this.transactions[args.respData.result.transactionHash]);
         delete this.transactions[args.respData.result.transactionHash]; // No longer needed
+      } else {
+        // Was not a eth_getTransactionReceipt in the context of a transaction
+        return;
       }
     } else {
       dataObject = args.reqData.params[0];


### PR DESCRIPTION
This caused logs like:
```
Blockchain> Resolver.unknown(unknown) | 0xb5b9c95cc268158ec3221265c7a1011f71928c50af07721b0e04beed1e0af782 | gas:46946 | blk:11 | status:0x1 │
│ Blockchain> SimpleStorage.unknown(unknown) | 0x80257c5b6cb5b4f3f1f638e01dd85a8d30e0cc005cb04d075a81c57c7bfe6e72 | gas:26661 | blk:19 | status:0x1 │
```
It happened because the cockpit fetches transaction data, which calls `eth_getTransactionReceipt`, which is a method the transaction-logger reacts to.
The thing is, it should only  react to receipts that are attached to transactions, not receipts that come from normal GETs