### PR TITLE
fix(@cockpit/contracts): ensure contract state is emitted in realtime

### DIFF
--- a/packages/embark/src/cmd/dashboard/dashboard.js
+++ b/packages/embark/src/cmd/dashboard/dashboard.js
@@ -41,18 +41,6 @@ class Dashboard {
       '/embark-api/dashboard',
       (ws, _req) => {
         let dashboardState = {contractsState: [], environment: "", status: "", availableServices: []};
-
-
-
-        // self.events.request('setDashboardState');
-        // self.events.on('contractsState', (contracts) => {
-        //   dashboardState.contractsState = [];
-
-        //   contracts.forEach(function (row) {
-        //     dashboardState.contractsState.push({contractName: row[0], address: row[1], status: row[2]});
-        //   });
-        //   ws.send(JSON.stringify(dashboardState));
-        // });
         self.events.on('status', (status) => {
           dashboardState.status = status;
           ws.send(JSON.stringify(dashboardState));
@@ -64,32 +52,22 @@ class Dashboard {
       }
     );
 
-    // this.events.on('contractsState', monitor.setContracts);
-
     this.events.on("deployment:contract:error", (_contract) => {
       this.events.request("contracts:state", (err, contracts) => {
         monitor.setContracts(contracts)
       });
-      // self.events.emit('contractsState', self.contractsState());
     });
 
     this.events.on("deployment:contract:deployed", (_contract) => {
-      // self.events.emit('contractsState', self.contractsState());
       this.events.request("contracts:state", (err, contracts) => {
+        this.events.emit('contracts:state', contracts);
         monitor.setContracts(contracts);
       });
     });
 
     this.events.on("deployment:contract:undeployed", (_contract) => {
-      // self.events.emit('contractsState', self.contractsState());
       this.events.request("contracts:state", (err, contracts) => {
-        monitor.setContracts(contracts);
-      });
-    });
-
-    this.events.on("deployment:contract:undeployed", (_contract) => {
-      // self.events.emit('contractsState', self.contractsState());
-      this.events.request("contracts:state", (err, contracts) => {
+        this.events.emit('contracts:state', contracts);
         monitor.setContracts(contracts)
       });
     });

--- a/packages/stack/contracts-manager/src/index.js
+++ b/packages/stack/contracts-manager/src/index.js
@@ -83,7 +83,7 @@ export default class ContractsManager {
     });
 
     this.events.setCommandHandler('setDashboardState', () => {
-      self.events.emit('contractsState', self.contractsState());
+      self.events.emit('contracts:state', self.contractsState());
     });
   }
 
@@ -200,7 +200,7 @@ export default class ContractsManager {
         this.events.on('contractsDeployed', () => {
           ws.send(JSON.stringify(this._contractsForApi()), () => undefined);
         });
-        this.events.on('contractsState', () => {
+        this.events.on('contracts:state', () => {
           ws.send(JSON.stringify(this._contractsForApi()), () => undefined);
         });
       }


### PR DESCRIPTION
This fixes a bug that redeployment of contracts has not been properly
reflected in the cockpit contract list.

The reason for that was that it's listening for a websocket API that
only updates when the `contractsState` event has been emitted.

The commit ensures `contractsState` is emitted during dedicated deployment
events.