### PR TITLE
fix(@embark/dapps): Contracts app test failure

### DIFF
--- a/dapps/tests/contracts/contracts.json
+++ b/dapps/tests/contracts/contracts.json
@@ -4,6 +4,7 @@
       "solc": "0.4.24"
     },
     "dappConnection": [
+      "$EMBARK",
       "$WEB3",
       "ws://localhost:8546",
       "http://localhost:8550",

--- a/packages/embarkjs/ens/src/index.js
+++ b/packages/embarkjs/ens/src/index.js
@@ -228,9 +228,9 @@ __embarkENS.setProvider = function(config) {
     if (!result.connected || result.error) {
       console.error(result.error);
     }
-    const accounts = await self.web3.eth.getAccounts();
-    self.web3.eth.defaultAccount = accounts[0];
     try {
+      const accounts = await self.web3.eth.getAccounts();
+      self.web3.eth.defaultAccount = accounts[0];
       const id = await self.web3.eth.net.getId()
       const registryAddress = self.registryAddresses[id] || config.registryAddress;
       self._isAvailable = true;


### PR DESCRIPTION
During `embark test`, the contracts dapp was throwing an error:
```
connection not open on send()
Error: Invalid JSON RPC response: ""
    at Object.InvalidResponse (/Users/michael/repos/embark/node_modules/web3-core-helpers/src/errors.js:42:16)
    at XMLHttpRequest.request.onreadystatechange (/Users/michael/repos/embark/node_modules/web3-providers-http/src/index.js:92:32)
    at XMLHttpRequestEventTarget.dispatchEvent (/Users/michael/repos/embark/node_modules/xhr2-cookies/xml-http-request-event-target.ts:44:13)
    at XMLHttpRequest._setReadyState (/Users/michael/repos/embark/node_modules/xhr2-cookies/xml-http-request.ts:219:8)
    at XMLHttpRequest._onHttpRequestError (/Users/michael/repos/embark/node_modules/xhr2-cookies/xml-http-request.ts:379:8)
    at ClientRequest.<anonymous> (/Users/michael/repos/embark/node_modules/xhr2-cookies/xml-http-request.ts:266:37)
    at ClientRequest.emit (events.js:198:13)
    at Socket.socketErrorListener (_http_client.js:392:9)
    at Socket.emit (events.js:198:13)
    at emitErrorNT (internal/streams/destroy.js:91:8)
    at emitErrorAndCloseNT (internal/streams/destroy.js:59:3)
    at process._tickCallback (internal/process/next_tick.js:63:19)
(node:75120) UnhandledPromiseRejectionWarning: Error: Provider not set or invalid
...
```

This was due to the fact that during testing, the Ganache VM **provider** is used as the blockchain node, instead of spinning up an instance of Ganache. Due to this, there is no HTTP nor WebSockets RPC endpoint opened on the VM node, and the contracts dapp was not able to connect to the node during tests.

Add `$EMBARK` to the contract config’s `dappConnection` list, so that the contract test dapp can successfully connect to Embark’s proxy, which ultimately communicates with the Ganache VM.

As a side note, without `$EMBARK` in the `dappConnection` list, the tests could run successfully when using `embark test —node=embark`. This succeeds because the geth node exposes the RPC WebSockets endpoint that the contracts app connects to on `ws://localhost:8546`.