### PR TITLE
refactor(@embark/plugins/profiler): re-enable embark-profiler plugin

### DIFF
--- a/packages/cockpit/ui/src/components/Console.css
+++ b/packages/cockpit/ui/src/components/Console.css
@@ -7,6 +7,11 @@
   text-transform: capitalize;
 }
 
+.console-text {
+  font-family: monospace;
+  white-space: pre;
+}
+
 .text__new-line, .card.warnings-card .list-group-item, .card.errors-card .list-group-item {
   white-space: pre-wrap;
   font-family: monospace;

--- a/packages/cockpit/ui/src/components/Console.js
+++ b/packages/cockpit/ui/src/components/Console.js
@@ -77,6 +77,7 @@ class Console extends Component {
 
   logClassName(item) {
     return classnames('m-0', {
+      'console-text': true,
       'text-success': item.logLevel === 'info',
       'text-info': item.logLevel === 'debug',
       'text-danger': item.logLevel === 'error',

--- a/packages/core/core/src/engine.ts
+++ b/packages/core/core/src/engine.ts
@@ -286,6 +286,7 @@ export class Engine {
     this.registerModulePackage('embark-specialconfigs', {plugins: this.plugins});
     this.registerModulePackage('embark-transaction-logger');
     this.registerModulePackage('embark-transaction-tracker');
+    this.registerModulePackage('embark-profiler');
   }
 
   storageComponent() {

--- a/packages/plugins/profiler/package.json
+++ b/packages/plugins/profiler/package.json
@@ -45,6 +45,7 @@
     "ascii-table": "0.0.9",
     "async": "2.6.1",
     "core-js": "3.3.5",
+    "web3": "1.2.1",
     "web3-utils": "1.2.1"
   },
   "devDependencies": {

--- a/packages/plugins/profiler/src/index.js
+++ b/packages/plugins/profiler/src/index.js
@@ -19,7 +19,8 @@ class Profiler {
     profileObj.name = contractName;
     profileObj.methods = [];
 
-    self.events.request('contracts:contract', contractName, (contract) => {
+    self.events.request('contracts:contract', contractName, (err, contract) => {
+      if (err) return returnCb(err);
       if (!contract || !contract.deployedAddress) {
         return returnCb("--  couldn't profile " + contractName + " - it's not deployed or could be an interface");
       }


### PR DESCRIPTION
Hook `embark-profiler` into the engine's contracts group.

Adjust `request` signatures to match v5 usage.

Ensure gas numbers are formatted consistently in the ascii table.

Display non-json output in cockpit's console as monospace/pre to preserve profiler table formatting.