### PR TITLE
refactor(@embark/core/console): silence errors when autocomplete is attempted on bad reference

### DIFF
--- a/packages/core/code-runner/src/index.ts
+++ b/packages/core/code-runner/src/index.ts
@@ -52,7 +52,7 @@ class CodeRunner {
     this.vm.registerVar(varName, code, cb);
   }
 
-  private evalCode(code: string, cb: Callback<any>, tolerateError = false) {
+  private evalCode(code: string, cb: Callback<any>, tolerateError = false, logCode = true, logError = true) {
     cb = cb || (() => { });
 
     if (!code) {
@@ -61,8 +61,12 @@ class CodeRunner {
 
     this.vm.doEval(code, tolerateError, (err, result) => {
       if (err) {
-        this.logger.error(__("Error running code: %s", code));
-        this.logger.error(err.toString());
+        if (logCode) {
+          this.logger.error(__("Error running code: %s", code));
+        }
+        if (logError) {
+          this.logger.error(err.toString());
+        }
         return cb(err);
       }
 

--- a/packages/embark/src/cmd/dashboard/repl.js
+++ b/packages/embark/src/cmd/dashboard/repl.js
@@ -27,7 +27,7 @@ class REPL {
     this.events.request('console:executeCmd', cmd.trim(), function (err, message) {
       if (err) {
         // Do not return as the first param (error), because the dashboard doesn't print errors
-        return callback(null, err.red);
+        return callback(null, err.message ? err.message.red : err.red);
       }
       callback(null, message === undefined ? '' : message); // This way, we don't print undefined
     });
@@ -58,9 +58,9 @@ class REPL {
       hint = partial;
     }
 
-    this.events.request('console:executeCmd', context, (err, result)  => {
-      if (err !== null) {
-        cb(err, [[], partial]);
+    this.events.request('console:executePartial', context, (err, result)  => {
+      if (err || !result) {
+        return cb(null, [[], partial]);
       }
 
       let props = Object


### PR DESCRIPTION
In the embark cli dashboard/console, if you were to type `Foo.` and hit tab for autocomplete then (assuming you hadn't defined `Foo`) there would be unhandled errors and the console could even become unusable.

Refactor `packages/core/console` and related code so that nothing happens when you attempt to autocomplete a bad reference (the same behavior as Node's own REPL).