### PR TITLE
refactor(@embark/library-manager): restrict versionable packages to only solc

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -7,13 +7,7 @@
   "extends": [
     "eslint:recommended"
   ],
-  "parserOptions": {
-    "ecmaFeatures": {
-      "jsx": true
-    },
-    "ecmaVersion": 2018,
-    "sourceType": "module"
-  },
+  "parser": "babel-eslint",
   "plugins": [
     "react"
   ],

--- a/dapps/templates/boilerplate/embark.json
+++ b/dapps/templates/boilerplate/embark.json
@@ -9,9 +9,7 @@
   "buildDir": "dist/",
   "config": "config/",
   "versions": {
-    "web3": "1.2.1",
-    "solc": "0.5.0",
-    "ipfs-api": "17.2.4"
+    "solc": "0.5.0"
   },
   "plugins": {
   },

--- a/dapps/templates/demo/embark.json
+++ b/dapps/templates/demo/embark.json
@@ -9,9 +9,7 @@
   "buildDir": "dist/",
   "config": "config/",
   "versions": {
-    "web3": "1.2.1",
-    "solc": "0.5.0",
-    "ipfs-api": "17.2.4"
+    "solc": "0.5.0"
   },
   "plugins": {
   },

--- a/dapps/tests/app/embark.json
+++ b/dapps/tests/app/embark.json
@@ -15,9 +15,7 @@
   "buildDir": "dist/",
   "config": "config/",
   "versions": {
-    "solc": "0.4.25",
-    "web3": "1.2.1",
-    "ipfs-api": "17.2.7"
+    "solc": "0.4.25"
   },
   "plugins": {
     "embark-dapp-test-service": {}

--- a/dapps/tests/contracts/embark.json
+++ b/dapps/tests/contracts/embark.json
@@ -12,7 +12,6 @@
     "namesystem": "ens.json"
   },
   "versions": {
-    "web3": "1.2.1",
     "solc": "0.4.24"
   },
   "plugins": {

--- a/package.json
+++ b/package.json
@@ -1,5 +1,6 @@
 {
   "devDependencies": {
+    "babel-eslint": "10.0.3",
     "chalk": "2.4.2",
     "coveralls": "3.0.6",
     "find-up": "4.1.0",

--- a/packages/core/console/suggestions.json
+++ b/packages/core/console/suggestions.json
@@ -33,7 +33,7 @@
     {
       "value": "versions",
       "command_type": "embark command",
-      "description": "display versions in use for libraries and tools like web3 and solc"
+      "description": "display versions in use for libraries and tools like solc"
     },
     {
       "value": "ipfs",

--- a/packages/core/i18n/locales/en.json
+++ b/packages/core/i18n/locales/en.json
@@ -67,7 +67,7 @@
   "Webserver": "Webserver",
   "versions": "versions",
   "possible commands are:": "possible commands are:",
-  "display versions in use for libraries and tools like web3 and solc": "display versions in use for libraries and tools like web3 and solc",
+  "display versions in use for libraries and tools like solc": "display versions in use for libraries and tools like solc",
   "instantiated web3.js object configured to the current environment": "instantiated web3.js object configured to the current environment",
   "to immediatly exit (alias: exit)": "to immediatly exit (alias: exit)",
   "The web3 object and the interfaces for the deployed contracts and their methods are also available": "The web3 object and the interfaces for the deployed contracts and their methods are also available",

--- a/packages/core/i18n/locales/es.json
+++ b/packages/core/i18n/locales/es.json
@@ -10,7 +10,7 @@
    "loading solc compiler": "cargando el compilador solc",
    "Welcome to Embark": "Bienvenido a Embark",
    "possible commands are:": "los comandos posibles son:",
-   "display versions in use for libraries and tools like web3 and solc": "mostrar versiones en uso para bibliotecas y herramientas como web3 y solc",
+   "display versions in use for libraries and tools like solc": "mostrar versiones en uso para bibliotecas y herramientas como solc",
    "instantiated web3.js object configured to the current environment": "objeto web3.js instanciado ha sido configurado para el entorno actual",
    "to immediatly exit (alias: exit)": "para salir inmediatamente (alias: exit)",
    "The web3 object and the interfaces for the deployed contracts and their methods are also available": "El objeto web3 y las interfaces para los contratos desplegados y sus métodos también están disponibles",

--- a/packages/core/i18n/locales/fr.json
+++ b/packages/core/i18n/locales/fr.json
@@ -10,7 +10,7 @@
   "loading solc compiler": "chargement du compilateur solc",
   "Welcome to Embark": "Bienvenue sur Embark",
   "possible commands are:": "les commandes possibles sont:",
-  "display versions in use for libraries and tools like web3 and solc": "liste des versions utilisées pour les bibliothèques et les outils comme web3 et solc",
+  "display versions in use for libraries and tools like solc": "liste des versions utilisées pour les bibliothèques et les outils comme solc",
   "instantiated web3.js object configured to the current environment": "objet web3.js instancié configuré pour l'environnement actuel",
   "to immediatly exit (alias: exit)": "quitter immédiatement (alias: exit)",
   "The web3 object and the interfaces for the deployed contracts and their methods are also available": "L'objet web3 et les interfaces avec les contrats déployés et leurs méthodes sont également disponibles",

--- a/packages/core/i18n/locales/pt.json
+++ b/packages/core/i18n/locales/pt.json
@@ -10,7 +10,7 @@
   "loading solc compiler": "carregando o compilador solc",
   "Welcome to Embark": "Bem-vindo ao Embark",
   "possible commands are:": "comandos possíveis são:",
-  "display versions in use for libraries and tools like web3 and solc": "lista versões em uso para bibliotecas e ferramentas como web3 e solc",
+  "display versions in use for libraries and tools like solc": "lista versões em uso para bibliotecas e ferramentas como solc",
   "instantiated web3.js object configured to the current environment": "objeto web3.js instanciado configurado para o ambiente atual",
   "to immediatly exit (alias: exit)": "para sair imediatamente (atalho: exit)",
   "The web3 object and the interfaces for the deployed contracts and their methods are also available": "O objeto web3 e as interfaces para os contratos implantados e seus métodos também estão disponíveis",

--- a/packages/core/i18n/locales/sl.json
+++ b/packages/core/i18n/locales/sl.json
@@ -67,7 +67,7 @@
   "Webserver": "Spletni strežnik",
   "versions": "različice",
   "possible commands are:": "možni ukazi so:",
-  "display versions in use for libraries and tools like web3 and solc": "pokaži različice v uporabi za orodja kot sta web3 in solc",
+  "display versions in use for libraries and tools like solc": "pokaži različice v uporabi za orodja kot sta solc",
   "instantiated web3.js object configured to the current environment": "nameščen web3.js objekt nastavljen za uporabo v trenutnem okolju",
   "to immediatly exit (alias: exit)": "za takojšnji izhod (alias: exit)",
   "The web3 object and the interfaces for the deployed contracts and their methods are also available": "Web3 objekt in The web3 object and the vmesniki so na voljo",

--- a/packages/embark/src/lib/core/config.js
+++ b/packages/embark/src/lib/core/config.js
@@ -487,11 +487,8 @@ Config.prototype.loadExternalContractsFiles = function() {
 };
 
 Config.prototype.loadStorageConfigFile = function() {
-  var versions = recursiveMerge({"ipfs-api": "17.2.4"}, this.embarkConfig.versions || {});
-
   var configObject = {
     "default": {
-      "versions": versions,
       "enabled": true,
       "available_providers": ["ipfs", "swarm"],
       "ipfs_bin": "ipfs",

--- a/packages/embark/src/lib/core/configDefaults.js
+++ b/packages/embark/src/lib/core/configDefaults.js
@@ -39,7 +39,6 @@ export function getBlockchainDefaults(env) {
 
 export function getContractDefaults(embarkConfigVersions) {
   const defaultVersions = {
-    "web3": "1.2.1",
     "solc": "0.5.0"
   };
   const versions = recursiveMerge(defaultVersions, embarkConfigVersions || {});

--- a/packages/embark/src/test/config.js
+++ b/packages/embark/src/test/config.js
@@ -197,7 +197,7 @@ describe('embark.Config', function () {
     it('should load contract config correctly', function () {
       config.loadContractsConfigFile();
       let expectedConfig = {
-        versions: {'web3': '1.2.1', solc: '0.5.0'},
+        versions: {solc: '0.5.0'},
         dappConnection: ['$WEB3', 'localhost:8545'],
         dappAutoEnable: true,
         "gas": "400000",
@@ -219,7 +219,7 @@ describe('embark.Config', function () {
 
     it('should replace occurrences of `0x0` with full zero addresses', () => {
       let expectedConfig = {
-        versions: {'web3': '1.2.1', solc: '0.5.0'},
+        versions: {solc: '0.5.0'},
         dappConnection: ['$WEB3', 'localhost:8545'],
         dappAutoEnable: true,
         "gas": "auto",

--- a/packages/embark/src/test/contracts.js
+++ b/packages/embark/src/test/contracts.js
@@ -89,7 +89,6 @@ describe('embark.Contracts', function() {
 
     contractsConfig = {
       "versions": {
-        "web3": "1.2.1",
         "solc": "0.4.17"
       },
       "deployment": {
@@ -213,7 +212,6 @@ describe('embark.Contracts', function() {
 
     contractsConfig = {
       "versions": {
-        "web3": "1.2.1",
         "solc": "0.4.17"
       },
       "deployment": {

--- a/site/source/docs/configuration.md
+++ b/site/source/docs/configuration.md
@@ -22,9 +22,7 @@ Every application [created with Embark](create_project.html) comes with an `emba
   "generationDir": "embarkArtifacts",
   "config": "config/",
   "versions": {
-    "web3": "1.2.1",
-    "solc": "0.4.25",
-    "ipfs-api": "17.2.4"
+    "solc": "0.4.25"
   },
   "plugins": {
   },
@@ -92,7 +90,9 @@ This is the location of the configuration files. There are different options to 
 
 ### versions (3rd-party libraries)
 
-Here you can optionally specify the versions of the library to be used by Embark. Embark will automatically download the specific library version if necessary. It's possible to override this in other configuration files such as `contracts.json` on a per environment basis.
+Here you can optionally specify the versions of the library to be used by Embark. Embark will automatically download the specific library version if necessary.
+
+Currently, `solc` is the only library that can be specified in this way. It's possible to override the `solc` version in other configuration files such as `contracts.json` on a per environment basis.
 
 ### plugins
 

--- a/site/source/docs/storage_configuration.md
+++ b/site/source/docs/storage_configuration.md
@@ -25,10 +25,7 @@ module.exports = {
     "dappConnection":[
       {"provider": "swarm", "host": "localhost", "port": 8500, "getUrl": "http://localhost:8500/bzz:/"},
       {"provider": "ipfs", "host": "localhost", "port": 5001, "getUrl": "http://localhost:8080/ipfs/"}
-    ],
-    "versions": {
-      "ipfs-api": "17.2.4"
-    }
+    ]
   },
   "development": {
     "enabled": true,
@@ -41,8 +38,8 @@ module.exports = {
 
 The available options are:
 
-Option | Type: `default` | Value         
---- | --- | --- 
+Option | Type: `default` | Value
+--- | --- | ---
 `enabled`    | boolean: `true` | Enables or completely disables storage support
 `ipfs_bin`    | string: `ipfs` | Name or desired path to the ipfs binary
 `available_providers`    | array: `["ipfs", "swarm"]` | List of storages to be supported on the dapp. This will affect what's available with the EmbarkJS library on the dapp.
@@ -53,12 +50,11 @@ Option | Type: `default` | Value
 `upload.port`        | integer: `5001` | Port value used to interact with the storage provider for upload, i.e. `5001` (IPFS local node) or `8500` (Swarm local node) or `80`
 `upload.getUrl`      | string: `http://localhost:8080/ipfs/` | Only for IPFS. This sets the file/document retrieval URL, which is different than the host/port combination used to interact with the IPFS API.
 `dappConnection`     | | List of storage providers to attempt connection to in the dapp. Each provider process will be launched in a child process. Each connection listed will be tried in order on the dapp, until one is avaialable. Can also specify `$BZZ` to attempt to connect to an injected swarm object.
-`dappConnection.provider` | string: `ipfs` | Desired provider to use for dapp storage. 
+`dappConnection.provider` | string: `ipfs` | Desired provider to use for dapp storage.
 `dappConnection.protocol`    | string: `http` | Storage provider protocol used in the dapp, i.e. `http` or `https`
 `dappConnection.host`        | string | Host value used to interact with the storage provider in the dapp, i.e. `localhost` or `swarm-gateways.net`
 `dappConnection.port`        | integer | Port value used to interact with the storage provider in the dapp, i.e. `5001` (IPFS local node) or `8500` (Swarm local node) or `80`. Can specify `false` if a port should not be included in the connection URL (i.e. for a public gateway like `http://swarm-gateways.net`).
 `dappConnection.getUrl`      | string | Only for IPFS. This sets the file/document retrieval URL, which is different than the host/port combination used to interact with the IPFS API.
-`versions`    | object | key-value hash of library and its desired version
 
 ## Using a local node
 
@@ -130,4 +126,3 @@ NOTE: `http://localhost:8545` and `ws://localhost:8546` are for geth.
 ```
 swarm --bzzaccount=fedda09fd9218d1ea4fd41ad44694fa4ccba1878 --datadir=~/.bzz-data/ --password=config/development/password --corsdomain=http://localhost:8000,http://localhost:8080,http://localhost:8545,ws://localhost:8546 --ens-api=''
 ```
-


### PR DESCRIPTION
BREAKING CHANGE:

Remove support for specifying the versions of `web3` and `ipfs-api` in a project's `embark.json`.