### PR TITLE
add Fathom Analytics JS to the site

### DIFF
--- a/site/themes/embark/layout/layout.swig
+++ b/site/themes/embark/layout/layout.swig
@@ -12,6 +12,21 @@
         {% for version in Object.keys(site.data.versions) %}'{{version}}': '{{site.data.versions[version].url}}'{% if !loop.last %},{% endif%}{% endfor %}
       };
     </script>
+
+    <!-- Fathom - simple website analytics - https://github.com/usefathom/fathom -->
+    <script>
+    (function(f, a, t, h, o, m){
+        a[h]=a[h]||function(){(a[h].q=a[h].q||[]).push(arguments)};
+        o=f.createElement('script'),
+        m=f.getElementsByTagName('script')[0];
+        o.async=1; o.src=t; o.id='fathom-script';
+        m.parentNode.insertBefore(o,m)
+    })(document, window, '//fathom.status.im/tracker.js', 'fathom');
+    fathom('set', 'siteId', 'JOQKN');
+    fathom('trackPageview');
+    </script>
+    <!-- / Fathom -->
+
     <script src="/js/index.js"></script>
 
     {% if config.algolia[page.lang] %}


### PR DESCRIPTION
This adds a script for site analytics we added to https://status.im/ recently(https://github.com/status-im/status.im/pull/396).

You can read about it here:
https://our.status.im/implementing-fathom-analytics-on-marketing-websites/