### PR TITLE
chore(@embark/core): Set DApp plugins to load last

### DIFF
--- a/packages/embark/src/cmd/cmd_controller.js
+++ b/packages/embark/src/cmd/cmd_controller.js
@@ -269,11 +269,6 @@ class EmbarkController {
         engine.init({}, callback);
       },
       callback => {
-        let pluginList = engine.plugins.listPlugins();
-        if (pluginList.length > 0) {
-          engine.logger.info(__("loaded plugins") + ": " + pluginList.join(", "));
-        }
-
         engine.registerModuleGroup("coreComponents");
         engine.registerModuleGroup("stackComponents");
 
@@ -288,6 +283,13 @@ class EmbarkController {
 
         if (!options.onlyCompile) {
           engine.registerModuleGroup("storage");
+        }
+
+        // load custom plugins
+        engine.loadDappPlugins();
+        let pluginList = engine.plugins.listPlugins();
+        if (pluginList.length > 0) {
+          engine.logger.info(__("loaded plugins") + ": " + pluginList.join(", "));
         }
 
         engine.events.on('deployment:deployContracts:afterAll', () => {
@@ -368,11 +370,6 @@ class EmbarkController {
         engine.init({}, callback);
       },
       callback => {
-        let pluginList = engine.plugins.listPlugins();
-        if (pluginList.length > 0) {
-          engine.logger.info(__("loaded plugins") + ": " + pluginList.join(", "));
-        }
-
         engine.registerModuleGroup("coreComponents");
         engine.registerModuleGroup("stackComponents");
         engine.registerModuleGroup("consoleComponents");
@@ -391,6 +388,13 @@ class EmbarkController {
           engine.registerModuleGroup("cockpit");
         }
         engine.registerModulePackage('embark-deploy-tracker', { plugins: engine.plugins });
+
+        // load custom plugins
+        engine.loadDappPlugins();
+        let pluginList = engine.plugins.listPlugins();
+        if (pluginList.length > 0) {
+          engine.logger.info(__("loaded plugins") + ": " + pluginList.join(", "));
+        }
 
         callback();
       },
@@ -470,17 +474,19 @@ class EmbarkController {
         engine.init({}, callback);
       },
       function (callback) {
-        let pluginList = engine.plugins.listPlugins();
-        if (pluginList.length > 0) {
-          engine.logger.info(__("loaded plugins") + ": " + pluginList.join(", "));
-        }
-
         engine.registerModuleGroup("coreComponents");
         engine.registerModuleGroup("stackComponents");
 
         engine.registerModuleGroup("compiler");
         engine.registerModuleGroup("contracts");
         engine.registerModulePackage("embark-graph");
+
+        // load custom plugins
+        engine.loadDappPlugins();
+        let pluginList = engine.plugins.listPlugins();
+        if (pluginList.length > 0) {
+          engine.logger.info(__("loaded plugins") + ": " + pluginList.join(", "));
+        }
 
         engine.startEngine(async () => {
           let contractsFiles = await engine.events.request2("config:contractsFiles");
@@ -660,10 +666,6 @@ class EmbarkController {
         });
       },
       function startServices(callback) {
-        let pluginList = engine.plugins.listPlugins();
-        if (pluginList.length > 0) {
-          engine.logger.info(__("loaded plugins") + ": " + pluginList.join(", "));
-        }
         engine.registerModuleGroup("coreComponents");
         engine.registerModuleGroup("stackComponents");
 
@@ -677,6 +679,13 @@ class EmbarkController {
         engine.registerModuleGroup("filewatcher");
         engine.registerModuleGroup("storage");
         engine.registerModulePackage('embark-deploy-tracker', { plugins: engine.plugins });
+
+        // load custom plugins
+        engine.loadDappPlugins();
+        let pluginList = engine.plugins.listPlugins();
+        if (pluginList.length > 0) {
+          engine.logger.info(__("loaded plugins") + ": " + pluginList.join(", "));
+        }
 
         const plugin = engine.plugins.createPlugin('cmdcontrollerplugin', {});
         plugin.registerActionForEvent("embark:engine:started", async (_params, cb) => {


### PR DESCRIPTION
DApp plugins were already been setup to load last for run and test. This PR sets updates `console`, `build`, `graph`, and `upload` to do the same.