### PR TITLE
Fix connecting to an external node

### DIFF
--- a/packages/core/core/src/config.ts
+++ b/packages/core/core/src/config.ts
@@ -10,6 +10,7 @@ const constants = require('embark-core/constants');
 import { __ } from 'embark-i18n';
 import {
   buildUrlFromConfig,
+  deconstructUrl,
   canonicalHost,
   dappPath,
   defaultHost,
@@ -389,16 +390,27 @@ export class Config {
       });
     }
 
-    if (!this.blockchainConfig.endpoint) {
+    if (this.blockchainConfig.endpoint) {
+      const {type, host, port} = deconstructUrl(this.blockchainConfig.endpoint);
+      if (type === 'ws') {
+        this.blockchainConfig.wsHost = host;
+        this.blockchainConfig.wsPort = port;
+        this.blockchainConfig.wsRPC = true;
+      } else {
+        this.blockchainConfig.rpcHost = host;
+        this.blockchainConfig.rpcPort = port;
+        this.blockchainConfig.wsRPC = false;
+      }
+    } else {
       const urlConfig = (this.blockchainConfig.wsHost) ? {
         host: this.blockchainConfig.wsHost,
         port: this.blockchainConfig.wsPort,
         type: 'ws'
       } : {
-          host: this.blockchainConfig.rpcHost,
-          port: this.blockchainConfig.rpcPort,
-          type: 'rpc'
-        };
+        host: this.blockchainConfig.rpcHost,
+        port: this.blockchainConfig.rpcPort,
+        type: 'rpc'
+      };
       this.blockchainConfig.endpoint = buildUrlFromConfig(urlConfig);
       this.blockchainConfig.isAutoEndpoint = true;
     }

