### PR TITLE
refactor(@embark/core): spec embark-whisper-* as deps of embark-core instead of embark

### DIFF
--- a/packages/core/core/package.json
+++ b/packages/core/core/package.json
@@ -54,6 +54,8 @@
     "embark-logger": "^5.0.0-alpha.2",
     "embark-rpc-manager": "^5.0.0-alpha.2",
     "embark-utils": "^5.0.0-alpha.2",
+    "embark-whisper-geth": "^5.0.0-alpha.2",
+    "embark-whisper-parity": "^5.0.0-alpha.2",
     "flatted": "0.2.3",
     "fs-extra": "8.1.0",
     "globule": "1.2.1",

--- a/packages/embark/package.json
+++ b/packages/embark/package.json
@@ -118,8 +118,6 @@
     "embark-watcher": "^5.0.0-alpha.2",
     "embark-web3": "^5.0.0-alpha.2",
     "embark-webserver": "^5.0.0-alpha.2",
-    "embark-whisper-geth": "^5.0.0-alpha.2",
-    "embark-whisper-parity": "^5.0.0-alpha.2",
     "embarkjs-ens": "^5.0.0-alpha.2",
     "embarkjs-ipfs": "^5.0.0-alpha.2",
     "embarkjs-swarm": "^5.0.0-alpha.2",


### PR DESCRIPTION
It is unnecessary and not a good idea for `packages/embark` to provide dependencies to other monorepo packages via any kind of transitive dependency relationship. In this case, `embark` depended on `embark-core` and `embark-core` needs `embark-whisper-*` packages but it's `embark` that supplies those packages indirectly. It works out in the monorepo, *probably* in production too, but we need to move away from that pattern completely.