### PR TITLE
refactor(@embark/core): make 8547 the default port of communication provider node

### DIFF
--- a/dapps/templates/boilerplate/config/communication.js
+++ b/dapps/templates/boilerplate/config/communication.js
@@ -10,8 +10,8 @@ module.exports = {
   // assumed to be the intended environment by `embark run`
   development: {
     connection: {
-      host: "localhost", // Host of the blockchain node
-      port: 8557, // Port of the blockchain node
+      host: "localhost", // Host of the provider node
+      port: 8547, // Port of the provider node
       type: "ws" // Type of connection (ws or rpc)
     }
   },

--- a/dapps/templates/demo/config/communication.js
+++ b/dapps/templates/demo/config/communication.js
@@ -10,8 +10,8 @@ module.exports = {
   // assumed to be the intended environment by `embark run`
   development: {
     connection: {
-      host: "localhost", // Host of the blockchain node
-      port: 8557, // Port of the blockchain node
+      host: "localhost", // Host of the provider node
+      port: 8547, // Port of the provider node
       type: "ws" // Type of connection (ws or rpc)
     }
   },

--- a/packages/core/core/src/config.ts
+++ b/packages/core/core/src/config.ts
@@ -569,7 +569,7 @@ export class Config {
         available_providers: ["whisper"],
         connection: {
           host: defaultHost,
-          port: 8557,
+          port: 8547,
           type: "ws"
         }
       }


### PR DESCRIPTION
Client traffic with the communication provider node, e.g. a whisper node, is not proxied so make the default port 8547 instead of 8557. It's not a technical problem for it to be 8557, but our convention to present has been for 855* ports to be proxied while the upstream is an 854* port.

Update the boilerplate and demo templates to match.