### PR TITLE
Fix test running with another Embark instance running

### DIFF
--- a/packages/core/core/src/engine.ts
+++ b/packages/core/core/src/engine.ts
@@ -232,14 +232,14 @@ export class Engine {
   }
 
   blockchainStackComponents() {
-    this.registerModulePackage('embark-blockchain', { plugins: this.plugins });
+    this.registerModulePackage('embark-blockchain', { plugins: this.plugins, ipc: this.ipc });
     this.registerModulePackage('embark-blockchain-client');
     this.registerModulePackage('embark-process-logs-api-manager');
   }
 
   stackComponents(options) {
     this.registerModulePackage('embark-pipeline', { plugins: this.plugins });
-    this.registerModulePackage('embark-blockchain', { plugins: this.plugins });
+    this.registerModulePackage('embark-blockchain', { plugins: this.plugins, ipc: this.ipc });
     this.registerModulePackage('embark-proxy', { plugins: this.plugins });
     // TODO: coverage param should be part of the request compilation command, not an option here
     // some other params in the options might not longer be relevant, in fact we probably don't need options anymore
@@ -273,7 +273,7 @@ export class Engine {
   }
 
   testComponents(options) {
-    this.registerModulePackage('embark-test-runner', { plugins: this.plugins });
+    this.registerModulePackage('embark-test-runner', { plugins: this.plugins, ipc: this.ipc });
     this.registerModulePackage('embark-coverage', { plugins: this.plugins, coverage: options.coverage });
     this.registerModulePackage('embark-solidity-tests', { plugins: this.plugins, coverage: options.coverage });
     this.registerModulePackage('embark-mocha-tests', { plugins: this.plugins, coverage: options.coverage });

--- a/packages/core/utils/src/network.ts
+++ b/packages/core/utils/src/network.ts
@@ -8,7 +8,7 @@ export function findNextPort(port: number) {
   return new Promise<number>((resolve) => {
     server.once("close", () => resolve(port));
     server.on("error", () => resolve(findNextPort(port + 1)));
-    server.listen(port, () => server.close());
+    server.listen(port, 'localhost', () => server.close());
   });
 }
 

--- a/packages/plugins/solidity/src/solcW.js
+++ b/packages/plugins/solidity/src/solcW.js
@@ -48,7 +48,7 @@ class SolcW {
     const connectionTimeout = setTimeout(() => {
       cb('No compiler through IPC connection');
     }, 1000);
-    this.ipc.request('testConnection', () => {
+    this.ipc.request('testConnection', {}, () => {
       // Connection works, the compiler is available through IPC
       clearTimeout(connectionTimeout);
       cb();
@@ -93,8 +93,8 @@ class SolcW {
 
     if (this.ipc.isServer()) {
       this.ipc.on('compile', this.compile.bind(this));
-      this.ipc.on('testConnection', (cb) => {
-        cb(true);
+      this.ipc.on('testConnection', (_options, cb) => {
+        cb();
       });
     }
   }

--- a/packages/plugins/whisper-geth/src/blockchain.js
+++ b/packages/plugins/whisper-geth/src/blockchain.js
@@ -207,7 +207,7 @@ Blockchain.prototype.run = function () {
     // TOCHECK I don't understand why stderr and stdout are reverted.
     // This happens with Geth and Parity, so it does not seems a client problem
     self.child.stdout.on("data", (data) => {
-      self.logger.info(`${self.client.name} error: ${data}`);
+      self.logger.error(`${self.client.name} error: ${data}`);
     });
 
     self.child.stderr.on("data", async (data) => {

--- a/packages/plugins/whisper-geth/src/blockchainProcessLauncher.js
+++ b/packages/plugins/whisper-geth/src/blockchainProcessLauncher.js
@@ -25,7 +25,7 @@ export class BlockchainProcessLauncher {
     this.logger.info(__("Starting Whisper node in another process").cyan);
 
     this.blockchainProcess = new ProcessLauncher({
-      name: "blockchain",
+      name: "blockchainWhisper",
       modulePath: joinPath(__dirname, "./blockchainProcess.js"),
       logger: this.logger,
       events: this.events,

--- a/packages/plugins/whisper-geth/src/whisperGethClient.js
+++ b/packages/plugins/whisper-geth/src/whisperGethClient.js
@@ -157,7 +157,7 @@ class WhisperGethClient {
     let config = this.config;
     let rpcApi = this.config.rpcApi;
     let wsApi = this.config.wsApi;
-    let args = [];
+    let args = ['--ipcdisable']; // Add --ipcdisable as ipc is not needed for Whisper and it conflicts on Windows with the blockchain node
     async.series([
       function commonOptions(callback) {
         let cmd = self.commonOptions();

--- a/packages/stack/blockchain/src/index.js
+++ b/packages/stack/blockchain/src/index.js
@@ -20,6 +20,12 @@ class Blockchain {
 
     embark.registerActionForEvent("pipeline:generateAll:before", this.addArtifactFile.bind(this));
 
+    if (options.ipc.isServer()) {
+      options.ipc.on('blockchain:node', (_message, cb) => {
+        cb(null, this.blockchainConfig.endpoint);
+      });
+    }
+
     this.blockchainNodes = {};
     this.events.setCommandHandler("blockchain:node:register", (clientName, { isStartedFn, launchFn, stopFn }) => {
 

--- a/packages/stack/proxy/src/index.ts
+++ b/packages/stack/proxy/src/index.ts
@@ -94,7 +94,7 @@ export default class ProxyManager {
 
     // setup ports
     const rpcPort = await findNextPort(this.embark.config.blockchainConfig.rpcPort + constants.blockchain.servicePortOnProxy);
-    const wsPort = await findNextPort(this.embark.config.blockchainConfig.wsPort + constants.blockchain.servicePortOnProxy);
+    const wsPort = await findNextPort(rpcPort + 1);
     this.rpcPort = rpcPort;
     this.wsPort = wsPort;
 

--- a/packages/stack/proxy/src/index.ts
+++ b/packages/stack/proxy/src/index.ts
@@ -93,9 +93,10 @@ export default class ProxyManager {
     this.inited = true;
 
     // setup ports
-    const port = await findNextPort(this.embark.config.blockchainConfig.rpcPort + constants.blockchain.servicePortOnProxy);
-    this.rpcPort = port;
-    this.wsPort = port + 1;
+    const rpcPort = await findNextPort(this.embark.config.blockchainConfig.rpcPort + constants.blockchain.servicePortOnProxy);
+    const wsPort = await findNextPort(this.embark.config.blockchainConfig.wsPort + constants.blockchain.servicePortOnProxy);
+    this.rpcPort = rpcPort;
+    this.wsPort = wsPort;
 
     // setup proxy details
     this.isVm = this.embark.config.blockchainConfig.client === constants.blockchain.vm;


### PR DESCRIPTION
Fix conflict in ports when Embark is already running
Fix using --node for the tests. Makes it work and also uses the Embark compiler correctly over IPC