### PR TITLE
feat(@embark/plugins/geth): bump min supported geth version from 1.8.14 to 1.9.7

### DIFF
--- a/packages/plugins/geth/src/gethClient.js
+++ b/packages/plugins/geth/src/gethClient.js
@@ -9,7 +9,7 @@ const constants = require('embark-core/constants');
 
 const DEFAULTS = {
   "BIN": "geth",
-  "VERSIONS_SUPPORTED": ">=1.8.14",
+  "VERSIONS_SUPPORTED": ">=1.9.7",
   "NETWORK_TYPE": "custom",
   "NETWORK_ID": 1337,
   "RPC_API": ['eth', 'web3', 'net', 'debug', 'personal'],

--- a/packages/plugins/geth/src/whisperClient.js
+++ b/packages/plugins/geth/src/whisperClient.js
@@ -6,7 +6,7 @@ const constants = require('embark-core/constants');
 
 const DEFAULTS = {
   "BIN": "geth",
-  "VERSIONS_SUPPORTED": ">=1.8.14",
+  "VERSIONS_SUPPORTED": ">=1.9.7",
   "NETWORK_TYPE": "custom",
   "NETWORK_ID": 1337,
   "RPC_API": ['eth', 'web3', 'net', 'debug', 'personal'],


### PR DESCRIPTION
This PR is in a draft state at the moment because I'm not 100% sure how to best scope the commit — feat, perf, build, refactor?

Also, since embark only prints a warning re: geth versions that are older than the minimum supported version, should this be considered a breaking change or not?