### PR TITLE
Fix whisper component in the cockpit

### DIFF
--- a/packages/cockpit/ui/package.json
+++ b/packages/cockpit/ui/package.json
@@ -65,6 +65,7 @@
     "connected-react-router": "4.5.0",
     "date-fns": "2.3.0",
     "embark-api-client": "^5.0.0-alpha.1",
+    "eslint-plugin-import": "2.18.2",
     "ethereumjs-units": "0.2.0",
     "find-up": "4.1.0",
     "font-awesome": "4.7.0",

--- a/packages/cockpit/ui/src/components/Console.js
+++ b/packages/cockpit/ui/src/components/Console.js
@@ -115,6 +115,7 @@ class Console extends Component {
             </Logs>
             {process.name === "embark" &&
               <AsyncTypeahead
+                id="console-typeahead"
                 autoFocus={true}
                 emptyLabel={false}
                 labelKey="value"

--- a/packages/cockpit/ui/src/services/api.js
+++ b/packages/cockpit/ui/src/services/api.js
@@ -1,6 +1,6 @@
 import EmbarkAPI from 'embark-api-client';
 
-const embarkAPI = new EmbarkAPI()
+const embarkAPI = new EmbarkAPI();
 
 export function postCommand() {
   return embarkAPI.postCommand(...arguments)

--- a/packages/stack/library-manager/package.json
+++ b/packages/stack/library-manager/package.json
@@ -53,7 +53,8 @@
     "embark-solo": "^5.0.0-alpha.0",
     "eslint": "5.7.0",
     "npm-run-all": "4.1.5",
-    "rimraf": "3.0.0"
+    "rimraf": "3.0.0",
+    "web3": "1.2.1"
   },
   "engines": {
     "node": ">=10.17.0 <12.0.0",

--- a/packages/stack/library-manager/src/index.js
+++ b/packages/stack/library-manager/src/index.js
@@ -1,5 +1,6 @@
 import { __ } from 'embark-i18n';
 import { dappPath, embarkPath, normalizePath, toForwardSlashes } from 'embark-utils';
+import web3 from 'web3';
 const Npm = require('./npm.js');
 const {callbackify} = require('util');
 
@@ -44,6 +45,8 @@ class LibraryManager {
     let solcVersionInConfig = this.contractsConfig.versions["solc"];
 
     this.versions['solc'] = solcVersionInConfig;
+
+    this.versions.web3 = web3.version;
 
     Object.keys(this.versions).forEach(versionKey => {
       if (!this.isVersionable(versionKey)) return;


### PR DESCRIPTION
The problem was that the Whisper component checks if the Web3 version is high enough (supported), but when we removed the support for changing the web3 version in `versions`, it no longer was there for Cockpit to see.