### PR TITLE
fix(@embark/core): ensure type declaration for Plugin.registerActionF…

### DIFF
--- a/packages/core/typings/src/embark.d.ts
+++ b/packages/core/typings/src/embark.d.ts
@@ -1,5 +1,6 @@
 import { Logger } from './logger';
 import { Plugins } from './plugins';
+import { Callback } from './callbacks';
 
 type CommandCallback = (
   opt1?: any,
@@ -63,6 +64,8 @@ export interface Config {
   reloadConfig(): void;
 }
 
+type ActionCallback<T> = (params: any, cb: Callback<T>) => void;
+
 export interface Embark {
   env: string;
   events: Events;
@@ -73,8 +76,9 @@ export interface Embark {
   fs: any;
   config: Config;
   currentContext: string[];
-  registerActionForEvent(
+  registerActionForEvent<T>(
     name: string,
-    action: (params: any, cb: (error: any, result: any) => void) => void,
+    options?: ActionCallback<T> | { priority: number },
+    action?: ActionCallback<T>,
   ): void;
 }


### PR DESCRIPTION
…orEvent() is legit

In https://github.com/embark-framework/embark/commit/776db1b7f71e9a78f216cf2acc6c1387c60b3604#diff-5cab125016e6d753f03b6cd0241d5ebbR267 we've introduced the ability to add
a `priority` parameter to plugin actions, so the order of actions can be semi-ensured.

That commit also introduced typings for that new API but it actually didn't match the
implementation of the API, namely that the second parameter of `Plugin.registerActionForEvent()`
can be either an options object **or** a callback function.

This forces consumers to call the API as `registerActoniForEvent(name, undefined|null, callback)`
which shouldn't be necessary.