### PR TITLE
fix(@embark/tests): fix slow embark test because of the tx-logger

### DIFF
--- a/packages/embark/src/cmd/cmd_controller.js
+++ b/packages/embark/src/cmd/cmd_controller.js
@@ -761,7 +761,12 @@ class EmbarkController {
 
         engine.registerModuleGroup("blockchain");
         engine.registerModuleGroup("compiler");
-        engine.registerModuleGroup("contracts");
+        engine.registerModulePackage('embark-ganache');
+        engine.registerModulePackage('embark-ethereum-blockchain-client');
+        engine.registerModulePackage('embark-web3');
+        engine.registerModulePackage('embark-accounts-manager');
+        engine.registerModulePackage('embark-rpc-manager');
+        engine.registerModulePackage('embark-specialconfigs', { plugins: engine.plugins });
         engine.registerModuleGroup("pipeline");
         engine.registerModuleGroup("tests", options);
         engine.registerModulePackage('embark-deploy-tracker', { plugins: engine.plugins, trackContracts: false });

--- a/packages/plugins/transaction-logger/src/index.js
+++ b/packages/plugins/transaction-logger/src/index.js
@@ -47,6 +47,7 @@ export default class TransactionLogger {
     });
 
     this.writeLogFile = async.cargo((tasks, callback) => {
+      // TODO change this to only read once then use memory, because it slows things down a lot to read on each TX
       const data = this._readLogs();
 
       tasks.forEach(task => {


### PR DESCRIPTION
The transaction-logger was slowing down tests because each Tx, it
would read a file and write to it, but that's slow and even got
slower as the file grew bigger
To fix, I removed the Tx-logger from text, along with the profiler
as they are useless for tests