### PR TITLE
Add priority to registerActionsForEvents and fix funding accounts

### DIFF
--- a/dapps/tests/app/test/another_storage_spec.js
+++ b/dapps/tests/app/test/another_storage_spec.js
@@ -4,13 +4,15 @@ const AnotherStorage = require('Embark/contracts/AnotherStorage');
 const SimpleStorage = require('Embark/contracts/SimpleStorage');
 
 let accounts, defaultAccount;
+const numAddresses = 10;
 
 config({
   blockchain: {
     "accounts": [
       {
         "mnemonic": "example exile argue silk regular smile grass bomb merge arm assist farm",
-        balance: "5ether"
+        balance: "5ether",
+        numAddresses: 10
       }
     ]
   },
@@ -40,6 +42,16 @@ contract("AnotherStorage", function() {
     const balance = await web3.eth.getBalance(accounts[0]);
     assert.ok(parseInt(balance, 10) > 4900000000000000000);
     assert.ok(parseInt(balance, 10) <= 5000000000000000000);
+  });
+
+  it("should have the right balance for all other accounts ", async function() {
+    let balance;
+
+    for (let i = 1; i < numAddresses - 3; i++) {
+      balance = await web3.eth.getBalance(accounts[i]);
+      console.log('Account', i , balance);
+      assert.strictEqual(parseInt(balance, 10), 5000000000000000000, `Account ${i} doesn't have the balance set`);
+    }
   });
 
   it("set SimpleStorage address", async function() {

--- a/packages/embark/src/lib/core/plugin.js
+++ b/packages/embark/src/lib/core/plugin.js
@@ -5,6 +5,9 @@ const constants = require('embark-core/constants');
 const fs = require('fs-extra');
 const deepEqual = require('deep-equal');
 
+// Default priority of actions with no specified priority. 1 => Highest
+const DEFAULT_ACTION_PRIORITY = 50;
+
 // TODO: pass other params like blockchainConfig, contract files, etc..
 var Plugin = function(options) {
   this.name = options.name;
@@ -261,11 +264,15 @@ Plugin.prototype.registerImportFile = function(importName, importLocation) {
   this.addPluginType('imports');
 };
 
-Plugin.prototype.registerActionForEvent = function(eventName, cb) {
+Plugin.prototype.registerActionForEvent = function(eventName, options, cb) {
+  if (typeof options === 'function') {
+    cb = options;
+    options = {};
+  }
   if (!this.eventActions[eventName]) {
     this.eventActions[eventName] = [];
   }
-  this.eventActions[eventName].push(cb);
+  this.eventActions[eventName].push({action: cb, options: Object.assign({priority: DEFAULT_ACTION_PRIORITY}, options)});
   this.addPluginType('eventActions');
 };
 

--- a/packages/embark/src/lib/core/plugins.js
+++ b/packages/embark/src/lib/core/plugins.js
@@ -218,19 +218,31 @@ Plugins.prototype.runActionsForEvent = function(eventName, args, cb) {
     return cb(null, args);
   }
 
+  actionPlugins.sort((a, b) => {
+    const aPriority = a[0].options.priority;
+    const bPriority = b[0].options.priority;
+    if (aPriority < bPriority) {
+      return -1;
+    }
+    if (aPriority > bPriority) {
+      return 1;
+    }
+    return 0;
+  });
+
   this.events.log("ACTION", eventName, "");
 
   async.reduce(actionPlugins, args, function (current_args, pluginObj, nextEach) {
     const [plugin, pluginName] = pluginObj;
 
-    self.events.log("== ACTION FOR " + eventName, plugin.name, pluginName);
+    self.events.log("== ACTION FOR " + eventName, plugin.action.name, pluginName);
 
     if (typeof (args) === 'function') {
-      plugin.call(plugin, (...params) => {
+      plugin.action.call(plugin.action, (...params) => {
         nextEach(...params || current_args);
       });
     } else {
-      plugin.call(plugin, args, (...params) => {
+      plugin.action.call(plugin.action, args, (...params) => {
         nextEach(...params || current_args);
       });
     }

--- a/packages/embark/src/test/plugins.spec.js
+++ b/packages/embark/src/test/plugins.spec.js
@@ -1,0 +1,60 @@
+/*global __dirname, describe, it, beforeEach, afterEach, require*/
+import * as i18n from 'embark-i18n';
+
+const {fakeEmbark} = require('embark-testing');
+const assert = require('assert');
+const sinon = require('sinon');
+const Plugins = require('../lib/core/plugins');
+i18n.setOrDetectLocale('en');
+
+describe('embark.plugins', function() {
+  this.timeout(0);
+  let plugins;
+  const {embark} = fakeEmbark();
+  embark.events.log = () => {};
+
+  beforeEach(() => {
+    plugins = new Plugins(embark);
+  });
+
+  afterEach(() => {
+    embark.teardown();
+  });
+
+  describe('runActionsForEvent', () => {
+    it('should run actions in order of priority', (done) => {
+      let lastFunctionSetsMeToTrue = false;
+      const getPluginsPropertyAndPluginNameStub = sinon.stub(plugins, 'getPluginsPropertyAndPluginName')
+        .returns([
+          [
+            {
+              action: (_params, cb) => {
+                // This function should be called second
+                lastFunctionSetsMeToTrue = true;
+                cb();
+              },
+              options: {priority: 50}
+            },
+            'Action 2'
+          ],
+          [
+            {
+              action: (_params, cb) => {
+                // If this is called first, setting to false doesn't matter
+                lastFunctionSetsMeToTrue = false;
+                cb();
+              },
+              options: {priority: 30}
+            },
+            'Action 1'
+          ]
+        ]);
+
+      plugins.runActionsForEvent('bogusEvent', [], () => {
+        assert.strictEqual(lastFunctionSetsMeToTrue, true, 'Functions not called in order');
+        getPluginsPropertyAndPluginNameStub.restore();
+        done();
+      });
+    });
+  });
+});

--- a/packages/plugins/accounts-manager/src/index.ts
+++ b/packages/plugins/accounts-manager/src/index.ts
@@ -148,12 +148,16 @@ export default class AccountsManager {
     }
     try {
       const coinbase = await web3.eth.getCoinbase();
-      const fundingAccounts = this.accounts
-        .filter((account) => account.address)
-        .map((account) => {
-          return fundAccount(web3, account.address, coinbase, account.hexBalance);
+      const accts = this.accounts
+        .filter((account) => account.address);
+
+      async.eachLimit(accts, 1, (acct, eachCb) => {
+        fundAccount(web3, acct.address, coinbase, acct.hexBalance)
+          .then(() => {
+            eachCb();
+          })
+          .catch(eachCb);
       });
-      await Promise.all([fundingAccounts]);
     } catch (err) {
       this.logger.error(__("Error funding accounts"), err.message || err);
     }

--- a/packages/plugins/web3/src/index.js
+++ b/packages/plugins/web3/src/index.js
@@ -18,7 +18,7 @@ class EmbarkWeb3 {
 
     this.setupEmbarkJS();
 
-    embark.registerActionForEvent("deployment:contract:deployed", this.registerInVm.bind(this));
+    embark.registerActionForEvent("deployment:contract:deployed", {priority: 40}, this.registerInVm.bind(this));
     embark.registerActionForEvent("deployment:contract:undeployed", this.registerInVm.bind(this));
     embark.registerActionForEvent("deployment:contract:deployed", this.registerArtifact.bind(this));
     embark.registerActionForEvent("deployment:contract:undeployed", this.registerArtifact.bind(this));


### PR DESCRIPTION
Those are problems that were found while testing Teller with the new V5 release.

The priority was added because, with the refactor, for the event `deployment:contract:deployed`, multiple actions are fired at the same time in a "random" order that could cause a race condition where the `onDeploy` hooks could fire before the registrations in the VM, making some contracts fail to use their own Contract object.

The fund account issue is because we can't call multiple TXs in parallel on the node, otherwise we have nonce issues. IE all transactions will have the same nonce because they are sent at the same time.

I added tests for the respective fixes and features