### PR TITLE
fix(@embark/tests): Improve expiration unit test

### DIFF
--- a/dapps/tests/app/app/contracts/expiration.sol
+++ b/dapps/tests/app/app/contracts/expiration.sol
@@ -1,7 +1,7 @@
 pragma solidity ^0.4.25;
 
 contract Expiration {
-  uint public expirationTime; // In milliseconds
+  uint256 public expirationTime; // Unix epoch (seconds since 1/1/1970)
   address owner;
 
   constructor(uint expiration) public {
@@ -9,8 +9,7 @@ contract Expiration {
   }
 
   function isExpired() public view returns (bool retVal) {
-//    retVal = block.timestamp;
-    retVal = expirationTime < block.timestamp * 1000;
+    retVal = block.timestamp > expirationTime;
     return retVal;
   }
 }

--- a/dapps/tests/app/test/expiration_spec.js
+++ b/dapps/tests/app/test/expiration_spec.js
@@ -1,11 +1,12 @@
-/*global contract, config, it, assert, increaseTime*/
+/*global contract, config, it, assert, mineAtTimestamp*/
 const Expiration = require('Embark/contracts/Expiration');
+const now = Math.floor(new Date().getTime()/1000.0); // Get unix epoch. The getTime method returns the time in milliseconds.
 
 config({
   contracts: {
     deploy: {
       "Expiration": {
-        args: [Date.now() + 5000]
+        args: [now + 1000]
       }
     }
   }
@@ -18,7 +19,7 @@ contract("Expiration", function() {
   });
 
   it("should have expired after skipping time", async function () {
-    await increaseTime(5001);
+    await mineAtTimestamp(now + 1001); // sets block.timestamp to 1001
     const isExpired = await Expiration.methods.isExpired().call();
     assert.strictEqual(isExpired, true);
   });

--- a/packages/stack/test-runner/src/lib/index.js
+++ b/packages/stack/test-runner/src/lib/index.js
@@ -161,6 +161,12 @@ class TestRunner {
       await this.evmMethod("evm_increaseTime", [Number(amount)]);
       await this.evmMethod("evm_mine");
     };
+
+    // Mines a block and sets block.timestamp accordingly.
+    // See https://github.com/trufflesuite/ganache-core/pull/13 for more information
+    global.mineAtTimestamp = async (timestamp) => {
+      return this.evmMethod("evm_mine", [parseFloat(timestamp)]);
+    };
   }
 
   generateCoverageReport() {


### PR DESCRIPTION
Improve the reliability of the expiration unit test in the test dapp by explicitly setting the `block.timestamp` and comparing an expiration value against that.

This improves on the current implementation that relies on time passed which varies depending on the speed of unit tests run (CPU speed, logs shown, etc).