### PR TITLE
chore(@embark/proxy): suppress error logs when inside test-runner con…

### DIFF
--- a/packages/stack/proxy/src/index.ts
+++ b/packages/stack/proxy/src/index.ts
@@ -128,7 +128,7 @@ export default class ProxyManager {
         isWs: false,
         logger: this.logger,
         plugins: this.plugins,
-        isVm: this.isVm
+        isVm: this.isVm,
       })
         .serve(
           this.host,
@@ -143,7 +143,7 @@ export default class ProxyManager {
         isWs: true,
         logger: this.logger,
         plugins: this.plugins,
-        isVm: this.isVm
+        isVm: this.isVm,
       })
         .serve(
           this.host,

--- a/packages/stack/proxy/src/proxy.js
+++ b/packages/stack/proxy/src/proxy.js
@@ -152,7 +152,7 @@ export class Proxy {
       if (modifiedResp && modifiedResp.response && modifiedResp.response.error) {
         // error returned from the node and it wasn't stripped by our response actions
         const error = modifiedResp.response.error.message || modifiedResp.response.error;
-        this.logger.error(__(`Error returned from the node: ${error}`));
+        this.logger.debug(__(`Error returned from the node: ${error}`));
         const rpcErrorObj = { "jsonrpc": "2.0", "error": { "code": -32603, "message": error }, "id": modifiedResp.response.id };
         return this.respondError(transport, rpcErrorObj);
       }


### PR DESCRIPTION
…text

When running tests that expect the EVM to fail, Embark's proxy keeps logging
the VM errors to stdout making it look like tests weren't successful, while they
are actually passing.

Inside a test-runner it's probably expected not to see any error logs when the
tests in question expect errors.

This commit suppresses the logs emitted by the proxy when Embark is executed inside
a test-runner context, resulting in clean green tests without error log noise.