### PR TITLE
fix(@embark/core): don't exit in Engine consumer API

### DIFF
--- a/packages/core/core/src/engine.ts
+++ b/packages/core/core/src/engine.ts
@@ -116,9 +116,7 @@ export class Engine {
     if (this.plugins) {
       this.plugins.emitAndRunActionsForEvent("embark:engine:started", {}, (err) => {
         if (err) {
-          console.error("error starting engine");
-          console.error(err);
-          process.exit(1);
+          return cb(err);
         }
         cb();
       });

--- a/packages/embark/src/cmd/cmd_controller.js
+++ b/packages/embark/src/cmd/cmd_controller.js
@@ -196,7 +196,10 @@ class EmbarkController {
           engine.events.emit("status", __("Ready").green);
         });
 
-        engine.startEngine(async () => {
+        engine.startEngine(async (err) => {
+          if (err) {
+            return callback(err);
+          }
           callback();
 
           engine.events.request("webserver:start");
@@ -229,8 +232,12 @@ class EmbarkController {
       }
     ], function (err, _result) {
       if (err) {
-        engine.logger.error(err.message);
-        engine.logger.info(err.stack);
+        if (err.message && err.stack) {
+          engine.logger.error(err.message);
+          engine.logger.info(err.stack);
+        } else {
+          engine.logger.error(err);
+        }
       } else {
         // engine.events.emit('firstDeploymentDone');
       }


### PR DESCRIPTION
`Engine.startEngine(cb)` potentially exits the current process if
any registered plugins emits an error in the bootstrap phase.

This limits consumers of this API to react accordingly. Embark's APIs
should be considered library APIs that propagate errors, but let callers
decide what to do with them.

This commit ensures we keep propagating the error of `startEngine()` without
exiting the current process.