### PR TITLE
docs: remove docs for `service` command

### DIFF
--- a/site/source/docs/using_the_console.md
+++ b/site/source/docs/using_the_console.md
@@ -36,25 +36,6 @@ Embark (development) > help<ENTER>
 
 This is a good time to read a bit through the available commands and familiarize yourself with them.
 
-## Enabling and disabling processes
-
-There are several processes and services that Embark spins up to do its work (e.g. `geth` for blockchain process, `ipfs` as storage daemon, etc). Those are the same processes that are listed as "Available Services" in the dashboard.
-
-These processes can be enabled and disabled using the `service` command.
-
-Simply specify the process and turn it `on` or `off`:
-
-```
-Embark (development) > service ipfs off
-```
-
-The "Available Services" in the dashboard as well as Cockpit's dashboard will reflect the status of the processes as they are enabled and disabled.
-
-NOTE: There are two processes that cannot be started and stopped via console commands:
-1. **Embark** - The Embark process cannot stop and start itself.
-2. **Whisper** - Whisper cannot be started and stopped via a command because the blockchain process CLI parameters need to be modified and the blockchain process itself would need to be restarted. To disable Whisper, set `enabled: false` in the communications config, then restart Embark. To enable Whisper, set `enabled: true` in the communications config, then restart Embark.
-
-
 ## Enabling and disabling process logs
 
 By default, Embark will log output from all processes into the console. Since this can get quite verbose sometimes, we can disable logging for certain processes using the `log` command.
@@ -97,7 +78,7 @@ Embark (development) > await web3.eth.getAccounts()<ENTER>
 
 ## Installing plugins
 
-We can also install Embark plugins using the interactive console. This can be done using the `plugin` command. 
+We can also install Embark plugins using the interactive console. This can be done using the `plugin` command.
 
 ```
 Embark (development) > plugin install embark-status


### PR DESCRIPTION
As discussed in #2008, the `service on/off` command in Embark's interactive console
is non-functioning. As solving the root of the problem requires a bit more effort
than anticipated, we've decided offline to remove this command for the time-being.

The functionality is already gone, this commit removes the corresponding docs.