### PR TITLE
fix(@embark/cockpit): ensure correct data is send to web3's `ecRecover`

### DIFF
--- a/packages/plugins/ethereum-blockchain-client/src/api.js
+++ b/packages/plugins/ethereum-blockchain-client/src/api.js
@@ -407,6 +407,6 @@ export default class EthereumAPI {
   }
 
   async verifyMessage(message, signature) {
-    return this.web3.eth.personal.ecRecover(signature.message, signature.signature);
+    return this.web3.eth.personal.ecRecover(message, signature);
   }
 }


### PR DESCRIPTION
We've introduced a regression in https://github.com/embark-framework/embark/commit/f9557d4c9 where invalid data
has been sent to web3's `ecRecover()` method to verify signed messages.

This causes an internal server error and the utility feature inside Cockpit
unsuable.

This commit ensures that the correct data is sent to `ecRecover()` making verifying
messages through Cockpit functional again.