### PR TITLE
fix(@embark/blockchain): make disabling blockchain feature work

### DIFF
--- a/dapps/templates/demo/app/dapp.js
+++ b/dapps/templates/demo/app/dapp.js
@@ -27,12 +27,15 @@ class App extends React.Component {
 
   componentDidMount() {
     EmbarkJS.onReady((err) => {
-      this.setState({blockchainEnabled: true});
       if (err) {
         // If err is not null then it means something went wrong connecting to ethereum
         // you can use this to ask the user to enable metamask for e.g
         return this.setState({error: err.message || err});
       }
+
+      EmbarkJS.Blockchain.isAvailable().then(result => {
+        this.setState({blockchainEnabled: result});
+      });
 
       EmbarkJS.Messages.isAvailable().then(result => {
         this.setState({whisperEnabled: result});

--- a/packages/embarkjs/embarkjs/src/lib/blockchain.js
+++ b/packages/embarkjs/embarkjs/src/lib/blockchain.js
@@ -89,6 +89,13 @@ Blockchain.setProvider = function(providerName, options) {
   provider.init(options);
 };
 
+Blockchain.isAvailable = function () {
+  if (!this.blockchainConnector) {
+    return Promise.resolve(false);
+  }
+  return this.blockchainConnector.getNetworkId().then(_ => true);
+};
+
 Blockchain.doConnect = function(connectionList, opts, doneCb) {
   const self = this;
 

--- a/packages/embarkjs/embarkjs/src/lib/index.js
+++ b/packages/embarkjs/embarkjs/src/lib/index.js
@@ -6,7 +6,10 @@ import Utils from './utils';
 
 var EmbarkJS = {
   onReady: function (cb) {
-    Blockchain.execWhenReady(cb);
+    if (Blockchain.blockchainConnector) {
+      return Blockchain.execWhenReady(cb);
+    }
+    cb();
   },
   enableEthereum: function () {
     return Blockchain.enableEthereum();

--- a/packages/plugins/web3/src/index.js
+++ b/packages/plugins/web3/src/index.js
@@ -16,7 +16,9 @@ class EmbarkWeb3 {
     this.events = embark.events;
     this.config = embark.config;
 
-    this.setupEmbarkJS();
+    if (this.config.blockchainConfig.enabled) {
+      this.setupEmbarkJS();
+    }
 
     embark.registerActionForEvent("deployment:contract:deployed", {priority: 40}, this.registerInVm.bind(this));
     embark.registerActionForEvent("deployment:contract:undeployed", this.registerInVm.bind(this));

--- a/packages/stack/blockchain/src/index.js
+++ b/packages/stack/blockchain/src/index.js
@@ -37,6 +37,10 @@ class Blockchain {
     });
 
     this.events.setCommandHandler("blockchain:node:start", (blockchainConfig, cb) => {
+      if (!blockchainConfig.enabled) {
+        return cb();
+      }
+
       const clientName = blockchainConfig.client;
       const started = () => {
         this.startedClient = clientName;
@@ -102,6 +106,9 @@ class Blockchain {
   }
 
   addArtifactFile(_params, cb) {
+    if (!this.blockchainConfig.enabled) {
+      cb();
+    }
     this.events.request("config:contractsConfig", (_err, contractsConfig) => {
       async.map(contractsConfig.dappConnection, (conn, mapCb) => {
         if (conn === '$EMBARK') {
@@ -114,7 +121,7 @@ class Blockchain {
           this.logger.error(__('Error getting dapp connection'));
           return cb(err);
         }
-        let config = {
+        const config = {
           provider: contractsConfig.library || 'web3',
           dappConnection: results,
           dappAutoEnable: contractsConfig.dappAutoEnable,

--- a/packages/stack/deployment/src/index.js
+++ b/packages/stack/deployment/src/index.js
@@ -19,6 +19,9 @@ class Deployment {
     });
 
     this.events.setCommandHandler('deployment:contracts:deploy', (contractsList, contractDependencies, cb) => {
+      if (!this.blockchainConfig.enabled) {
+        return cb();
+      }
       this.deployContracts(contractsList, contractDependencies, cb);
     });
   }

--- a/packages/stack/embarkjs/src/index.js
+++ b/packages/stack/embarkjs/src/index.js
@@ -12,6 +12,7 @@ class EmbarkJS {
   constructor(embark, _options) {
     this.embark = embark;
     this.embarkConfig = embark.config.embarkConfig;
+    this.blockchainConfig = embark.config.blockchainConfig;
     this.events = embark.events;
     this.logger = embark.logger;
     this.contractArtifacts = {};

--- a/packages/stack/pipeline/src/index.js
+++ b/packages/stack/pipeline/src/index.js
@@ -24,7 +24,7 @@ class Pipeline {
   generateAll(cb) {
     async.waterfall([
       (next) => {
-        this.plugins.runActionsForEvent("pipeline:generateAll:before", {}, (err) => {
+        this.plugins.runActionsForEvent("pipeline:generateAll:before", (err) => {
           next(err);
         });
       },


### PR DESCRIPTION
Users can turn of blockchain support if they want to using the `blockchain.js`
configuration. In practice however, this has never properly worked as several
places in Embark's codebase weren't actually honoring that configuration value.

This commit introduces the necessary changes so that disabling blockchain support will:

- No longer generate blockchain related EmbarkJS artifacts
- No longer try to deploy Smart Contracts but still compile them