### PR TITLE
fix(@embark/templates): ensure boilerplate template comes with valid …

### DIFF
--- a/dapps/templates/boilerplate/config/communication.js
+++ b/dapps/templates/boilerplate/config/communication.js
@@ -11,7 +11,7 @@ module.exports = {
   development: {
     connection: {
       host: "localhost", // Host of the blockchain node
-      port: 8546, // Port of the blockchain node
+      port: 8557, // Port of the blockchain node
       type: "ws" // Type of connection (ws or rpc)
     }
   },


### PR DESCRIPTION
…whisper port

As part of the refactor in https://github.com/embark-framework/embark/commit/e330b338ea2a45acb14eebd93af93bc2aba62516 we've introduced a
second geth client process to enable whisper functionalities in DApps.
This introduced also a new default port for whisper (https://github.com/embark-framework/embark/commit/e330b338ea2a45acb14eebd93af93bc2aba62516#diff-a61fbc84e4172487789d676437f26b5fR14).
This default port has not been introduced on our boilerplate template which is
used in `embark new` when developers scaffold new apps.

This resulted in runtime errors where the geth process for whisper wasn't
able to successfully boot up as its configured port address is already in use:

```
geth exited with error code 1
geth exited with error code 1
Blockchain process ended before the end of this process. Try running blockchain in a separate process using `$ embark blockchain`. Code: null
```

Notice how the actual information needed is not propagated by Embark, making it very hard to figure out what's going on.

This commit changes the default port for whisper in the boilerplate template
to ensure apps created using `embark new` don't run into this error anymore.