### PR TITLE
fix(@cockpit/ens): ensure default account is set when registering sub…

### DIFF
--- a/packages/plugins/ens/src/index.js
+++ b/packages/plugins/ens/src/index.js
@@ -457,10 +457,9 @@ class ENS {
     ENSFunctions.lookupAddress(address, this.ensContract, namehash, this.createResolverContract.bind(this), cb);
   }
 
-  ensRegisterSubdomain(subdomain, address, cb) {
-    this.events.request("blockchain:defaultAccount:get", (_err, defaultAccount) => {
-      this.safeRegisterSubDomain(subdomain, address, defaultAccount, cb);
-    });
+  async ensRegisterSubdomain(subdomain, address, cb) {
+    const defaultAccount = await this.web3DefaultAccount;
+    this.safeRegisterSubDomain(subdomain, address, defaultAccount, cb);
   }
 
   isENSName(name) {


### PR DESCRIPTION
…domains

Prior to this commit, registering ENS subdomains would fail due to `defaultAccount`
being null. This is because the underlying API was still relying on `blockchain:defaultAccount:get`.

However since the bigger refactor, every plugin/module is in charge of creating its own
blockchain connector instance and ensuring it has a default account.

This commit makes use of ENS' module's `webDefaultAccount` async getter to
ensure a valid default account is set when registering an ENS subdomain.