### PR TITLE
fix(@embark/embarkjs): Fix event name misspelling

### DIFF
--- a/packages/stack/embarkjs/src/index.js
+++ b/packages/stack/embarkjs/src/index.js
@@ -37,7 +37,7 @@ class EmbarkJS {
       this.registerEmbarkJSPlugin(stackName, pluginName, packageName, cb || (() => {}));
     });
 
-    this.events.setCommandHandler("embarkjs:console:regsiter:custom", (stackName, pluginName, packageName, options, cb) => {
+    this.events.setCommandHandler("embarkjs:console:register:custom", (stackName, pluginName, packageName, options, cb) => {
       this.events.request("runcode:whitelist", packageName, () => {});
       this.registerCustomEmbarkJSPluginInVm(stackName, pluginName, packageName, options, cb || (() => {}));
     });


### PR DESCRIPTION
Fix misspelling in event name. This event is new to v5, so there is no deprecation or major version bump needed.