### PR TITLE
Fix "race condition" in test app

### DIFF
--- a/dapps/tests/app/test/simple_storage_spec.js
+++ b/dapps/tests/app/test/simple_storage_spec.js
@@ -1,4 +1,4 @@
-/*global contract, config, it, assert, web3, xit*/
+/*global contract, config, it, assert, web3*/
 const SimpleStorage = require('Embark/contracts/SimpleStorage');
 let accounts;
 const {Utils} = require('Embark/EmbarkJS');
@@ -37,7 +37,7 @@ contract("SimpleStorage", function() {
     });
   });
 
-  xit("should set to self address", async function() {
+  it("should set to self address", async function() {
     let result = await SimpleStorage.methods.registar().call();
     assert.strictEqual(result, SimpleStorage.options.address);
   });

--- a/dapps/tests/app/test/token_spec.js
+++ b/dapps/tests/app/test/token_spec.js
@@ -43,7 +43,7 @@ config({
       },
       SomeContract: {
         deployIf: (dependencies) => {
-          return dependencies.contract.MyToken.methods.isAvailable().call();
+          return dependencies.contracts.MyToken.methods.isAvailable().call();
         },
         args: [
           ["$MyToken2", "$SimpleStorage"],
@@ -91,7 +91,7 @@ describe("Token", function() {
       assert.strictEqual(result, MyToken.options.address);
     });
 
-    xit("should not deploy if deployIf returns false", function() {
+    it("should not deploy if deployIf returns false", function() {
       assert.ok(!SomeContract.options.address);
     });
 

--- a/packages/embark/src/cmd/cmd_controller.js
+++ b/packages/embark/src/cmd/cmd_controller.js
@@ -749,7 +749,7 @@ class EmbarkController {
         engine.registerModuleGroup("contracts");
         engine.registerModuleGroup("pipeline");
         engine.registerModuleGroup("tests", options);
-        engine.registerModulePackage('embark-deploy-tracker', {plugins: engine.plugins});
+        engine.registerModulePackage('embark-deploy-tracker', {plugins: engine.plugins, trackContracts: false});
 
         engine.startEngine(next);
       },

--- a/packages/plugins/deploy-tracker/src/deploymentChecks.js
+++ b/packages/plugins/deploy-tracker/src/deploymentChecks.js
@@ -98,7 +98,7 @@ export default class DeploymentChecks {
         return this.trackingFunctions.trackAndSaveContract(params, () => {
           // no need to wait for this function to finish as it has no impact on operation
           // past this point
-          this.logger.trace(__("Contract tracking setting has been updatred in chains.json"));
+          this.logger.trace(__("Contract tracking setting has been updated in chains.json"));
           cb(null, params);
         });
       }

--- a/packages/plugins/deploy-tracker/src/index.js
+++ b/packages/plugins/deploy-tracker/src/index.js
@@ -3,14 +3,11 @@ import TrackingFunctions from "./trackingFunctions";
 
 class DeployTracker {
 
-  constructor(embark, {trackContracts, env, plugins}) {
+  constructor(embark, {trackContracts, plugins}) {
     const {logger, events, fs, config} = embark;
     this.embark = embark;
 
-    // TODO: unclear where env comes from
-    // TODO: we should be getting the env from a request to the config
-
-    const trackingFunctions = new TrackingFunctions({config, fs, logger, events, env, trackContracts});
+    const trackingFunctions = new TrackingFunctions({config, fs, logger, events, trackContracts});
     const deploymentChecks = new DeploymentChecks({trackingFunctions, logger, events, plugins});
 
     this.embark.registerActionForEvent("deployment:contract:deployed", trackingFunctions.trackAndSaveContract.bind(trackingFunctions));

--- a/packages/plugins/deploy-tracker/src/trackingFunctions.js
+++ b/packages/plugins/deploy-tracker/src/trackingFunctions.js
@@ -3,11 +3,11 @@ import {dappPath} from 'embark-utils';
 import Web3 from 'web3';
 
 export default class TrackingFunctions {
-  constructor({config, env, fs, events, logger, trackContracts}) {
+  constructor({config, fs, events, logger, trackContracts}) {
     this.config = config;
     this.enabled = (config.contractsConfig.tracking !== false) && (trackContracts !== false);
     this.chainsFilePath = dappPath(config.contractsConfig.tracking || ".embark/chains.json");
-    this.env = env;
+    this.env = config.env;
     this.fs = fs;
     this.events = events;
     this.logger = logger;
@@ -69,7 +69,10 @@ export default class TrackingFunctions {
 
       const chains = (await this.chains) || {};
       const {hash} = await this.block;
-      this._currentChain = chains[hash];
+      this._currentChain = chains[hash] || {
+        contracts: {},
+        name: this.env
+      };
       return this._currentChain;
     })();
   }
@@ -130,6 +133,12 @@ export default class TrackingFunctions {
     if (contract.track === false) toTrack.track = false;
     const {hash} = await this.block;
     const chains = await this.chains;
+    if (!chains[hash]) {
+      chains[hash] = {
+        contracts: {},
+        name: this.env
+      };
+    }
     chains[hash].contracts[contract.hash] = toTrack;
     this.chains = chains;
   }


### PR DESCRIPTION
I put race condition in the title in quotes, because it ended up having nothing to do with a race.

The problem was that our deploy tracker was bugged. it only worked for  the first block hash it was created for. The subsequent hashes were never tracked.

In the context of the tests, it's a good thing, because that means that the test ended up never being tracked after the first run of anything, meaning the tests all passed.

Now the reason the tests never passed on CI is exactly that, the chains.json didn't exist, so the test contracts ended up being tracked, which is definitely not wanted.

So the fixes in this PR are for the tracker, so that it tracks every chain and also makes it so that we never track contracts in the tests, by using the `trackContract: false` options for test runs. 
just removing the deploy-tracker from the tests does not work, because it's that module that handles `deploy: false `configs, so some tests with `deploy: false` failed.