### PR TITLE
feat(@embark/test-runner): expose evmClientVersion for conditional tests

### DIFF
--- a/dapps/tests/app/test/expiration_spec.js
+++ b/dapps/tests/app/test/expiration_spec.js
@@ -19,6 +19,12 @@ contract("Expiration", function() {
   });
 
   it("should have expired after skipping time", async function () {
+    const client = await getEvmVersion();
+
+    if (client.indexOf('EthereumJS TestRPC') === -1) {
+      console.info(`Skipping test because it requires the use of Ganache. Current blockchain client: ${client}`);
+      return assert.ok(true);
+    }
     await mineAtTimestamp(now + 1001); // sets block.timestamp to 1001
     const isExpired = await Expiration.methods.isExpired().call();
     assert.strictEqual(isExpired, true);

--- a/packages/plugins/mocha-tests/src/lib/index.js
+++ b/packages/plugins/mocha-tests/src/lib/index.js
@@ -155,6 +155,7 @@ class MochaTestRunner {
     const provider = await this.events.request2("tests:blockchain:start", this.options);
     this.web3 = new Web3(provider);
     accounts = await this.web3.eth.getAccounts();
+
     await events.request2("contracts:reset");
     let contractFiles = await events.request2("config:contractsFiles");
 


### PR DESCRIPTION
This commit introduces a new `global.evmClientVersion` that can be used to
conditionally run tests, such as when tests rely on RPC APIs that are only
available in specific evm nodes.