### PR TITLE
fix(@embark/engine): ensure deployment hook logs don't produce unexpected output

### DIFF
--- a/packages/core/engine/src/index.ts
+++ b/packages/core/engine/src/index.ts
@@ -323,23 +323,25 @@ function interceptLogs(consoleContext, logger) {
   const context: any = {};
   context.console = consoleContext;
 
-  context.console.log = () => {
+  /* tslint:disable:only-arrow-functions */
+  context.console.log = function() {
     logger.info(normalizeInput(arguments));
   };
-  context.console.warn = () => {
+  context.console.warn = function() {
     logger.warn(normalizeInput(arguments));
   };
-  context.console.info = () => {
+  context.console.info = function() {
     logger.info(normalizeInput(arguments));
   };
-  context.console.debug = () => {
+  context.console.debug = function() {
     // TODO: ue JSON.stringify
     logger.debug(normalizeInput(arguments));
   };
-  context.console.trace = () => {
+  context.console.trace = function() {
     logger.trace(normalizeInput(arguments));
   };
-  context.console.dir = () => {
+  context.console.dir = function() {
     logger.dir(normalizeInput(arguments));
   };
+  /* tslint:enable:only-arrow-functions */
 }


### PR DESCRIPTION
Since https://github.com/embark-framework/embark/commit/ee56f3771389a00e019eadce595dcf30468f0afe, any deployment hook that
was using simple `console.log()` statements to output information, would result in
unexpected `[[object object], [object object]]`.

Unfortunately, the reason for that was that we switched from non-arrow functions to
arrow functions [here](https://github.com/embark-framework/embark/commit/ee56f3771389a00e019eadce595dcf30468f0afe#diff-a7c4cef8bfebeb39fcd092aca5570fecL324-L340). Usually switching from non-arrow functions to arrow functions solves
a lot of lexical scope issues where the current reference of `this` isn't pointing at the
right thing.

We're tempering with the global `console.log` inside Embark, which then, combined with
**proper** lexical scope, causes the output described above.

Generally there are a few ways to go about this:

1. Ensure that our custom log functions doesn't turn every log statement into an array output
2. Tell users not to use `console.log` inside deployment hooks and instead rely on `deps.logger`
3. Revert the changes made in the mentioned commit and use non-arrow functions inside `interceptLogs`

Option 2) is not really a solution as we can't simply tell our users that they can't use one of
the most used functions in JavaScript. Option 1) requires finding out why we're formatting logs
by default in an array shapre in the first place. On top of that, we might be relying on this
inside Embark, so it could break certain output.

Option 3) seems to be the most pragmatic solution for now as it doesn't introduce any of the
downsides mentioned above at the cost of using non-arrow functions.