### PR TITLE
fix(@embark/simulator): fix port used in simulator

### DIFF
--- a/packages/embark/src/cmd/simulator.js
+++ b/packages/embark/src/cmd/simulator.js
@@ -14,7 +14,7 @@ class Simulator {
     const cmds = [];
 
     const host = (dockerHostSwap(options.host || this.blockchainConfig.rpcHost) || defaultHost);
-    const configPort = this.blockchainConfig.wsRPC ? this.blockchainConfig.rpcPort : this.blockchainConfig.wsPort;
+    const configPort = this.blockchainConfig.wsRPC ? this.blockchainConfig.wsPort : this.blockchainConfig.rpcPort;
     let port = parseInt((options.port || configPort || 8545), 10);
 
     cmds.push("-p " + port);


### PR DESCRIPTION
When using websockets, the simulator was starting on port `8545` instead of `8546`, so the blockchain check was failing.

Update the simulator port to be websockets port from the config when using websockets.