### PR TITLE
fix(@embark/console): ensure Cockpit is only started in non-secondary…

### DIFF
--- a/packages/embark/src/cmd/cmd_controller.js
+++ b/packages/embark/src/cmd/cmd_controller.js
@@ -380,7 +380,9 @@ class EmbarkController {
         engine.registerModuleGroup("webserver");
         engine.registerModuleGroup("filewatcher");
         engine.registerModuleGroup("storage");
-        engine.registerModuleGroup("cockpit");
+        if (!isSecondaryProcess(engine)) {
+          engine.registerModuleGroup("cockpit");
+        }
         engine.registerModulePackage('embark-deploy-tracker', {plugins: engine.plugins});
 
         callback();


### PR DESCRIPTION
… mode

`embark console` registers and tries to spin up `Cockpit`, even when there's already
a Cockpit instance running and thefore exits with an error that a certain port is already
in use.

This commit ensures that Cockpit is only bootstrapped when `embark console` is
executed as a non-secondary process, meaning that there's no other `embark run`
process active that might occupy Cockpit's default port.