### PR TITLE
bugfix (@embark/embarkjs): fix required Web3 object so it can support…

### DIFF
--- a/packages/embarkjs/web3/src/index.js
+++ b/packages/embarkjs/web3/src/index.js
@@ -1,6 +1,6 @@
 /* global global require */
 
-const Web3 = global.Web3 || require('web3');
+const Web3 = require('web3');
 const __embarkWeb3 = {};
 
 __embarkWeb3.init = function(config) {


### PR DESCRIPTION
… brave and other browser not injecting a Web3 object with websockets