### PR TITLE
fix(@embark/embarkjs): use getNetworkId to test connection

### DIFF
--- a/packages/embarkjs/embarkjs/src/lib/blockchain.js
+++ b/packages/embarkjs/embarkjs/src/lib/blockchain.js
@@ -100,18 +100,23 @@ Blockchain.doConnect = function(connectionList, opts, doneCb) {
   const self = this;
 
   const checkConnect = (next) => {
-    this.blockchainConnector.getAccounts((error, _a) => {
-      const provider = self.blockchainConnector.getCurrentProvider();
-      const connectionString = provider.host;
-
-      if (error) this.blockchainConnector.setProvider(null);
-
-      return next(null, {
-        connectionString,
-        error,
-        connected: !error
+    const provider = self.blockchainConnector.getCurrentProvider();
+    const connectionString = provider.host;
+    this.blockchainConnector.getNetworkId()
+      .then(_id => {
+        next(null, {
+          connectionString,
+          error: null,
+          connected: true
+        });
+      })
+      .catch(error => {
+        next(null, {
+          connectionString,
+          error,
+          connected: false
+        });
       });
-    });
   };
 
   const connectWeb3 = async (next) => {
@@ -171,10 +176,7 @@ Blockchain.doConnect = function(connectionList, opts, doneCb) {
       return doneCb(new BlockchainConnectionError(connectionErrs));
     }
 
-    self.blockchainConnector.getAccounts(async (err, accounts) => {
-      if (err) {
-        return doneCb(err);
-      }
+    self.blockchainConnector.getAccounts(async (_err, accounts) => {
       const currentProv = self.blockchainConnector.getCurrentProvider();
       if (opts.warnAboutMetamask) {
         // if we are using metamask, ask embark to turn on dev_funds

--- a/packages/embarkjs/embarkjs/src/test/blockchain.js
+++ b/packages/embarkjs/embarkjs/src/test/blockchain.js
@@ -1,4 +1,4 @@
-/* global before describe it require */
+/* global before describe it */
 
 const {startRPCMockServer, TestProvider} = require('./helpers/blockchain');
 const {assert} = require('chai');
@@ -50,7 +50,8 @@ describe('Blockchain', () => {
         await new Promise((resolve, reject) => {
           Blockchain.connect({dappConnection}, err => {
             try {
-              assert(scenario.error ? err : !err);
+              assert(scenario.error ? err : !err,
+                scenario.error ? 'There should have been an error, but there was none' : 'There should not have been an error, but there was one');
               servers.forEach((server, idx) => {
                 assert.strictEqual(server.visited, scenario.visited[idx]);
               });

--- a/packages/embarkjs/embarkjs/src/test/helpers/blockchain.js
+++ b/packages/embarkjs/embarkjs/src/test/helpers/blockchain.js
@@ -27,11 +27,9 @@ const startRPCMockServer = (options = {}, callback) => {
     req.on('end', () => {
       const request = JSON.parse(body);
       const accountsResponse = JSON.stringify({
-        "jsonrpc": "2.0",
-        "id": request.id,
-        "result": [
-          "0x7c67d951b7338a96168f259a16b7ba25e7a30315"
-        ]
+        jsonrpc: "2.0",
+        id: request.id,
+        result: 1337
       });
 
       res.writeHead(200, {


### PR DESCRIPTION
Changes the connection check to `getNetworkId` because using `getAccounts` was not a good idea because of EIP1102.

Basically, in Status, if the user didn't give access to his wallet, `getAccounts` returns an error, which EmbarkJS interprets as a faulty connection.

When using `dappAutoEnable: false`, this triggered the error straight away

NB: this merges in https://github.com/embark-framework/embark/pull/2133