### PR TITLE
chore(@embark/utils): improve error handling for downloading file con…

### DIFF
--- a/packages/core/utils/src/file.ts
+++ b/packages/core/utils/src/file.ts
@@ -60,7 +60,7 @@ export class File {
   }
 
   public get content(): Promise<string> {
-    return new Promise<string>((resolve) => {
+    return new Promise<string>((resolve, reject) => {
       switch (this.type) {
         case Types.embarkInternal: {
           const content = fs.readFileSync(embarkPath(path.join('dist', this.path)), 'utf-8');
@@ -80,7 +80,10 @@ export class File {
 
         case Types.http: {
           fs.ensureFileSync(this.path);
-          return downloadFile(this.externalUrl, this.path, () => {
+          return downloadFile(this.externalUrl, this.path, err => {
+            if (err) {
+              reject(err);
+            }
             const content = fs.readFileSync(this.path, 'utf-8');
             resolve(content);
           });


### PR DESCRIPTION
…tents

Embark's `File.content` is an asynchrononus getter that potentially downloads the
contents of a file from its `externalUrl`. This can potentially fail but is not properly
reported to the user as the error itself is ignored.

This commit ensures errors are propagated and displayed to the user.