### PR TITLE
build: specify missing test action in relevant package.json "qa" scripts

### DIFF
--- a/packages/plugins/coverage/package.json
+++ b/packages/plugins/coverage/package.json
@@ -34,7 +34,7 @@
     "clean": "npm run reset",
     "lint": "npm-run-all lint:*",
     "lint:ts": "tslint -c tslint.json \"src/**/*.ts\"",
-    "qa": "npm-run-all lint typecheck _build",
+    "qa": "npm-run-all lint typecheck _build test",
     "reset": "npx rimraf dist embark-*.tgz package",
     "solo": "embark-solo",
     "test": "nyc --reporter=html --reporter=json mocha \"dist/test/**/*.js\" --exit --no-timeouts --require source-map-support/register",

--- a/packages/plugins/ens/package.json
+++ b/packages/plugins/ens/package.json
@@ -53,6 +53,7 @@
     "web3": "1.2.1"
   },
   "devDependencies": {
+    "@babel/core": "7.7.4",
     "babel-eslint": "10.0.3",
     "babel-jest": "24.9.0",
     "embark-solo": "^5.0.0-alpha.2",
@@ -79,7 +80,15 @@
     "testEnvironment": "node",
     "testMatch": [
       "**/test/**/*.js"
-    ]
+    ],
+    "transform": {
+      "\\.js$": [
+        "babel-jest",
+        {
+          "rootMode": "upward"
+        }
+      ]
+    }
   },
   "engines": {
     "node": ">=10.17.0 <12.0.0",

--- a/packages/plugins/ens/test/index.js
+++ b/packages/plugins/ens/test/index.js
@@ -1,4 +1,4 @@
-const ENS = require("../dist/index");
+const ENS = require("../src/index");
 const { fakeEmbark } = require('embark-testing');
 const {Utils} = require('embarkjs');
 const secureSend = Utils.secureSend;
@@ -11,6 +11,7 @@ describe('embark-ens', () => {
 
   beforeEach(() => {
     embark.events.setCommandHandler('namesystem:node:register', () => {});
+    embark.config.blockchainConfig = { enabled: true };
     ens = new ENS(embark);
     ens.config = {
       embarkConfig: {

--- a/packages/plugins/mocha-tests/package.json
+++ b/packages/plugins/mocha-tests/package.json
@@ -32,7 +32,7 @@
     "ci": "npm run qa",
     "clean": "npm run reset",
     "lint": "eslint src/",
-    "qa": "npm-run-all lint _build",
+    "qa": "npm-run-all lint _build test",
     "reset": "npx rimraf .nyc_output dist embark-*.tgz package",
     "solo": "embark-solo",
     "test": "nyc --reporter=html --reporter=json mocha \"dist/test/**/*.js\" --exit --no-timeouts --require source-map-support/register"

--- a/packages/plugins/solidity-tests/package.json
+++ b/packages/plugins/solidity-tests/package.json
@@ -32,7 +32,7 @@
     "ci": "npm run qa",
     "clean": "npm run reset",
     "lint": "eslint src/",
-    "qa": "npm-run-all lint _build",
+    "qa": "npm-run-all lint _build test",
     "reset": "npx rimraf .nyc_output dist embark-*.tgz package",
     "solo": "embark-solo",
     "test": "nyc --reporter=html --reporter=json mocha \"dist/test/**/*.js\" --exit --no-timeouts --require source-map-support/register"
@@ -42,6 +42,7 @@
   },
   "dependencies": {
     "@babel/runtime-corejs3": "7.7.4",
+    "@types/async": "3.0.3",
     "async": "3.1.0",
     "core-js": "3.4.3",
     "remix-tests": "0.1.20",
@@ -49,13 +50,14 @@
     "yo-yoify": "4.3.0"
   },
   "devDependencies": {
-    "@types/async": "3.0.3",
     "embark-solo": "^5.0.0-alpha.2",
+    "embark-utils": "^5.0.0-alpha.2",
     "eslint": "5.7.0",
     "mocha": "6.2.2",
     "npm-run-all": "4.1.5",
     "nyc": "13.1.0",
     "rimraf": "3.0.0",
+    "sinon": "7.4.2",
     "source-map-support": "0.5.13"
   },
   "engines": {

--- a/packages/stack/communication/package.json
+++ b/packages/stack/communication/package.json
@@ -33,7 +33,7 @@
     "ci": "npm run qa",
     "clean": "npm run reset",
     "lint": "eslint src/",
-    "qa": "npm-run-all lint _build",
+    "qa": "npm-run-all lint _build test",
     "reset": "npx rimraf dist embark-*.tgz package",
     "solo": "embark-solo",
     "test": "jest"

--- a/packages/stack/deployment/package.json
+++ b/packages/stack/deployment/package.json
@@ -33,7 +33,7 @@
     "ci": "npm run qa",
     "clean": "npm run reset",
     "lint": "eslint src/",
-    "qa": "npm-run-all lint _build",
+    "qa": "npm-run-all lint _build test",
     "reset": "npx rimraf dist embark-*.tgz package",
     "solo": "embark-solo",
     "test": "jest"

--- a/packages/stack/deployment/test/deployment.spec.js
+++ b/packages/stack/deployment/test/deployment.spec.js
@@ -15,6 +15,7 @@ describe('stack/deployment', () => {
   let doneCb;
 
   beforeEach(() => {
+    embark.config.blockchainConfig = { enabled: true };
     deployment = new Deployment(embark, { plugins });
 
     beforeAllAction = sinon.spy((params, cb) => { cb(null, params); });

--- a/packages/utils/testing/package.json
+++ b/packages/utils/testing/package.json
@@ -34,7 +34,7 @@
     "lint": "npm-run-all lint:*",
     "lint:js": "eslint src/",
     "lint:ts": "tslint -c tslint.json \"src/**/*.ts\"",
-    "qa": "npm-run-all lint typecheck _build",
+    "qa": "npm-run-all lint typecheck _build test",
     "reset": "npx rimraf dist embark-*.tgz package",
     "solo": "embark-solo",
     "typecheck": "tsc",


### PR DESCRIPTION
It's a relevant `package.json` if the package has a test suite. If `test` isn't specified then the tests won't run in CI (they have't been running).

Include a fix for one failing test in `packages/plugins/ens` and two failing test in `packages/stack/deployment`. In all three cases, the mock embark object's config needed a `blockchainConfig` section with `{ enabled: true }`.