### PR TITLE
fix(@embark/rpc-manager): implement missing RPC modifier for eth_sign

### DIFF
--- a/packages/plugins/rpc-manager/src/lib/eth_signData.ts
+++ b/packages/plugins/rpc-manager/src/lib/eth_signData.ts
@@ -1,0 +1,68 @@
+import { Callback, Embark, Events } /* supplied by @types/embark in packages/embark-typings */ from "embark";
+import { __ } from "embark-i18n";
+import Web3 from "web3";
+import RpcModifier from "./rpcModifier";
+
+export default class EthSignData extends RpcModifier {
+  constructor(embark: Embark, rpcModifierEvents: Events) {
+    super(embark, rpcModifierEvents);
+
+    this.embark.registerActionForEvent("blockchain:proxy:request", this.ethSignDataRequest.bind(this));
+    this.embark.registerActionForEvent("blockchain:proxy:response", this.ethSignDataResponse.bind(this));
+  }
+
+  private async ethSignDataRequest(params: any, callback: Callback<any>) {
+    if (params.request.method === "eth_sign") {
+      try {
+        const nodeAccounts = await this.nodeAccounts;
+        const [fromAddr] = params.request.params;
+        if (!nodeAccounts.includes(fromAddr)) {
+          params.sendToNode = false;
+        }
+      } catch (err) {
+        return callback(err);
+      }
+    }
+
+    callback(null, params);
+  }
+
+  private async ethSignDataResponse(params: any, callback: Callback<any>) {
+    if (params.request.method !== "eth_sign") {
+      return callback(null, params);
+    }
+
+    try {
+      const accounts = await this.accounts;
+      const nodeAccounts = await this.nodeAccounts;
+      const [fromAddr, data] = params.request.params;
+
+      if (nodeAccounts.includes(fromAddr)) {
+        return callback(null, params);
+      }
+
+      this.logger.trace(__(`Modifying blockchain '${params.request.method}' response:`));
+      this.logger.trace(__(`Original request/response data: ${JSON.stringify(params)}`));
+
+      const account = accounts.find(acc => (
+        Web3.utils.toChecksumAddress(acc.address) ===
+          Web3.utils.toChecksumAddress(fromAddr)
+      ));
+
+      if (!(account && account.privateKey)) {
+        return callback(
+          new Error(__("Could not sign transaction because Embark does not have a private key associated with '%s'. " +
+                       "Please ensure you have configured your account(s) to use a mnemonic, privateKey, or privateKeyFile.", fromAddr)));
+      }
+
+      const signature = new Web3().eth.accounts.privateKeyToAccount(account.privateKey).sign(data).signature;
+      params.response.result = signature;
+
+      this.logger.trace(__(`Modified request/response data: ${JSON.stringify(params)}`));
+    } catch (err) {
+      return callback(err);
+    }
+
+    callback(null, params);
+  }
+}

--- a/packages/plugins/rpc-manager/src/lib/index.ts
+++ b/packages/plugins/rpc-manager/src/lib/index.ts
@@ -3,6 +3,7 @@ import { Logger } from 'embark-logger';
 import Web3 from "web3";
 import EthAccounts from "./eth_accounts";
 import EthSendTransaction from "./eth_sendTransaction";
+import EthSignData from "./eth_signData";
 import EthSignTypedData from "./eth_signTypedData";
 import EthSubscribe from "./eth_subscribe";
 import EthUnsubscribe from "./eth_unsubscribe";
@@ -36,15 +37,18 @@ export default class RpcManager {
       }
       return this.updateAccounts(this._nodeAccounts, cb);
     });
+
     this.modifiers = [
       PersonalNewAccount,
       EthAccounts,
       EthSendTransaction,
       EthSignTypedData,
+      EthSignData,
       EthSubscribe,
       EthUnsubscribe
     ].map((rpcModifier) => new rpcModifier(this.embark, this.rpcModifierEvents));
   }
+
   private async updateAccounts(updatedNodeAccounts: any[], cb: Callback<null>) {
     for (const modifier of this.modifiers) {
       await (modifier.nodeAccounts = Promise.resolve(updatedNodeAccounts));


### PR DESCRIPTION
This is actually not a WIP but a `fix`.

Let's wait for #2050 to land first. This one then needs rebase.

Thanks @michaelsbradleyjr for helping implementing this!