### PR TITLE
Enable modules in tests

### DIFF
--- a/dapps/tests/app/test/embarkJS_spec.js
+++ b/dapps/tests/app/test/embarkJS_spec.js
@@ -20,8 +20,7 @@ config({
 });
 
 describe("EmbarkJS functions", function() {
-  // FIXME ENS integration need to be added back to the tests
-  xit('should have access to ENS functions and registered test.eth', async function() {
+  it('should have access to ENS functions and registered test.eth', async function() {
     const rootAddress = await EmbarkJS.Names.resolve('test.eth');
     assert.strictEqual(rootAddress, web3.eth.defaultAccount);
 

--- a/dapps/tests/app/test/namesystem_spec.js
+++ b/dapps/tests/app/test/namesystem_spec.js
@@ -33,8 +33,7 @@ config({
 });
 
 describe("ENS functions", function() {
-  // FIXME Re-enable when ENS is fixed for tests
-  xit('should allow directives in ENS subdomains', async function() {
+  it('should allow directives in ENS subdomains', async function() {
     const myTokenAddress = await EmbarkJS.Names.resolve('mytoken.embark.eth');
     assert.strictEqual(MyToken.options.address, myTokenAddress);
 

--- a/dapps/tests/app/test/token_spec.js
+++ b/dapps/tests/app/test/token_spec.js
@@ -1,4 +1,4 @@
-/*global describe, config, it, web3, xit*/
+/*global describe, config, it, web3*/
 const assert = require('assert');
 const Token = require('Embark/contracts/Token');
 const MyToken = require('Embark/contracts/MyToken');
@@ -95,8 +95,7 @@ describe("Token", function() {
       assert.ok(!SomeContract.options.address);
     });
 
-    // FIXME when ENS is activated in tests again
-    xit("should set the ens attr to the address of embark.eth", async function() {
+    it("should set the ens attr to the address of embark.eth", async function() {
       const result = await Test.methods.ens().call();
       // Testing that it is an address as we don't really know the address
       assert.strictEqual(web3.utils.isAddress(result), true);

--- a/dapps/tests/contracts/ens.json
+++ b/dapps/tests/contracts/ens.json
@@ -1,7 +1,8 @@
 {
   "default" : {
     "enabled": true,
-    "available_providers": "ens",
+    "available_providers": ["ens"],
+    "provider": "ens",
     "register": {
       "rootDomain": "embark.eth"
     }

--- a/dapps/tests/contracts/test/another_storage_spec.js
+++ b/dapps/tests/contracts/test/another_storage_spec.js
@@ -13,11 +13,8 @@ config({
       "SimpleStorage": {
         args: [100]
       },
-      // "AnotherStorage": {
-      //   args: ["$SimpleStorage", "embark.eth"]
-      // },
       "AnotherStorage": {
-        args: ["$SimpleStorage", "$SimpleStorage"]
+        args: ["$SimpleStorage", "embark.eth"]
       }
     }
   }
@@ -33,8 +30,7 @@ contract("AnotherStorage", function() {
     assert.equal(result.toString(), SimpleStorage.options.address);
   });
 
-  // FIXME add back when the ENS feature is back
-  xit("set ENS address", async function() {
+  it("set ENS address", async function() {
     const result = await AnotherStorage.methods.ens().call();
     assert.equal(result.toString(), accounts[0]);
   });

--- a/packages/embark/src/cmd/cmd_controller.js
+++ b/packages/embark/src/cmd/cmd_controller.js
@@ -749,6 +749,7 @@ class EmbarkController {
         engine.registerModuleGroup("pipeline");
         engine.registerModuleGroup("tests", options);
         engine.registerModulePackage('embark-deploy-tracker', {plugins: engine.plugins, trackContracts: false});
+        engine.registerModuleGroup("namesystem");
 
         engine.startEngine(next);
       },

--- a/packages/embark/src/cmd/cmd_controller.js
+++ b/packages/embark/src/cmd/cmd_controller.js
@@ -750,8 +750,19 @@ class EmbarkController {
         engine.registerModuleGroup("tests", options);
         engine.registerModulePackage('embark-deploy-tracker', {plugins: engine.plugins, trackContracts: false});
         engine.registerModuleGroup("namesystem");
+        engine.registerModuleGroup("storage");
+        engine.registerModuleGroup("communication");
 
         engine.startEngine(next);
+      },
+      function startNodes(next) {
+        Promise.all([
+          engine.events.request2("storage:node:start", engine.config.storageConfig),
+          engine.events.request2("communication:node:start", engine.config.communicationConfig),
+          engine.events.request2("namesystem:node:start", engine.config.namesystemConfig)
+        ]).then(() => {
+          next();
+        }).catch(next);
       },
       function setupTestEnvironment(next) {
         engine.events.request2('tests:run', options, next);

--- a/packages/plugins/ens/package.json
+++ b/packages/plugins/ens/package.json
@@ -49,6 +49,7 @@
     "embarkjs": "^5.0.0-alpha.1",
     "embarkjs-ens": "^5.0.0-alpha.1",
     "eth-ens-namehash": "2.0.8",
+    "lodash.clonedeep": "4.5.0",
     "web3": "1.2.1"
   },
   "devDependencies": {

--- a/packages/plugins/mocha-tests/src/lib/index.js
+++ b/packages/plugins/mocha-tests/src/lib/index.js
@@ -68,15 +68,9 @@ class MochaTestRunner {
             });
           },
           (next) => {
-            events.request('tests:config:check', cfg, (err, needResetEmbarkJS) => {
+            events.request('tests:config:check', cfg, (err) => {
               if (err) {
                 return next(err);
-              }
-              if (needResetEmbarkJS) {
-                // TODO add back this event?
-                // events.request("runcode:embarkjs:reset", (err) => {
-                //   next(err, accounts);
-                // });
               }
               next();
             });

--- a/packages/stack/embarkjs/src/index.js
+++ b/packages/stack/embarkjs/src/index.js
@@ -88,7 +88,12 @@ class EmbarkJS {
     if (stackName === 'storage') {
       code = `EmbarkJS.${moduleName}.setProviders(${JSON.stringify(config)});`;
     } else if (stackName === 'blockchain') {
-      code = `EmbarkJS.${moduleName}.setProvider('${pluginName}', ${config});`;
+      const endpoint = await this.events.request2("proxy:endpoint:get");
+      const dappConnectionConfig = {
+        dappConnection: [endpoint]
+      };
+      code = `EmbarkJS.${moduleName}.setProvider('${pluginName}', ${config});
+              EmbarkJS.Blockchain.connect(${JSON.stringify(dappConnectionConfig)}, (err) => {if (err) { console.error(err); } });`;
     } else {
       code = `EmbarkJS.${moduleName}.setProvider('${pluginName}', ${JSON.stringify(config)});`;
     }

--- a/packages/stack/namesystem/src/index.js
+++ b/packages/stack/namesystem/src/index.js
@@ -38,7 +38,6 @@ export default class Namesystem {
     });
   }
 
-  // TODO START PLS
   startNode(namesystemConfig, cb) {
     if (!namesystemConfig.enabled) {
       return cb();

--- a/packages/stack/test-runner/src/lib/index.js
+++ b/packages/stack/test-runner/src/lib/index.js
@@ -1,5 +1,5 @@
 import { __ } from 'embark-i18n';
-import {buildUrl, deconstructUrl, recursiveMerge, prepareContractsConfig} from "embark-utils";
+import {buildUrl, deconstructUrl, recursiveMerge} from "embark-utils";
 const assert = require('assert').strict;
 const async = require('async');
 const chalk = require('chalk');
@@ -32,9 +32,7 @@ class TestRunner {
     this.simOptions = {};
 
     this.moduleConfigs = {
-      namesystem: {},
-      storage: {},
-      communication: {}
+      namesystem: {}
     };
 
     this.events.setCommandHandler('tests:run', (options, callback) => {


### PR DESCRIPTION
With this, you can now change, per test, the ENS config. That way, you could have the root domain be `embark.eth` in test A, and in test B, the root domain could be `testb.eth`.

For storage and communication, you can start them too, but only at the start of the tests, using the config file with the `test` environment. I tied enabling the ability to change those per test, but it's way more painful, because there is an actual node that needs to stop