### PR TITLE
fix(@embark/whisper): show message when geth port is already taken

### DIFF
--- a/packages/plugins/geth/src/blockchain.js
+++ b/packages/plugins/geth/src/blockchain.js
@@ -221,7 +221,7 @@ Blockchain.prototype.run = function () {
     // TOCHECK I don't understand why stderr and stdout are reverted.
     // This happens with Geth and Parity, so it does not seems a client problem
     self.child.stdout.on('data', (data) => {
-      self.logger.info(`${self.client.name} error: ${data}`);
+      self.logger.error(`${self.client.name} error: ${data}`);
     });
 
     self.child.stderr.on('data', async (data) => {

--- a/packages/plugins/geth/src/whisperClient.js
+++ b/packages/plugins/geth/src/whisperClient.js
@@ -169,7 +169,7 @@ class WhisperGethClient {
     if (config.wsRPC) {
       cmd.push("--ws");
 
-      cmd.push(`--wsport=${communicationConfig.connection.port || config.wsPost++}`);
+      cmd.push(`--wsport=${communicationConfig.connection.port || config.wsPort++}`);
       cmd.push(`--wsaddr=${communicationConfig.connection.host || config.wsHost++}`);
 
       if (config.wsOrigins) {

--- a/packages/plugins/whisper/src/index.js
+++ b/packages/plugins/whisper/src/index.js
@@ -1,6 +1,5 @@
 import { __ } from 'embark-i18n';
-import {dappPath, canonicalHost, defaultHost} from 'embark-utils';
-const constants = require('embark-core/constants');
+import {canonicalHost, defaultHost} from 'embark-utils';
 const API = require('./api.js');
 
 class Whisper {
@@ -11,8 +10,6 @@ class Whisper {
     this.communicationConfig = embark.config.communicationConfig;
     this.embarkConfig = embark.config.embarkConfig;
     this.embark = embark;
-    this.webSocketsChannels = {};
-    this.modulesPath = dappPath(embark.config.embarkConfig.generationDir, constants.dappArtifacts.symlinkDir);
 
     this.api = new API(embark);
     this.whisperNodes = {};
@@ -42,7 +39,7 @@ class Whisper {
     let connection = this.communicationConfig.connection || {};
     const config = {
       server: canonicalHost(connection.host || defaultHost),
-      port: connection.port || '8546',
+      port: connection.port || '8557',
       type: connection.type || 'ws'
     };
 

--- a/packages/plugins/whisper/src/index.js
+++ b/packages/plugins/whisper/src/index.js
@@ -22,6 +22,11 @@ class Whisper {
     });
 
     this.events.request("communication:node:register", "whisper", (readyCb) => {
+      if (this.communicationConfig.connection.port === this.embark.config.blockchainConfig.wsPort) {
+        this.logger.warn(__('Communication connection set to open on port %s, which is the same as your blockchain node. It will probably conflict', this.communicationConfig.connection.port));
+        this.logger.warn(__('You can change that port in you communication config file as `connection.port`'));
+      }
+
       let clientName = this.communicationConfig.client || "geth";
       let registerCb = this.whisperNodes[clientName];
       if (!registerCb) return readyCb("whisper client " + clientName + " not found");

--- a/packages/plugins/whisper/src/index.js
+++ b/packages/plugins/whisper/src/index.js
@@ -24,7 +24,7 @@ class Whisper {
     this.events.request("communication:node:register", "whisper", (readyCb) => {
       if (this.communicationConfig.connection.port === this.embark.config.blockchainConfig.wsPort) {
         this.logger.warn(__('Communication connection set to open on port %s, which is the same as your blockchain node. It will probably conflict', this.communicationConfig.connection.port));
-        this.logger.warn(__('You can change that port in you communication config file as `connection.port`'));
+        this.logger.warn(__('You can change that port in your communication config file as `connection.port`'));
       }
 
       let clientName = this.communicationConfig.client || "geth";


### PR DESCRIPTION
The problem that Teller had was that it still used the old port for WS, so it tried to start Geth on the same port as the blockchain.

I tried using `findNextPort`, the function that detects if the port is used and tries the next one, but it doesn't work with WS. Then I figure, it will just be confusing for the user if the port is changed, so instead, he should get a message when the port is in use.

So I changed the Geth process to print the errors as errors (duh), so for ports taken or just other errors, users will see it. The error itself I think is clear enough that the port is taken, so it should be changed.

I always added a warning if the port is the same as the node port, as seen in the config.

I'll also add a line in the migration guide to tell users to change that port.
