### PR TITLE
Fix embark test with --node

### DIFF
--- a/packages/plugins/geth/src/index.js
+++ b/packages/plugins/geth/src/index.js
@@ -41,7 +41,7 @@ class Geth {
         this.registerServiceCheck();
       },
       stopFn: async (cb) => {
-        await this.events.request("processes:stop", "blockchain");
+        await this.events.request2("processes:stop", "blockchain");
         cb();
       }
     });

--- a/packages/plugins/solidity/src/solcP.js
+++ b/packages/plugins/solidity/src/solcP.js
@@ -8,7 +8,6 @@ class SolcProcess extends ProcessWrapper {
     super({pingParent: false});
     this._logger = options.logger;
     this._showSpinner = options.showSpinner === true;
-    this._providerUrl = options.providerUrl;
   }
 
   findImports(filename) {


### PR DESCRIPTION
There were 2 issues:

- The IPC was connected, but the compiler was not loaded in the blockchain node, so the calls to the IPC hung
- There was a request with an `await`, so it needed `request2`