### PR TITLE
Fixes so that the tests in Teller work

### DIFF
--- a/packages/plugins/mocha-tests/src/lib/index.js
+++ b/packages/plugins/mocha-tests/src/lib/index.js
@@ -75,6 +75,18 @@ class MochaTestRunner {
               next();
             });
           },
+
+          (next) => {
+            this.web3.eth.getAccounts((err, accts) => {
+              if (err) {
+                return next(err);
+              }
+              accounts = accts;
+              this.web3.eth.defaultAccount = accts[0];
+              global.web3.eth.defaultAccount = accts[0];
+              next();
+            });
+          },
           (next) => {
           // Remove contracts that are not in the configs
             const realContracts = {};
@@ -117,16 +129,12 @@ class MochaTestRunner {
               if (!compiledContracts[contract.className]) {
                 compiledContracts[contract.className] = {};
               }
+              instance.options.from = accounts[0];
+              instance.options.gas = 900000;
               Object.setPrototypeOf(compiledContracts[contract.className], instance);
             }
 
             next();
-          },
-          (next) => {
-            this.web3.eth.getAccounts((err, accts) => {
-              accounts = accts;
-              next(err);
-            });
           }
         ], (err) => {
           // Reset the gas accumulator so that we don't show deployment gas on the

--- a/packages/plugins/mocha-tests/src/lib/index.js
+++ b/packages/plugins/mocha-tests/src/lib/index.js
@@ -7,6 +7,7 @@ const Web3 = require('web3');
 
 const Reporter = require('./reporter');
 
+const GAS_LIMIT = 6000000;
 const JAVASCRIPT_TEST_MATCH = /^.+\.js$/i;
 const TEST_TIMEOUT = 15000; // 15 seconds in milliseconds
 
@@ -130,7 +131,7 @@ class MochaTestRunner {
                 compiledContracts[contract.className] = {};
               }
               instance.options.from = accounts[0];
-              instance.options.gas = 900000;
+              instance.options.gas = GAS_LIMIT;
               Object.setPrototypeOf(compiledContracts[contract.className], instance);
             }
 


### PR DESCRIPTION
- Fix account management in tests so that contracts have the right `from` address and have a basic `gas` value (that value is relatively arbitrary, I'm not sure what we used to have, but I had to add this value for tests to work)
- Fix the sign data rpc call so that it compares addresses correctly, other wise, it didn't detect that accounts were part of the Node