### PR TITLE
docs: add CHANGELOG.md entry for v4.2.0 into master

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,26 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 
 
+# [4.2.0](https://github.com/embark-framework/embark/compare/v4.1.1...v4.2.0) (2019-12-18)
+
+
+### Build System
+
+* **deps:** bump web3[-*] from 1.2.1 to 1.2.4 ([e7ed552](https://github.com/embark-framework/embark/commit/e7ed552))
+
+
+### BREAKING CHANGES
+
+* **deps:** bump embark's minimum supported version of geth from
+`>=1.8.14` to `>=1.9.0` and its minimum supported version of parity from
+`>=2.0.0` to `>=2.2.1`. This is necessary since web3 1.2.4 makes use of the
+`eth_chainId` RPC method (EIP 695) and those client versions are the earliest
+ones to implement it.
+
+
+
+
+
 # [5.0.0-alpha.7](https://github.com/embark-framework/embark/compare/v5.0.0-alpha.6...v5.0.0-alpha.7) (2019-12-18)
 
 


### PR DESCRIPTION
The release of v4.2.0 was done from the `4.2.x` branch, so it's necessary to add it manually.

---

**QUESTIONS**

In the [comparison view](https://github.com/embark-framework/embark/compare/v4.1.1...v4.2.0) of v4.1.1 with v4.2.0 there were 46 `CHANGELOG.md` files updated.

So in this kind of situation, where a release was done from a branch other than `master`, do we think it's important to manually add all the changelog entries to their respective changelog files in `master` (if the package exists in `master`), or is it satisfactory to add only the root changelog entry?

Also, is it better to put the entry for 4.2.0 at the top or should it be situated between the entries for 4.1.1 and 5.0.0-alpha.0? There's a date included in the first line of each changelog entry, so I'm guessing it's better to keep it at the top, i.e. in date-order.

Once we've decided on these questions, I'll make any necessary changes and take this PR out of draft.