### PR TITLE
chore(@embark/whisper): improve whisper startup logging

### DIFF
--- a/packages/plugins/geth/src/blockchain.js
+++ b/packages/plugins/geth/src/blockchain.js
@@ -26,6 +26,7 @@ var Blockchain = function(userConfig, clientClass, communicationConfig) {
   this.events = userConfig.events;
   this.isStandalone = userConfig.isStandalone;
   this.certOptions = userConfig.certOptions;
+  this.isWhisper = !!communicationConfig;
 
 
   let defaultWsApi = clientClass.DEFAULTS.WS_API;
@@ -165,7 +166,7 @@ Blockchain.prototype.run = function () {
   var self = this;
   this.logger.info("===============================================================================".magenta);
   this.logger.info("===============================================================================".magenta);
-  this.logger.info(__("Embark Blockchain using %s", self.client.prettyName.underline).magenta);
+  this.logger.info(__(`Embark ${this.isWhisper ? "Whisper" : "Blockchain"} using %s`, self.client.prettyName.underline).magenta);
   this.logger.info("===============================================================================".magenta);
   this.logger.info("===============================================================================".magenta);
 

--- a/packages/plugins/geth/src/blockchainProcessLauncher.js
+++ b/packages/plugins/geth/src/blockchainProcessLauncher.js
@@ -15,6 +15,7 @@ export class BlockchainProcessLauncher {
     this.isDev = options.isDev;
     this.client = options.client;
     this.embark = options.embark;
+    this.isWhisper = !!this.communicationConfig;
   }
 
   processEnded(code) {
@@ -22,7 +23,7 @@ export class BlockchainProcessLauncher {
   }
 
   startBlockchainNode(readyCb) {
-    this.logger.info(__('Starting Blockchain node in another process').cyan);
+    this.logger.info(__(`Starting ${this.isWhisper ? "Whisper" : "Blockchain"} node in another process`).cyan);
 
     this.blockchainProcess = new ProcessLauncher({
       name: 'blockchain',
@@ -47,7 +48,7 @@ export class BlockchainProcessLauncher {
     });
 
     this.blockchainProcess.once('result', constants.blockchain.blockchainReady, () => {
-      this.logger.info(__('Blockchain node is ready').cyan);
+      this.logger.info(__(`${this.isWhisper ? "Whisper" : "Blockchain"} node is ready`).cyan);
       readyCb();
       // this.events.emit(constants.blockchain.blockchainReady);
     });


### PR DESCRIPTION
When whisper was being started in a new process, the message displayed in the console was “Starting Blockchain node in another process”. This is misleading as it is the same message that geth/parity use to start up their processes.

Update whisper initialisation process messaging so it states “Starting Whisper node in another process”.