### PR TITLE
fix(@embark/coverage): ensure handlers for 'tests:finished' are run a…

### DIFF
--- a/packages/plugins/coverage/src/lib/index.ts
+++ b/packages/plugins/coverage/src/lib/index.ts
@@ -40,7 +40,7 @@ export default class Coverage {
     });
 
     this.embark.events.on("tests:ready", this.pushDeployedContracts.bind(this));
-    this.embark.events.on("tests:finished", this.produceCoverageReport.bind(this));
+    this.embark.registerActionForEvent("tests:finished", this.produceCoverageReport.bind(this));
     this.embark.events.on("tests:manualDeploy", this.registerWeb3Contract.bind(this));
   }
 
@@ -67,7 +67,7 @@ export default class Coverage {
     this.deployedContracts = this.deployedContracts.concat(newContracts);
   }
 
-  private async produceCoverageReport(cb: () => void) {
+  private async produceCoverageReport(_params, cb: () => void) {
     const web3Contracts = await this.getWeb3Contracts();
     await Promise.all(this.collectEvents(web3Contracts));
     this.writeCoverageReport(cb);

--- a/packages/plugins/mocha-tests/src/lib/index.js
+++ b/packages/plugins/mocha-tests/src/lib/index.js
@@ -235,10 +235,11 @@ class MochaTestRunner {
         async.series(fns, next);
       }
     ], (err) => {
-      events.emit('tests:finished');
+      this.embark.config.plugins.runActionsForEvent('tests:finished', () => {
+        Module.prototype.require = originalRequire;
+        cb(err);
+      });
 
-      Module.prototype.require = originalRequire;
-      cb(err);
     });
   }
 }


### PR DESCRIPTION
…s actions

There was a race condition in which the coverage module tried to read a generated
coverage report before it was actually generated.
The issue was that the coverage generation was done on Embark's `tests:finished` event
in a fire and forget manner via `emit('tests:finished')` which doesn't
ensure control flow.
This commit changes it to use `runActionsForEvent('tests:finished')` instead and also
registers the handler for coverage report generation as action via `registerActionForEvent()`.

This ensures that those actions are run first, before the code moves on with other
operations that might rely on the result of any of those actions.