### PR TITLE
WIP: enable embark-ens' test suite to run in CI

### DIFF
--- a/packages/plugins/ens/package.json
+++ b/packages/plugins/ens/package.json
@@ -34,7 +34,7 @@
     "ci": "npm run qa",
     "clean": "npm run reset",
     "lint": "eslint src/",
-    "qa": "npm-run-all lint _build",
+    "qa": "npm-run-all lint _build test",
     "reset": "npx rimraf dist embark-*.tgz package",
     "solo": "embark-solo",
     "test": "jest"


### PR DESCRIPTION
Adding `test` to `embark-ens`'s `"qa"` script (in its `package.json`) makes it apparent in CI that one of the tests is failing: it times out and even with a very large timeout (several minutes) it never completes.

@PascalPrecht I believe this may have something to do with changes in #2110 but I'm not entirely sure.

I've made this a *draft* PR because I don't have a solution yet for getting the test to pass and I thought someone else on the team who is more familiar with embark's ENS functionality maybe can take over this branch/PR.

After making this discovery, I did a full check of `"qa"` scripts in the monorepo and found more packages that have test suites but don't specify `test` in `"qa"`, so those tests haven't been running in CI. Luckily, all those tests are passing, as can be seen by running `yarn test` in the root of the monorepo. That list of packages is: `embark-coverage`, `embark-mocha-tests`, `embark-solidity-tests`, `embark-communication`, `embark-deployment`, `embark-testing`. I've already added `test` to all of their `"qa"` scripts in my `refactor/typings` branch and that change will be part of my PR for that branch. Also, for now, on `refactor/typings` branch I've changed `it(..)` to `it.skip(...)` for the failing test in `embark-ens`.

Note that at present on `master`, the failing test doesn't cause the lerna process to exit with error. That's something else I've fixed on `refactor/typings` but for this branch (since it's off `master`) look in the CI output above the failing dapp test. The reason the dapp test fails is because after `embark-ens` has a failing test, the CI process never gets to the point of building `packages/embark` though it does go ahead and try to run the test dapps (it shouldn't try to run them at that point and, as mentioned previously, I've fixed that in `refactor/typings`).