### PR TITLE
WIP: refactor so that embark-scaffolding can be used in embark v5

### DIFF
--- a/packages/embark/package.json
+++ b/packages/embark/package.json
@@ -84,7 +84,6 @@
     "embark-i18n": "^5.0.0-alpha.5",
     "embark-logger": "^5.0.0-alpha.5",
     "embark-reset": "^5.0.0-alpha.5",
-    "embark-scaffolding": "^5.0.0-alpha.9",
     "embark-utils": "^5.0.0-alpha.9",
     "eth-ens-namehash": "2.0.8",
     "ethereumjs-wallet": "0.6.3",

--- a/packages/embark/tsconfig.json
+++ b/packages/embark/tsconfig.json
@@ -40,9 +40,6 @@
       "path": "../plugins/graph"
     },
     {
-      "path": "../plugins/scaffolding"
-    },
-    {
       "path": "../plugins/solidity"
     },
     {

--- a/packages/plugins/scaffolding/src/framework/reactBuilder/templates/dapp.js.hbs
+++ b/packages/plugins/scaffolding/src/framework/reactBuilder/templates/dapp.js.hbs
@@ -1,5 +1,5 @@
 import EmbarkJS from 'Embark/EmbarkJS';
-import {{contractName}} from 'Embark/contracts/{{contractName}}';
+import {{contractName}} from '{{relativeGenerationDir}}/contracts/{{contractName}}';
 
 import React, { Component, Fragment } from 'react';
 import ReactDOM from 'react-dom';

--- a/packages/plugins/scaffolding/src/framework/reactBuilder/templates/index.html.hbs
+++ b/packages/plugins/scaffolding/src/framework/reactBuilder/templates/index.html.hbs
@@ -11,6 +11,6 @@
   </head>
   <body class="container">
     <div id="app"></div>
-    <script src="js/{{filename}}.js"></script>
+    <script src="./{{filename}}.js"></script>
   </body>
 </html>

--- a/packages/plugins/scaffolding/src/index.ts
+++ b/packages/plugins/scaffolding/src/index.ts
@@ -1,4 +1,4 @@
-import { Contract, Embark } from "embark-core";
+import { Callback, Contract, Embark } from "embark-core";
 import { CommandOptions, ContractLanguage, Framework } from "./commandOptions";
 import { SolidityBuilder } from "./contractLanguage/solidityBuilder";
 import { ReactBuilder } from "./framework/reactBuilder";
@@ -7,13 +7,23 @@ import { SmartContractsRecipe } from "./smartContractsRecipe";
 export default class Scaffolding {
 
   constructor(private embark: Embark, private options: any) {
-    this.embark.events.setCommandHandler("scaffolding:generate:contract", (cmdLineOptions: any,  cb: (files: Array<(string|undefined)>) => void) => {
-      this.generateContract(cmdLineOptions).then(cb);
-    });
+    this.embark.events.setCommandHandler(
+      "scaffolding:generate:contract",
+      (cmdLineOptions: any,  cb: Callback<Array<(string|undefined)>>) => {
+        this.generateContract(cmdLineOptions)
+          .then(files => cb(null, files))
+          .catch(cb);
+      }
+    );
 
-    this.embark.events.setCommandHandler("scaffolding:generate:ui", (cmdLineOptions: any,  cb: (files: string[]) => void) => {
-      this.generateUi(cmdLineOptions).then(cb);
-    });
+    this.embark.events.setCommandHandler(
+      "scaffolding:generate:ui",
+      (cmdLineOptions: any,  cb: Callback<string[]>) => {
+        this.generateUi(cmdLineOptions)
+          .then(files => cb(null, files))
+          .catch(cb);
+      }
+    );
   }
 
   private contractLanguageStrategy(recipe: SmartContractsRecipe, options: CommandOptions) {
@@ -53,10 +63,6 @@ export default class Scaffolding {
   }
 
   private getContracts() {
-    return new Promise<Contract[]>((resolve) => {
-      this.embark.events.request("contracts:list", (_: null, contracts: Contract[]) => {
-        resolve(contracts);
-      });
-    });
+    return this.embark.events.request2("contracts:list") as Promise<Contract[]>;
   }
 }


### PR DESCRIPTION
This is a best effort WIP PR to get `embark-scaffolding` operational for embark v5, prior to holidays.

With these changes in place, `embark scaffold ...` does work, but there are some limitations and things to be aware of, so that's why the PR is in draft status.

**NOTES**

`embark-scaffolding` is removed from `packages/embark/package.json` since it's actually loaded by `packages/core/engine` and therefore is a dependency of the latter. There are a few more `embark-[*]` dependencies in `packages/embark/package.json` that can likewise be moved to engine, but that can be handled in a future PR.

I aimed for the bare minimum `engine.registerModuleGroup()` calls needed to make scaffold work, and I think I succeeded. It would be nice if the following logger output could be suppressed as it's not really helpful for the user:

```
loading solc compiler...
compiling solidity contracts...
```

I didn't see any good way to do that, though, so for now expect to see it anytime you execute `embark scaffold`.

Some decision-making about what's logged is split between `cmd_controller` and the internals of `embark-scaffoldfing`. A future refactor, or some bigger changes added to this PR, could clean that up. It would be nice, for example, if `cmd_controller` wasn't responsible for any of the logger output related to `embark scaffold`; also, it would be nice if scaffold logged about the contract file it generates.

`reactBuilder` has been updated to install a `<1.0.0` version range of react-bootstrap because `>1.0.0` versions aren't happy with the react code generated by the builder (because of API changes in react-boostrap, I think).

`embark scaffold` is not very useful if `embark.json` doesn't define an `"app"` key, which is currently how a dapp signals that basic-pipeline should be used. If there's no `"app"` key, then there's no good way for scaffold to know where it should put e.g. react `.js` output — in a CRA project that would be `dappPath('src')` but it doesn't seem like a good idea to try to encode that knowledge in `embark-scaffolding`. The changes in this PR just assume that if `"app"` is missing then only a contract should be generated, but as mentioned above there's no logging about contracts, and no warning that framework code won't be generated, so only if the project is a git repo would it be obvious after `embark scaffold` finishes what that command changed in the project. Related to all of this, embark's docs will need updates re: the limitations of using `embark scaffold` when the project doesn't make use of basic-pipeline.