### PR TITLE
refactor(@embark/cmd): exit with error when command is unknown

### DIFF
--- a/packages/embark/src/cmd/cmd.js
+++ b/packages/embark/src/cmd/cmd.js
@@ -463,7 +463,7 @@ class Cmd {
           console.log((__('did you mean') + ' "%s"?').green, suggestion);
         }
         console.log("type embark --help to see the available commands");
-        process.exit(0);
+        process.exit(1);
       });
   }
 


### PR DESCRIPTION
Example: `embark rest && embark run`

The command/s following `&&` shouldn't run after the first one fails and prints an "unknown command" message.