### PR TITLE
chore(@embark/geth): Add back DevTxs

### DIFF
--- a/packages/plugins/geth/package.json
+++ b/packages/plugins/geth/package.json
@@ -32,10 +32,15 @@
     "_build": "npm run solo -- build",
     "ci": "npm run qa",
     "clean": "npm run reset",
-    "lint": "eslint src/",
-    "qa": "npm-run-all lint _build",
+    "lint": "npm-run-all lint:*",
+    "lint:js": "eslint src/",
+    "lint:ts": "tslint -c tslint.json \"src/**/*.ts\"",
+    "qa": "npm-run-all lint typecheck _build",
     "reset": "npx rimraf dist embark-*.tgz package",
-    "solo": "embark-solo"
+    "solo": "embark-solo",
+    "typecheck": "tsc",
+    "watch": "run-p watch:*",
+    "watch:typecheck": "npm run typecheck -- --preserveWatchOutput --watch"
   },
   "eslintConfig": {
     "extends": "../../../.eslintrc.json"
@@ -51,13 +56,16 @@
     "fs-extra": "8.1.0",
     "netcat": "1.3.5",
     "semver": "5.6.0",
+    "web3": "1.2.1",
     "ws": "7.1.2"
   },
   "devDependencies": {
     "embark-solo": "^5.0.0-alpha.2",
     "eslint": "5.7.0",
     "npm-run-all": "4.1.5",
-    "rimraf": "3.0.0"
+    "rimraf": "3.0.0",
+    "tslint": "5.16.0",
+    "typescript": "3.6.3"
   },
   "engines": {
     "node": ">=10.17.0 <12.0.0",

--- a/packages/plugins/geth/src/devtxs.ts
+++ b/packages/plugins/geth/src/devtxs.ts
@@ -1,0 +1,91 @@
+import { __ } from 'embark-i18n';
+import { Embark, Events, Logger } from "embark";
+import Web3 from "web3";
+import constants from "embark-core/constants.json";
+export default class DevTxs {
+  private embark: Embark;
+  private events: Events;
+  private logger: Logger;
+  private web3?: Web3;
+  private regularTxsInt?: NodeJS.Timeout;
+  constructor(embark: Embark) {
+    this.embark = embark;
+    this.logger = embark.logger;
+    this.events = embark.events;
+  }
+  public async init() {
+    const provider = await this.events.request2("blockchain:client:provider", "ethereum");
+    this.web3 = new Web3(provider);
+
+    const accounts = await this.web3.eth.getAccounts();
+    this.web3.eth.defaultAccount = accounts[0];
+
+    this.registerConsoleCommands();
+  }
+
+  private registerConsoleCommands() {
+    this.embark.registerConsoleCommand({
+      description: __("Toggles regular transactions used to prevent transactions from getting stuck when using Geth and Metamask"),
+      matches: ["devtxs on", "devtxs off", "regularTxs on", "regularTxs off"],
+      usage: "devtxs on/off",
+      process: async (cmd, callback) => {
+        const enable = cmd.trim().endsWith('on');
+        this.logger.info(`${enable ? "Enabling" : "Disabling"} regular transactions...`);
+        if (enable) {
+          try {
+            await this.startRegularTxs();
+          } catch (err) {
+            return callback(err);
+          }
+          callback(null, __("Regular transactions have been enabled"));
+          return;
+        }
+        try {
+          this.stopRegularTxs();
+        } catch (err) {
+          return callback(err);
+        }
+        callback(null, __("Regular transactions have been disabled"));
+      }
+    });
+
+    this.embark.registerConsoleCommand({
+      description: __("Sends a transaction from default --dev account (generally used if txs are getting stuck in geth in development)"),
+      matches: ["senddevtx"],
+      process: async (_cmd, callback) => {
+        this.logger.info(__("Sending a tx from the dev account..."));
+        const receipt = await this.sendTx();
+        callback(null, __("Transaction sent. Tx hash: ") + `\n${JSON.stringify(receipt && receipt.transactionHash)}`);
+      }
+    });
+  }
+
+  private async sendTx() {
+    if (!this.web3) {
+      return;
+    }
+    return this.web3.eth.sendTransaction({ value: "0", to: this.web3.eth.defaultAccount, from: this.web3.eth.defaultAccount });
+  }
+
+  public async startRegularTxs() {
+    if (this.regularTxsInt) {
+      throw new Error("Regular txs already started.");
+    }
+    if (!this.web3) {
+      return;
+    }
+    const networkId = await this.web3.eth.net.getId();
+    if (networkId !== constants.blockchain.networkIds.development) {
+      return;
+    }
+    this.regularTxsInt = setInterval(async () => { await this.sendTx(); }, 1000 * 10);
+  }
+
+  private stopRegularTxs() {
+    if (!this.regularTxsInt) {
+      throw new Error("Regular txs not started.");
+    }
+    clearInterval(this.regularTxsInt);
+    this.regularTxsInt = undefined;
+  }
+}

--- a/packages/plugins/geth/src/index.js
+++ b/packages/plugins/geth/src/index.js
@@ -3,6 +3,7 @@ const { normalizeInput } = require('embark-utils');
 import { BlockchainProcessLauncher } from './blockchainProcessLauncher';
 import { BlockchainClient } from './blockchain';
 import { ws, rpc } from './check.js';
+import DevTxs from "./devtxs";
 const constants = require('embark-core/constants');
 
 class Geth {
@@ -50,6 +51,19 @@ class Geth {
         cb();
       }
     });
+
+    this.setupDevTxs();
+  }
+  
+  async setupDevTxs() {
+    const devTxs = new DevTxs(this.embark);
+    await devTxs.init();
+    try {
+      await devTxs.startRegularTxs();
+      this.logger.info("Regular transactions started");
+    } catch (err) {
+      this.logger.error(`Error starting regular transactions: ${err.message}`);
+    }
   }
 
   shouldInit() {

--- a/packages/plugins/geth/tsconfig.json
+++ b/packages/plugins/geth/tsconfig.json
@@ -1,0 +1,4 @@
+{
+  "extends": "../../../tsconfig.json",
+  "include": ["src/**/*"]
+}

--- a/packages/plugins/geth/tslint.json
+++ b/packages/plugins/geth/tslint.json
@@ -1,0 +1,3 @@
+{
+  "extends": "../../../tslint.json"
+}


### PR DESCRIPTION
Add back DevTxs.

DevTxs sends a zero-value tx to push through any pending txs that may get stuck with geth while in `—dev` mode.

Converted the legacy code in to typescript.