### PR TITLE
Fix to Whisper Geth node issues

### DIFF
--- a/packages/plugins/whisper-geth/src/blockchain.js
+++ b/packages/plugins/whisper-geth/src/blockchain.js
@@ -207,7 +207,7 @@ Blockchain.prototype.run = function () {
     // TOCHECK I don't understand why stderr and stdout are reverted.
     // This happens with Geth and Parity, so it does not seems a client problem
     self.child.stdout.on("data", (data) => {
-      self.logger.info(`${self.client.name} error: ${data}`);
+      self.logger.error(`${self.client.name} error: ${data}`);
     });
 
     self.child.stderr.on("data", async (data) => {

--- a/packages/plugins/whisper-geth/src/blockchainProcessLauncher.js
+++ b/packages/plugins/whisper-geth/src/blockchainProcessLauncher.js
@@ -25,7 +25,7 @@ export class BlockchainProcessLauncher {
     this.logger.info(__("Starting Whisper node in another process").cyan);
 
     this.blockchainProcess = new ProcessLauncher({
-      name: "blockchain",
+      name: "blockchainWhisper",
       modulePath: joinPath(__dirname, "./blockchainProcess.js"),
       logger: this.logger,
       events: this.events,

--- a/packages/plugins/whisper-geth/src/whisperGethClient.js
+++ b/packages/plugins/whisper-geth/src/whisperGethClient.js
@@ -157,7 +157,7 @@ class WhisperGethClient {
     let config = this.config;
     let rpcApi = this.config.rpcApi;
     let wsApi = this.config.wsApi;
-    let args = [];
+    let args = ['--ipcdisable']; // Add --ipcdisable as ipc is not needed for Whisper and it conflicts on Windows with the blockchain node
     async.series([
       function commonOptions(callback) {
         let cmd = self.commonOptions();


### PR DESCRIPTION
Fix issue where Whisper logs were printed twice because it had the same name as the blockchain, so the event to listen to process logs was registered twice. Just needed to change the name.

Fix Windows issue where the Whisper Geth node was conflicting with the main blockchain node over the IPC. Reason is that on Windows, the IPC link is made through a pipe file on disk. Changing that would mean to only change it on Windows, so it would be a pain. Instead, just putting `ipcdisable` in the Whisper node fixes it, and IPC is not really needed for Whisper anyway.