--- a/packages/embarkjs/embarkjs/src/lib/blockchain.js
+++ b/packages/embarkjs/embarkjs/src/lib/blockchain.js
@@ -100,18 +100,23 @@ Blockchain.doConnect = function(connectionList, opts, doneCb) {
   const self = this;
 
   const checkConnect = (next) => {
-    this.blockchainConnector.getAccounts((error, _a) => {
-      const provider = self.blockchainConnector.getCurrentProvider();
-      const connectionString = provider.host;
-
-      if (error) this.blockchainConnector.setProvider(null);
-
-      return next(null, {
-        connectionString,
-        error,
-        connected: !error
+    const provider = self.blockchainConnector.getCurrentProvider();
+    const connectionString = provider.host;
+    this.blockchainConnector.getNetworkId()
+      .then(_id => {
+        next(null, {
+          connectionString,
+          error: null,
+          connected: true
+        });
+      })
+      .catch(error => {
+        next(null, {
+          connectionString,
+          error,
+          connected: false
+        });
       });
-    });
   };
 
   const connectWeb3 = async (next) => {
@@ -171,10 +176,7 @@ Blockchain.doConnect = function(connectionList, opts, doneCb) {
       return doneCb(new BlockchainConnectionError(connectionErrs));
     }
 
-    self.blockchainConnector.getAccounts(async (err, accounts) => {
-      if (err) {
-        return doneCb(err);
-      }
+    self.blockchainConnector.getAccounts(async (_err, accounts) => {
       const currentProv = self.blockchainConnector.getCurrentProvider();
       if (opts.warnAboutMetamask) {
         // if we are using metamask, ask embark to turn on dev_funds

--- a/packages/embarkjs/embarkjs/src/test/blockchain.js
+++ b/packages/embarkjs/embarkjs/src/test/blockchain.js
@@ -1,4 +1,4 @@
-/* global before describe it require */
+/* global before describe it */
 
 const {startRPCMockServer, TestProvider} = require('./helpers/blockchain');
 const {assert} = require('chai');
@@ -50,7 +50,8 @@ describe('Blockchain', () => {
         await new Promise((resolve, reject) => {
           Blockchain.connect({dappConnection}, err => {
             try {
-              assert(scenario.error ? err : !err);
+              assert(scenario.error ? err : !err,
+                scenario.error ? 'There should have been an error, but there was none' : 'There should not have been an error, but there was one');
               servers.forEach((server, idx) => {
                 assert.strictEqual(server.visited, scenario.visited[idx]);
               });

--- a/packages/embarkjs/embarkjs/src/test/helpers/blockchain.js
+++ b/packages/embarkjs/embarkjs/src/test/helpers/blockchain.js
@@ -27,11 +27,9 @@ const startRPCMockServer = (options = {}, callback) => {
     req.on('end', () => {
       const request = JSON.parse(body);
       const accountsResponse = JSON.stringify({
-        "jsonrpc": "2.0",
-        "id": request.id,
-        "result": [
-          "0x7c67d951b7338a96168f259a16b7ba25e7a30315"
-        ]
+        jsonrpc: "2.0",
+        id: request.id,
+        result: 1337
       });
 
       res.writeHead(200, {

--- a/packages/plugins/geth/src/check.js
+++ b/packages/plugins/geth/src/check.js
@@ -1,5 +1,6 @@
 const WebSocket = require("ws");
 const http = require("http");
+const https = require("https");
 
 const LIVENESS_CHECK = `{"jsonrpc":"2.0","method":"web3_clientVersion","params":[],"id":42}`;
 
@@ -20,10 +21,8 @@ const parseAndRespond = (data, cb) => {
   cb(null, version);
 };
 
-const rpc = (host, port, cb) => {
+const rpcWithEndpoint = (endpoint, cb) => {
   const options = {
-    hostname: host, // TODO(andremedeiros): get from config
-    port: port, // TODO(andremedeiros): get from config
     method: "POST",
     timeout: 1000,
     headers: {
@@ -32,7 +31,12 @@ const rpc = (host, port, cb) => {
     }
   };
 
-  const req = http.request(options, (res) => {
+  let obj = http;
+  if (endpoint.startsWith('https')) {
+    obj = https;
+  }
+
+  const req = obj.request(endpoint, options, (res) => {
     let data = "";
     res.on("data", chunk => { data += chunk; });
     res.on("end", () => parseAndRespond(data, cb));
@@ -42,8 +46,8 @@ const rpc = (host, port, cb) => {
   req.end();
 };
 
-const ws = (host, port, cb) => {
-  const conn = new WebSocket("ws://" + host + ":" + port);
+const ws = (endpoint, cb) => {
+  const conn = new WebSocket(endpoint);
   conn.on("message", (data) => {
     parseAndRespond(data, cb);
     conn.close();
@@ -54,5 +58,5 @@ const ws = (host, port, cb) => {
 
 module.exports = {
   ws,
-  rpc
+  rpcWithEndpoint
 };

--- a/packages/plugins/parity/src/index.js
+++ b/packages/plugins/parity/src/index.js
@@ -2,7 +2,7 @@ import { __ } from 'embark-i18n';
 import {BlockchainClient} from "./blockchain";
 const {normalizeInput} = require('embark-utils');
 import {BlockchainProcessLauncher} from './blockchainProcessLauncher';
-import {ws, rpc} from './check.js';
+import {ws, rpcWithEndpoint} from './check.js';
 const constants = require('embark-core/constants');
 
 class Parity {
@@ -70,11 +70,10 @@ class Parity {
   }
 
   _doCheck(cb) {
-    const { rpcHost, rpcPort, wsRPC, wsHost, wsPort } = this.blockchainConfig;
-    if (wsRPC) {
-      return ws(wsHost, wsPort, (err, version) => this._getNodeState(err, version, cb));
+    if (this.blockchainConfig.endpoint.startsWith('ws')) {
+      return ws(this.blockchainConfig.endpoint, (err, version) => this._getNodeState(err, version, cb));
     }
-    rpc(rpcHost, rpcPort, (err, version) => this._getNodeState(err, version, cb));
+    rpcWithEndpoint(this.blockchainConfig.endpoint, (err, version) => this._getNodeState(err, version, cb));
   }
 
   // TODO: need to get correct port taking into account the proxy

--- a/packages/plugins/rpc-manager/src/lib/eth_accounts.ts
+++ b/packages/plugins/rpc-manager/src/lib/eth_accounts.ts
@@ -21,6 +21,12 @@ export default class EthAccounts extends RpcModifier {
   constructor(embark: Embark, rpcModifierEvents: Events) {
     super(embark, rpcModifierEvents);
 
+    this.init();
+  }
+
+  private async init() {
+    await this.nodeAccounts;
+
     this.embark.registerActionForEvent("blockchain:proxy:response", this.ethAccountsResponse.bind(this));
   }
 

--- a/packages/plugins/rpc-manager/src/lib/rpcModifier.ts
+++ b/packages/plugins/rpc-manager/src/lib/rpcModifier.ts
@@ -44,7 +44,7 @@ export default class RpcModifier {
   public set nodeAccounts(nodeAccounts: Promise<any[]>) {
     (async () => {
       this._nodeAccounts = await nodeAccounts;
-      // reset accounts backing variable as it neesd to be recalculated
+      // reset accounts backing variable as it needs to be recalculated
       this._accounts = null;
     })();
   }

--- a/packages/plugins/whisper-geth/src/index.js
+++ b/packages/plugins/whisper-geth/src/index.js
@@ -3,7 +3,7 @@ import { dappPath, canonicalHost, defaultHost } from "embark-utils";
 const constants = require("embark-core/constants");
 const API = require("./api.js");
 import { BlockchainProcessLauncher } from "./blockchainProcessLauncher";
-import { ws, rpc } from "./check.js";
+import { ws, rpcWithEndpoint } from "./check.js";
 const { normalizeInput } = require("embark-utils");
 
 class Whisper {
@@ -64,12 +64,10 @@ class Whisper {
 
   registerServiceCheck() {
     this.events.request("services:register", "Whisper", (cb) => {
-      const { host, port, type } = this.communicationConfig.connection;
-      if (type === "ws") {
-        return ws(host, port, (err, version) => this._getNodeState(err, version, cb));
+      if (this.blockchainConfig.endpoint.startsWith('ws')) {
+        return ws(this.blockchainConfig.endpoint, (err, version) => this._getNodeState(err, version, cb));
       }
-      rpc(host, port, (err, version) => this._getNodeState(err, version, cb));
-
+      rpcWithEndpoint(this.blockchainConfig.endpoint, (err, version) => this._getNodeState(err, version, cb));
     }, 5000, "off");
   }
 

--- a/packages/stack/proxy/src/index.ts
+++ b/packages/stack/proxy/src/index.ts
@@ -92,8 +92,13 @@ export default class ProxyManager {
     }
     this.inited = true;
 
+    let port = this.embark.config.blockchainConfig.rpcPort;
+    if (!port && port !== 0) {
+      port = 8545;
+    }
+
     // setup ports
-    const rpcPort = await findNextPort(this.embark.config.blockchainConfig.rpcPort + constants.blockchain.servicePortOnProxy);
+    const rpcPort = await findNextPort(port + constants.blockchain.servicePortOnProxy);
     const wsPort = await findNextPort(rpcPort + 1);
     this.rpcPort = rpcPort;
     this.wsPort = wsPort;


### PR DESCRIPTION
Long story short, we did not support connecting to HTTPS and WSS urls at all for the nodes. Also, just anything not localhost was not very supported

As you'll see, I had to duplicate the fix 3 times for Geth, Parity and Whisper... Maybe we could reopen the conversation about abstracting some of that.