### PR TITLE
fix(@embark/transaction-logger): Circular JSON log and unknown contract log level

### DIFF
--- a/packages/plugins/transaction-logger/src/index.js
+++ b/packages/plugins/transaction-logger/src/index.js
@@ -1,6 +1,7 @@
 const async = require('async');
 import { __ } from 'embark-i18n';
 const Web3 = require('web3');
+const util = require('util');
 
 const { blockchain: blockchainConstants } = require('embark-core/constants');
 import { dappPath, hexToNumber } from 'embark-utils';
@@ -169,7 +170,7 @@ export default class TransactionLogger {
 
     const contract = this.addressToContract[address];
     if (!contract) {
-      this.logger.info(`Contract log for unknown contract: ${JSON.stringify(args)}`);
+      this.logger.debug(`Contract log for unknown contract: ${util.inspect(args)}`);
       return this._getContractsList((contractsList) => {
         this.addressToContract = getAddressToContract(contractsList, this.addressToContract);
       });


### PR DESCRIPTION
## Issue
Transaction logs for contracts that were unknown to Embark (ie not in the dapp) would often log super large unformatted objects (filling the terminal), making the information logged hard to read without actually being that useful. In addition, occasionally the object logged would throw the error `TypeError: Converting circular structure to JSON`.

## Fix
Set the log level for transaction logs that are not from a known contract to `debug`, so that they do not flood the terminal with often unused information.

Use `util.inspect` to print the transaction log instead of `JSON.stringify` to prevent circular structure errors.