### PR TITLE
fix: fix ws providers to have the patch for a bigger threshold

### DIFF
--- a/dapps/tests/app/app/contracts/BFC.sol
+++ b/dapps/tests/app/app/contracts/BFC.sol
@@ -1,0 +1,6382 @@
+// to test issue with nodes breaking with large clients over WS
+// fixed in web3 with fragmentationThreshold: 8192
+
+pragma solidity ^0.4.17;
+contract BigFreakingContract {
+
+  event Transfer(address indexed from, address indexed to, uint value);
+  event Approval( address indexed owner, address indexed spender, uint value);
+
+  mapping( address => uint ) _balances;
+  mapping( address => mapping( address => uint ) ) _approvals;
+  uint public _supply;
+
+  // TODO: currently commented due to a bug with the params
+  // constructor( uint initial_balance ) public {
+  constructor() public {
+    // _balances[msg.sender] = initial_balance;
+    // _supply = initial_balance;
+    _balances[msg.sender] = 100;
+    _supply = 100;
+  }
+  function totalSupply() public constant returns (uint supply) {
+    return _supply;
+  }
+  function balanceOf( address who ) public constant returns (uint value) {
+    return _balances[who];
+  }
+  function transfer( address to, uint value) public returns (bool ok) {
+    if( _balances[msg.sender] < value ) {
+      revert();
+    }
+    if( !safeToAdd(_balances[to], value) ) {
+      revert();
+    }
+    _balances[msg.sender] -= value;
+    _balances[to] += value;
+    emit Transfer( msg.sender, to, value );
+    return true;
+  }
+  function transferFrom( address from, address to, uint value) public returns (bool ok) {
+    // if you don't have enough balance, throw
+    if( _balances[from] < value ) {
+      revert();
+    }
+    // if you don't have approval, throw
+    if( _approvals[from][msg.sender] < value ) {
+      revert();
+    }
+    if( !safeToAdd(_balances[to], value) ) {
+      revert();
+    }
+    // transfer and return true
+    _approvals[from][msg.sender] -= value;
+    _balances[from] -= value;
+    _balances[to] += value;
+    emit Transfer( from, to, value );
+    return true;
+  }
+  function approve(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+  function allowance(address owner, address spender) public constant returns (uint _allowance) {
+    return _approvals[owner][spender];
+  }
+  function safeToAdd(uint a, uint b) internal pure returns (bool) {
+    return (a + b >= a);
+  }
+  function isAvailable() public pure returns (bool) {
+    return false;
+  }
+
+  function approve_1(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_2(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_3(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_4(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_5(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_6(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_7(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_8(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_9(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_10(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_11(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_12(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_13(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_14(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_15(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_16(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_17(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_18(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_19(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_20(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_21(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_22(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_23(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_24(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_25(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_26(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_27(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_28(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_29(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_30(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_31(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_32(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_33(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_34(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_35(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_36(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_37(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_38(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_39(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_40(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_41(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_42(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_43(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_44(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_45(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_46(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_47(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_48(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_49(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_50(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_51(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_52(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_53(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_54(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_55(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_56(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_57(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_58(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_59(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_60(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_61(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_62(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_63(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_64(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_65(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_66(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_67(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_68(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_69(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_70(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_71(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_72(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_73(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_74(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_75(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_76(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_77(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_78(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_79(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_80(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_81(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_82(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_83(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_84(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_85(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_86(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_87(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_88(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_89(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_90(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_91(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_92(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_93(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_94(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_95(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_96(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_97(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_98(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_99(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_100(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_101(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_102(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_103(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_104(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_105(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_106(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_107(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_108(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_109(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_110(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_111(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_112(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_113(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_114(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_115(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_116(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_117(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_118(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_119(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_120(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_121(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_122(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_123(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_124(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_125(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_126(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_127(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_128(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_129(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_130(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_131(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_132(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_133(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_134(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_135(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_136(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_137(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_138(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_139(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_140(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_141(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_142(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_143(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_144(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_145(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_146(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_147(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_148(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_149(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_150(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_151(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_152(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_153(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_154(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_155(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_156(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_157(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_158(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_159(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_160(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_161(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_162(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_163(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_164(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_165(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_166(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_167(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_168(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_169(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_170(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_171(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_172(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_173(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_174(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_175(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_176(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_177(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_178(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_179(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_180(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_181(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_182(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_183(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_184(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_185(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_186(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_187(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_188(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_189(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_190(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_191(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_192(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_193(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_194(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_195(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_196(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_197(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_198(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_199(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_200(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_201(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_202(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_203(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_204(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_205(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_206(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_207(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_208(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_209(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_210(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_211(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_212(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_213(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_214(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_215(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_216(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_217(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_218(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_219(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_220(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_221(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_222(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_223(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_224(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_225(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_226(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_227(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_228(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_229(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_230(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_231(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_232(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_233(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_234(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_235(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_236(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_237(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_238(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_239(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_240(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_241(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_242(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_243(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_244(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_245(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_246(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_247(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_248(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_249(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_250(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_251(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_252(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_253(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_254(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_255(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_256(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_257(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_258(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_259(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_260(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_261(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_262(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_263(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_264(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_265(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_266(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_267(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_268(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_269(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_270(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_271(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_272(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_273(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_274(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_275(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_276(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_277(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_278(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_279(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_280(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_281(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_282(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_283(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_284(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_285(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_286(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_287(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_288(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_289(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_290(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_291(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_292(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_293(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_294(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_295(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_296(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_297(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_298(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_299(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_300(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_301(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_302(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_303(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_304(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_305(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_306(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_307(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_308(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_309(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_310(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_311(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_312(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_313(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_314(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_315(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_316(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_317(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_318(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_319(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_320(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_321(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_322(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_323(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_324(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_325(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_326(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_327(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_328(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_329(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_330(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_331(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_332(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_333(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_334(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_335(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_336(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_337(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_338(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_339(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_340(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_341(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_342(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_343(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_344(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_345(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_346(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_347(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_348(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_349(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_350(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_351(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_352(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_353(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_354(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_355(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_356(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_357(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_358(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_359(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_360(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_361(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_362(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_363(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_364(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_365(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_366(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_367(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_368(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_369(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_370(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_371(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_372(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_373(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_374(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_375(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_376(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_377(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_378(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_379(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_380(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_381(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_382(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_383(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_384(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_385(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_386(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_387(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_388(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_389(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_390(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_391(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_392(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_393(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_394(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_395(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_396(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_397(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_398(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_399(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_400(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_401(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_402(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_403(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_404(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_405(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_406(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_407(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_408(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_409(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_410(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_411(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_412(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_413(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_414(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_415(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_416(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_417(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_418(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_419(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_420(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_421(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_422(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_423(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_424(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_425(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_426(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_427(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_428(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_429(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_430(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_431(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_432(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_433(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_434(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_435(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_436(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_437(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_438(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_439(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_440(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_441(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_442(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_443(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_444(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_445(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_446(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_447(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_448(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_449(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_450(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_451(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_452(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_453(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_454(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_455(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_456(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_457(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_458(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_459(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_460(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_461(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_462(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_463(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_464(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_465(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_466(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_467(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_468(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_469(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_470(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_471(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_472(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_473(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_474(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_475(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_476(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_477(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_478(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_479(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_480(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_481(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_482(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_483(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_484(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_485(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_486(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_487(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_488(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_489(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_490(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_491(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_492(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_493(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_494(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_495(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_496(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_497(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_498(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_499(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_500(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_501(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_502(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_503(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_504(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_505(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_506(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_507(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_508(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_509(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_510(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_511(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_512(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_513(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_514(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_515(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_516(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_517(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_518(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_519(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_520(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_521(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_522(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_523(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_524(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_525(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_526(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_527(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_528(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_529(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_530(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_531(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_532(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_533(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_534(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_535(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_536(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_537(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_538(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_539(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_540(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_541(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_542(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_543(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_544(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_545(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_546(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_547(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_548(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_549(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_550(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_551(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_552(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_553(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_554(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_555(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_556(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_557(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_558(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_559(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_560(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_561(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_562(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_563(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_564(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_565(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_566(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_567(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_568(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_569(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_570(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_571(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_572(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_573(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_574(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_575(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_576(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_577(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_578(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_579(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_580(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_581(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_582(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_583(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_584(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_585(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_586(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_587(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_588(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_589(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_590(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_591(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_592(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_593(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_594(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_595(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_596(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_597(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_598(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_599(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_600(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_601(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_602(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_603(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_604(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_605(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_606(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_607(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_608(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_609(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_610(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_611(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_612(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_613(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_614(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_615(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_616(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_617(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_618(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_619(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_620(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_621(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_622(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_623(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_624(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_625(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_626(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_627(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_628(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_629(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_630(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_631(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_632(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_633(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_634(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_635(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_636(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_637(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_638(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_639(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_640(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_641(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_642(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_643(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_644(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_645(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_646(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_647(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_648(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_649(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_650(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_651(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_652(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_653(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_654(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_655(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_656(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_657(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_658(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_659(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_660(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_661(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_662(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_663(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_664(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_665(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_666(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_667(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_668(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_669(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_670(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_671(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_672(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_673(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_674(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_675(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_676(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_677(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_678(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_679(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_680(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_681(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_682(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_683(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_684(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_685(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_686(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_687(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_688(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_689(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_690(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_691(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_692(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_693(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_694(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_695(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_696(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_697(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_698(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_699(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_700(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_701(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_702(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_703(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_704(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_705(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_706(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_707(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_708(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_709(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_710(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_711(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_712(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_713(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_714(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_715(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_716(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_717(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_718(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_719(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_720(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_721(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_722(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_723(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_724(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_725(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_726(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_727(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_728(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_729(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_730(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_731(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_732(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_733(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_734(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_735(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_736(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_737(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_738(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_739(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_740(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_741(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_742(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_743(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_744(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_745(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_746(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_747(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_748(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_749(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_750(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_751(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_752(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_753(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_754(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_755(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_756(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_757(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_758(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_759(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_760(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_761(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_762(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_763(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_764(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_765(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_766(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_767(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_768(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_769(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_770(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_771(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_772(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_773(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_774(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_775(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_776(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_777(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_778(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_779(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_780(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_781(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_782(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_783(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_784(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_785(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_786(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_787(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_788(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_789(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_790(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_791(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_792(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_793(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_794(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_795(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_796(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_797(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_798(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_799(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_800(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_801(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_802(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_803(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_804(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_805(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_806(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_807(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_808(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_809(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_810(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_811(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_812(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_813(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_814(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_815(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_816(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_817(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_818(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_819(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_820(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_821(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_822(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_823(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_824(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_825(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_826(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_827(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_828(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_829(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_830(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_831(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_832(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_833(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_834(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_835(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_836(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_837(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_838(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_839(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_840(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_841(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_842(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_843(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_844(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_845(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_846(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_847(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_848(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_849(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_850(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_851(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_852(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_853(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_854(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_855(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_856(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_857(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_858(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_859(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_860(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_861(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_862(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_863(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_864(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_865(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_866(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_867(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_868(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_869(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_870(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_871(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_872(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_873(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_874(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_875(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_876(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_877(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_878(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_879(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_880(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_881(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_882(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_883(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_884(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_885(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_886(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_887(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_888(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_889(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_890(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_891(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_892(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_893(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_894(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_895(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_896(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_897(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_898(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_899(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_900(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+  function approve_901(address spender, uint value) public returns (bool ok) {
+    // TODO: should increase instead
+    _approvals[msg.sender][spender] = value;
+    emit Approval( msg.sender, spender, value );
+    return true;
+  }
+
+}

--- a/dapps/tests/app/config/contracts.js
+++ b/dapps/tests/app/config/contracts.js
@@ -31,6 +31,9 @@ module.exports = {
       AnotherStorage: {
         args: ["$SimpleStorage"]
         //args: ["0x0000000000000000000000000000000000000000"]
+      },
+      BFC: {
+        args: [100]
       }
     },
     afterDeploy: async (dependencies) => {

--- a/packages/plugins/ethereum-blockchain-client/package.json
+++ b/packages/plugins/ethereum-blockchain-client/package.json
@@ -44,6 +44,7 @@
     "@babel/runtime-corejs3": "7.6.3",
     "async": "2.6.1",
     "core-js": "3.3.4",
+    "embark-core": "^5.0.0-alpha.0",
     "embark-i18n": "^5.0.0-alpha.0",
     "embark-utils": "^5.0.0-alpha.0",
     "embarkjs": "^5.0.0-alpha.0",

--- a/packages/stack/blockchain-client/src/index.js
+++ b/packages/stack/blockchain-client/src/index.js
@@ -1,4 +1,5 @@
 const Web3 = require('web3');
+const constants = require('embark-core/constants');
 
 class BlockchainClient {
 
@@ -18,6 +19,16 @@ class BlockchainClient {
       this.events.request("proxy:endpoint:get", (err, endpoint) => {
         if (err) {
           return cb(err);
+        }
+        if (endpoint.startsWith('ws')) {
+          return cb(null, new Web3.providers.WebsocketProvider(endpoint, {
+            headers: {Origin: constants.embarkResourceOrigin},
+            // TODO remove this when Geth fixes this: https://github.com/ethereum/go-ethereum/issues/16846
+            //  Edit: This has been fixed in Geth 1.9, but we don't support 1.9 yet and still support 1.8
+            clientConfig: {
+              fragmentationThreshold: 81920
+            }
+          }));
         }
         const web3 = new Web3(endpoint);
         cb(null, web3.currentProvider);

--- a/packages/stack/proxy/package.json
+++ b/packages/stack/proxy/package.json
@@ -53,7 +53,8 @@
     "embark-utils": "^5.0.0-alpha.0",
     "express": "4.17.1",
     "express-ws": "4.0.0",
-    "web3-core-requestmanager": "1.2.1"
+    "web3-core-requestmanager": "1.2.1",
+    "web3-providers-ws": "1.2.1"
   },
   "devDependencies": {
     "@types/cors": "2.8.6",


### PR DESCRIPTION
This is a patch we had back in the day to fix big payloads when using WS providers.
It's because of a bug in Geth, it would not understand big payloads from web3, because it was split.
Increasing the threshold makes it so that the big payloads are not split