### PR TITLE
fix(@embark/proxy): Fix unsubsribe handling and add new provider

### DIFF
--- a/dapps/tests/app/app/contracts/simple_storage.sol
+++ b/dapps/tests/app/app/contracts/simple_storage.sol
@@ -4,7 +4,7 @@ contract SimpleStorage {
   uint public storedData;
   address public registar;
   address owner;
-  event EventOnSet2(bool passed, string message);
+  event EventOnSet2(bool passed, string message, uint setValue);
 
   constructor(uint initialValue) public {
     storedData = initialValue;
@@ -20,7 +20,7 @@ contract SimpleStorage {
 
   function set2(uint x) public {
     storedData = x;
-    emit EventOnSet2(true, "hi");
+    emit EventOnSet2(true, "hi", x);
   }
 
   function set3(uint x) public {

--- a/dapps/tests/app/test/simple_storage_spec.js
+++ b/dapps/tests/app/test/simple_storage_spec.js
@@ -51,10 +51,9 @@ contract("SimpleStorage", function() {
   });
 
   it('listens to events', function(done) {
-    SimpleStorage.once('EventOnSet2', async function(error, _result) {
+    SimpleStorage.once('EventOnSet2', async function(error, result) {
       assert.strictEqual(error, null);
-      let result = await SimpleStorage.methods.get().call();
-      assert.strictEqual(parseInt(result, 10), 150);
+      assert.strictEqual(parseInt(result.returnValues.setValue, 10), 150);
       done(error);
     });
 
@@ -63,7 +62,7 @@ contract("SimpleStorage", function() {
 
   it('asserts event triggered', async function() {
     const tx = await SimpleStorage.methods.set2(160).send();
-    assert.eventEmitted(tx, 'EventOnSet2', {passed: true, message: "hi"});
+    assert.eventEmitted(tx, 'EventOnSet2', {passed: true, message: "hi", setValue: "160"});
   });
 
   it("should revert with a value lower than 5", async function() {

--- a/packages/core/core/constants.json
+++ b/packages/core/core/constants.json
@@ -35,6 +35,7 @@
     "webpackDone": "webpackDone"
   },
   "blockchain": {
+    "ethereum": "ethereum",
     "vm": "vm",
     "call": "eth_call",
     "clients": {

--- a/packages/core/typings/src/embark.d.ts
+++ b/packages/core/typings/src/embark.d.ts
@@ -53,6 +53,7 @@ export interface Config {
     rpcCorsDomain: string;
     wsRPC: boolean;
     isDev: boolean;
+    client: string;
   };
   webServerConfig: {
     certOptions: {

--- a/packages/plugins/ganache/src/index.js
+++ b/packages/plugins/ganache/src/index.js
@@ -1,6 +1,6 @@
 class Ganache {
   constructor(embark) {
-    embark.events.request('proxy:vm:register', () => {
+    embark.events.request('blockchain:vm:register', () => {
       const ganache = require('ganache-cli');
       return ganache.provider();
     });

--- a/packages/plugins/rpc-manager/src/lib/eth_accounts.ts
+++ b/packages/plugins/rpc-manager/src/lib/eth_accounts.ts
@@ -21,30 +21,30 @@ export default class EthAccounts extends RpcModifier {
   constructor(embark: Embark, rpcModifierEvents: Events) {
     super(embark, rpcModifierEvents);
 
-    this.embark.registerActionForEvent("blockchain:proxy:response", this.checkResponseFor_eth_accounts.bind(this));
+    this.embark.registerActionForEvent("blockchain:proxy:response", this.ethAccountsResponse.bind(this));
   }
 
-  private async checkResponseFor_eth_accounts(params: any, callback: Callback<any>) {
+  private async ethAccountsResponse(params: any, callback: Callback<any>) {
 
-    if (!(METHODS_TO_MODIFY.includes(params.reqData.method))) {
+    if (!(METHODS_TO_MODIFY.includes(params.request.method))) {
       return callback(null, params);
     }
 
-    this.logger.trace(__(`Modifying blockchain '${params.reqData.method}' response:`));
-    this.logger.trace(__(`Original request/response data: ${JSON.stringify(params)}`));
+    this.logger.trace(__(`Modifying blockchain '${params.request.method}' response:`));
+    this.logger.trace(__(`Original request/response data: ${JSON.stringify({ request: params.request, response: params.response })}`));
 
     try {
-      if (!arrayEqual(params.respData.result, this._nodeAccounts || [])) {
+      if (!arrayEqual(params.response.result, this._nodeAccounts || [])) {
         // reset backing variables so accounts is recalculated
-        await this.rpcModifierEvents.request2("nodeAccounts:updated", params.respData.result);
+        await this.rpcModifierEvents.request2("nodeAccounts:updated", params.response.result);
       }
       const accounts = await this.accounts;
       if (!(accounts && accounts.length)) {
         return callback(null, params);
       }
 
-      params.respData.result = accounts.map((acc) => acc.address || acc);
-      this.logger.trace(__(`Modified request/response data: ${JSON.stringify(params)}`));
+      params.response.result = accounts.map((acc) => acc.address || acc);
+      this.logger.trace(__(`Modified request/response data: ${JSON.stringify({ request: params.request, response: params.response })}`));
     } catch (err) {
       return callback(err);
     }

--- a/packages/plugins/rpc-manager/src/lib/eth_signTypedData.ts
+++ b/packages/plugins/rpc-manager/src/lib/eth_signTypedData.ts
@@ -8,40 +8,40 @@ export default class EthSignTypedData extends RpcModifier {
   constructor(embark: Embark, rpcModifierEvents: Events) {
     super(embark, rpcModifierEvents);
 
-    this.embark.registerActionForEvent("blockchain:proxy:request", this.checkRequestFor_eth_signTypedData.bind(this));
-    this.embark.registerActionForEvent("blockchain:proxy:response", this.checkResponseFor_eth_signTypedData.bind(this));
+    this.embark.registerActionForEvent("blockchain:proxy:request", this.ethSignTypedDataRequest.bind(this));
+    this.embark.registerActionForEvent("blockchain:proxy:response", this.ethSignTypedDataResponse.bind(this));
   }
 
-  private async checkRequestFor_eth_signTypedData(params: any, callback: Callback<any>) {
+  private async ethSignTypedDataRequest(params: any, callback: Callback<any>) {
     // check for:
     // - eth_signTypedData
     // - eth_signTypedData_v3
     // - eth_signTypedData_v4
     // - personal_signTypedData (parity)
-    if (params.reqData.method.includes("signTypedData")) {
+    if (params.request.method.includes("signTypedData")) {
       // indicate that we do not want this call to go to the node
       params.sendToNode = false;
       return callback(null, params);
     }
     callback(null, params);
   }
-  private async checkResponseFor_eth_signTypedData(params: any, callback: Callback<any>) {
+  private async ethSignTypedDataResponse(params: any, callback: Callback<any>) {
 
     // check for:
     // - eth_signTypedData
     // - eth_signTypedData_v3
     // - eth_signTypedData_v4
     // - personal_signTypedData (parity)
-    if (!params.reqData.method.includes("signTypedData")) {
+    if (!params.request.method.includes("signTypedData")) {
       return callback(null, params);
     }
 
-    this.logger.trace(__(`Modifying blockchain '${params.reqData.method}' response:`));
-    this.logger.trace(__(`Original request/response data: ${JSON.stringify(params)}`));
+    this.logger.trace(__(`Modifying blockchain '${params.request.method}' response:`));
+    this.logger.trace(__(`Original request/response data: ${JSON.stringify({ request: params.request, response: params.response })}`));
 
     try {
       const accounts = await this.accounts;
-      const [fromAddr, typedData] = params.reqData.params;
+      const [fromAddr, typedData] = params.request.params;
       const account = accounts.find((acc) => Web3.utils.toChecksumAddress(acc.address) === Web3.utils.toChecksumAddress(fromAddr));
       if (!(account && account.privateKey)) {
         return callback(
@@ -51,8 +51,8 @@ export default class EthSignTypedData extends RpcModifier {
       const toSign = transaction.getToSignHash(typeof typedData === "string" ? JSON.parse(typedData) : typedData);
       const signature = sign(toSign, [account.privateKey]);
 
-      params.respData.result = signature[0];
-      this.logger.trace(__(`Modified request/response data: ${JSON.stringify(params)}`));
+      params.response.result = signature[0];
+      this.logger.trace(__(`Modified request/response data: ${JSON.stringify({ request: params.request, response: params.response })}`));
     } catch (err) {
       return callback(err);
     }

--- a/packages/plugins/rpc-manager/src/lib/eth_subscribe.ts
+++ b/packages/plugins/rpc-manager/src/lib/eth_subscribe.ts
@@ -1,0 +1,43 @@
+import { Callback, Embark, Events } /* supplied by @types/embark in packages/embark-typings */ from "embark";
+import { __ } from "embark-i18n";
+import RpcModifier from "./rpcModifier";
+
+export default class EthSubscribe extends RpcModifier {
+  constructor(embark: Embark, rpcModifierEvents: Events) {
+    super(embark, rpcModifierEvents);
+
+    embark.registerActionForEvent("blockchain:proxy:request", this.ethSubscribeRequest.bind(this));
+    embark.registerActionForEvent("blockchain:proxy:response", this.ethSubscribeResponse.bind(this));
+  }
+
+  private async ethSubscribeRequest(params: any, callback: Callback<any>) {
+    // check for eth_subscribe and websockets
+    if (params.isWs && params.request.method === "eth_subscribe") {
+      // indicate that we do not want this call to go to the node
+      params.sendToNode = false;
+      return callback(null, params);
+    }
+    callback(null, params);
+  }
+  private async ethSubscribeResponse(params: any, callback: Callback<any>) {
+
+    const { isWs, transport, request, response } = params;
+
+    // check for eth_subscribe and websockets
+    if (!(isWs && request.method.includes("eth_subscribe"))) {
+      return callback(null, params);
+    }
+
+    this.logger.trace(__(`Modifying blockchain '${request.method}' response:`));
+    this.logger.trace(__(`Original request/response data: ${JSON.stringify({ request, response })}`));
+
+    try {
+      const nodeResponse = await this.events.request2("proxy:websocket:subscribe", transport, request, response);
+      params.response = nodeResponse;
+      this.logger.trace(__(`Modified request/response data: ${JSON.stringify({ request, response: params.response })}`));
+    } catch (err) {
+      return callback(err);
+    }
+    callback(null, params);
+  }
+}

--- a/packages/plugins/rpc-manager/src/lib/eth_unsubscribe.ts
+++ b/packages/plugins/rpc-manager/src/lib/eth_unsubscribe.ts
@@ -1,0 +1,44 @@
+import { Callback, Embark, Events } /* supplied by @types/embark in packages/embark-typings */ from "embark";
+import { __ } from "embark-i18n";
+import RpcModifier from "./rpcModifier";
+
+export default class EthUnsubscribe extends RpcModifier {
+
+  constructor(embark: Embark, rpcModifierEvents: Events) {
+    super(embark, rpcModifierEvents);
+
+    embark.registerActionForEvent("blockchain:proxy:request", this.ethUnsubscribeRequest.bind(this));
+    embark.registerActionForEvent("blockchain:proxy:response", this.ethUnsubscribeResponse.bind(this));
+  }
+
+  private async ethUnsubscribeRequest(params: any, callback: Callback<any>) {
+    // check for eth_subscribe and websockets
+    if (params.isWs && params.request.method === "eth_unsubscribe") {
+      // indicate that we do not want this call to go to the node
+      params.sendToNode = false;
+      return callback(null, params);
+    }
+    callback(null, params);
+  }
+  private async ethUnsubscribeResponse(params: any, callback: Callback<any>) {
+
+    const { isWs, request, response } = params;
+
+    // check for eth_subscribe and websockets
+    if (!(isWs && request.method.includes("eth_unsubscribe"))) {
+      return callback(null, params);
+    }
+
+    this.logger.trace(__(`Modifying blockchain '${request.method}' response:`));
+    this.logger.trace(__(`Original request/response data: ${JSON.stringify({ request, response })}`));
+
+    try {
+      const nodeResponse = await this.events.request2("proxy:websocket:unsubscribe", request, response);
+      params.response = nodeResponse;
+      this.logger.trace(__(`Modified request/response data: ${JSON.stringify({ request, response: params.response })}`));
+    } catch (err) {
+      return callback(err);
+    }
+    callback(null, params);
+  }
+}

--- a/packages/plugins/rpc-manager/src/lib/index.ts
+++ b/packages/plugins/rpc-manager/src/lib/index.ts
@@ -4,6 +4,8 @@ import Web3 from "web3";
 import EthAccounts from "./eth_accounts";
 import EthSendTransaction from "./eth_sendTransaction";
 import EthSignTypedData from "./eth_signTypedData";
+import EthSubscribe from "./eth_subscribe";
+import EthUnsubscribe from "./eth_unsubscribe";
 import PersonalNewAccount from "./personal_newAccount";
 import RpcModifier from "./rpcModifier";
 
@@ -34,7 +36,14 @@ export default class RpcManager {
       }
       return this.updateAccounts(this._nodeAccounts, cb);
     });
-    this.modifiers = [PersonalNewAccount, EthAccounts, EthSendTransaction, EthSignTypedData].map((rpcModifier) => new rpcModifier(this.embark, this.rpcModifierEvents));
+    this.modifiers = [
+      PersonalNewAccount,
+      EthAccounts,
+      EthSendTransaction,
+      EthSignTypedData,
+      EthSubscribe,
+      EthUnsubscribe
+    ].map((rpcModifier) => new rpcModifier(this.embark, this.rpcModifierEvents));
   }
   private async updateAccounts(updatedNodeAccounts: any[], cb: Callback<null>) {
     for (const modifier of this.modifiers) {

--- a/packages/plugins/rpc-manager/src/lib/personal_newAccount.ts
+++ b/packages/plugins/rpc-manager/src/lib/personal_newAccount.ts
@@ -7,16 +7,16 @@ export default class PersonalNewAccount extends RpcModifier {
   constructor(embark: Embark, rpcModifierEvents: Events) {
     super(embark, rpcModifierEvents);
 
-    embark.registerActionForEvent("blockchain:proxy:response", this.checkResponseFor_personal_newAccount.bind(this));
+    embark.registerActionForEvent("blockchain:proxy:response", this.personalNewAccountResponse.bind(this));
   }
 
-  private async checkResponseFor_personal_newAccount(params: any, callback: Callback<any>) {
-    if (params.reqData.method !== blockchainConstants.transactionMethods.personal_newAccount) {
+  private async personalNewAccountResponse(params: any, callback: Callback<any>) {
+    if (params.request.method !== blockchainConstants.transactionMethods.personal_newAccount) {
       return callback(null, params);
     }
 
     // emit event so tx modifiers can refresh accounts
-    await this.rpcModifierEvents.request2("nodeAccounts:added", params.respData.result);
+    await this.rpcModifierEvents.request2("nodeAccounts:added", params.response.result);
 
     callback(null, params);
   }

--- a/packages/stack/blockchain-client/src/index.js
+++ b/packages/stack/blockchain-client/src/index.js
@@ -9,30 +9,35 @@ class BlockchainClient {
 
     this.blockchainClients = {};
     this.client = null;
+    this.vms = [];
     this.events.setCommandHandler("blockchain:client:register", (clientName, blockchainClient) => {
       this.blockchainClients[clientName] = blockchainClient;
       this.client = blockchainClient;
     });
+    this.events.setCommandHandler("blockchain:vm:register", (handler) => {
+      this.vms.push(handler());
+    });
 
     // TODO: unclear currently if this belongs here so it's a bit hardcoded for now
-    this.events.setCommandHandler("blockchain:client:provider", (clientName, cb) => {
-      this.events.request("proxy:endpoint:get", (err, endpoint) => {
-        if (err) {
-          return cb(err);
-        }
-        if (endpoint.startsWith('ws')) {
-          return cb(null, new Web3.providers.WebsocketProvider(endpoint, {
-            headers: {Origin: constants.embarkResourceOrigin},
-            // TODO remove this when Geth fixes this: https://github.com/ethereum/go-ethereum/issues/16846
-            //  Edit: This has been fixed in Geth 1.9, but we don't support 1.9 yet and still support 1.8
-            clientConfig: {
-              fragmentationThreshold: 81920
-            }
-          }));
-        }
-        const web3 = new Web3(endpoint);
-        cb(null, web3.currentProvider);
-      });
+    this.events.setCommandHandler("blockchain:client:vmProvider", async (cb) => {
+      if (!this.vms.length) {
+        return cb(`Failed to get the VM provider. Please register one using 'blockchain:vm:register', or by ensuring the 'embark-ganache' package is registered.`);
+      }
+      return cb(null, this.vms[this.vms.length - 1]);
+    });
+    this.events.setCommandHandler("blockchain:client:provider", async (clientName, endpoint, cb) => {
+      if (!cb && typeof endpoint === "function") {
+        cb = endpoint;
+        endpoint = null;
+      }
+      let provider;
+      try {
+        provider = await this._getProvider(clientName, endpoint);
+      }
+      catch (err) {
+        return cb(`Error getting provider: ${err.message || err}`);
+      }
+      cb(null, provider);
     });
 
     // TODO: maybe not the ideal event to listen to?
@@ -46,7 +51,28 @@ class BlockchainClient {
       // set default account
     });
   }
-
+  async _getProvider(clientName, endpoint) {
+    // Passing in an endpoint allows us to customise which URL the provider connects to.
+    // If no endpoint is provided, the provider will connect to the proxy.
+    // Explicity setting an endpoint is useful for cases where we want to connect directly
+    // to the node (ie in the proxy).
+    if (!endpoint) {
+      // will return the proxy URL
+      endpoint = await this.events.request2("proxy:endpoint:get");
+    }
+    if (endpoint.startsWith('ws')) {
+      return new Web3.providers.WebsocketProvider(endpoint, {
+        headers: { Origin: constants.embarkResourceOrigin },
+        // TODO remove this when Geth fixes this: https://github.com/ethereum/go-ethereum/issues/16846
+        //  Edit: This has been fixed in Geth 1.9, but we don't support 1.9 yet and still support 1.8
+        clientConfig: {
+          fragmentationThreshold: 81920
+        }
+      });
+    }
+    const web3 = new Web3(endpoint);
+    return web3.currentProvider;
+  }
 }
 
 module.exports = BlockchainClient;

--- a/packages/stack/test-runner/src/lib/reporter.js
+++ b/packages/stack/test-runner/src/lib/reporter.js
@@ -15,7 +15,7 @@ class Reporter {
   wireGasUsage() {
     const {events} = this.embark;
     events.on('blockchain:proxy:response', (params) => {
-      const {result} = params.respData;
+      const { result } = params.response;
 
       if (!result || !result.gasUsed) {
         return;

--- a/site/source/docs/plugin_reference.md
+++ b/site/source/docs/plugin_reference.md
@@ -477,5 +477,12 @@ embark.registerActionForEvent("deployment:contract:beforeDeploy", async (params,
 - `deployment:deployContracts:afterAll`: Called after all contracts have deployed. No params
 - `tests:contracts:compile:before`: Called before the contracts are compiled in the context of the test. Only param is `contractFiles`
 - `tests:contracts:compile:after`: Called after the contracts are compiled in the context of the test. Only param is `compiledContracts`
-- `blockchain:proxy:request`: Called before a request from Embark or the Dapp is sent to the blockchain node. You can modify or react to the payload of the request. Only param is `reqData`, an object containing the payload
-- `blockchain:proxy:response`: Called before the node response is sent back to Embark or the Dapp. You can modify or react to the payload of the response. Two params, `reqData` and `respData`, objects containing the payloads
+- `blockchain:proxy:request`: Called before a request from Embark or the Dapp is sent to the blockchain node. You can modify or react to the payload of the request. Params are:
+  - `request`: an object containing the request payload
+  - `transport`: an object containing the client's websocket connection to the proxy
+  - `isWs`: a boolean flag indicating if the request was performed using websockets
+- `blockchain:proxy:response`: Called before the node response is sent back to Embark or the Dapp. You can modify or react to the payload of the response. Params are:
+  - `request`: an object containing the request payload
+  - `response`: an object containing the response payload
+  - `transport`: an object containing the client's websocket connection to the proxy
+  - `isWs`: a boolean flag indicating if the request was performed using websockets


### PR DESCRIPTION
### Changes
When `eth_unsubscribe` is received in the proxy, ensure this request is forwarded through on the correct socket (the same socket that was used for the corresponding `eth_subscribe`).

Move subscription handling for `eth_subscribe` and `eth_unsubscribe` to RpcModifiers (in `rpc-manager` package).

For each `eth_subscribe` request, a new `RequestManager` is created. Since the endpoint property on the proxy class was updated to be a provider, the same provider was being assigned to each new `RequestManager` and thus creating multiple event handlers for each subscription created. To circumvent this, we are now creating a new provider for each `RequestManager`. However, this does not apply to tests (see *Notes* below).

Small refactor includes renaming of `reqData` and `respData` in proxy to `request` and `response` for readability.

### Notes
For testing, a VM provider is required to be used, and as only one VM provider can be created per chain, we are forced to use the same provider during tests for each subscription. For each subscription created, a new event handler is attached to the provider, meaning that for every subscription event that occurs on the node, all subscribed handlers will be fired, sometimes with irrelevant data. This forces us to filter out subscription response data from the node. The downside of this is that for each subscription created, we are effectively exponentially increasing the number of event handlers that are fired (`numEventHandlers = numEventsSubscribed^2`), which has the potential to slow down the tests as more subscriptions are added.

Co-authored-by: Pascal Precht <pascal.precht@googlemail.com>