### PR TITLE
fix(@embark/ens): fix broken test due to async API

### DIFF
--- a/packages/plugins/ens/package.json
+++ b/packages/plugins/ens/package.json
@@ -34,7 +34,7 @@
     "ci": "npm run qa",
     "clean": "npm run reset",
     "lint": "eslint src/",
-    "qa": "npm-run-all lint _build",
+    "qa": "npm-run-all lint _build test",
     "reset": "npx rimraf dist embark-*.tgz package",
     "solo": "embark-solo",
     "test": "jest"

--- a/packages/plugins/ens/test/index.js
+++ b/packages/plugins/ens/test/index.js
@@ -19,7 +19,8 @@ describe('embark-ens', () => {
       namesystemConfig: {
         register: {
           rootDomain: 'root.eth'
-        }
+        },
+        dappConnection: []
       }
     };
   });
@@ -29,17 +30,18 @@ describe('embark-ens', () => {
   });
 
   it("should register the right artifact", (done) => {
-    const pipelineRegisterHandler = jest.fn((args, cb) => {
-      expect(args).toEqual({
-        path: ['test-dir', 'config'],
-        file: 'namesystem.json',
-        format: 'json',
-        content: Object.assign({}, embark.config.namesystemConfig, ens.getEnsConfig())
+    const pipelineRegisterHandler = jest.fn(async (args, cb) => {
+      ens.getEnsConfig((err, config) => {
+        expect(args).toEqual({
+          path: ['test-dir', 'config'],
+          file: 'namesystem.json',
+          format: 'json',
+          content: Object.assign({}, embark.config.namesystemConfig, config)
+        });
+        cb();
+        done();
       });
-      cb();
-      done();
     });
-    ens.getEnsConfig = jest.fn();
 
     embark.events.setCommandHandler('pipeline:register', pipelineRegisterHandler);
 


### PR DESCRIPTION
As part of https://github.com/embark-framework/embark/pull/2110/commits/8ed5376533b5a165e478f5f12ca74230c33beb7a we made `ENS.getEnsConfig()`
asynchronous, hence it needs a callback. This change was not done in one of the
ENS tests, resulting in the test to fail. The test mocked that particular API,
turning it into noop, which is why the test kept timing out.

This commit fixes the test by not mocking the API and adding the needed configuration
to the environment.