### PR TITLE
feat(@embark/deployment): introduce `interfaces` and `libraries` conf…

### DIFF
--- a/dapps/tests/app/config/contracts.js
+++ b/dapps/tests/app/config/contracts.js
@@ -11,10 +11,8 @@ module.exports = {
       console.log("before deploying contracts");
       console.log("==========================");
     },
+    interfaces: ['Ownable'],
     deploy: {
-      Ownable: {
-        deploy: false
-      },
       Token: {
         deploy: false,
         args: [1000]

--- a/packages/plugins/deploy-tracker/src/deploymentChecks.js
+++ b/packages/plugins/deploy-tracker/src/deploymentChecks.js
@@ -4,11 +4,12 @@ import Web3 from "web3";
 require("colors");
 
 export default class DeploymentChecks {
-  constructor({trackingFunctions, events, logger}) {
+  constructor({trackingFunctions, events, logger, contractsConfig}) {
     this.trackingFunctions = trackingFunctions;
     this.events = events;
     this.logger = logger;
     this._web3 = null;
+    this.contractsConfig = contractsConfig || {};
 
     this.events.on("blockchain:started", () => {
       this._web3 = null;
@@ -31,6 +32,13 @@ export default class DeploymentChecks {
     // previous event action check
     if (!params.shouldDeploy) {
       return cb(null, params);
+    }
+
+    const isInterface = this.contractsConfig.interfaces && this.contractsConfig.interfaces.includes(contract.className);
+    const isLibrary = this.contractsConfig.libraries && this.contractsConfig.libraries.includes(contract.className);
+
+    if (isInterface || isLibrary) {
+      contract.deploy = false;
     }
 
     // check if contract set to not deploy in the config

--- a/packages/plugins/deploy-tracker/src/index.js
+++ b/packages/plugins/deploy-tracker/src/index.js
@@ -8,7 +8,7 @@ class DeployTracker {
     this.embark = embark;
 
     const trackingFunctions = new TrackingFunctions({config, fs, logger, events, trackContracts});
-    const deploymentChecks = new DeploymentChecks({trackingFunctions, logger, events, plugins});
+    const deploymentChecks = new DeploymentChecks({trackingFunctions, logger, events, plugins, contractsConfig: config.contractsConfig});
 
     this.embark.registerActionForEvent("deployment:contract:deployed", trackingFunctions.trackAndSaveContract.bind(trackingFunctions));
     this.embark.registerActionForEvent("deployment:contract:shouldDeploy", deploymentChecks.checkContractConfig.bind(deploymentChecks));

--- a/packages/plugins/deploy-tracker/src/test/deploymentChecksSpec.js
+++ b/packages/plugins/deploy-tracker/src/test/deploymentChecksSpec.js
@@ -77,7 +77,7 @@ describe('embark.deploymentChecks', function () {
       }
     };
     trackingFunctions._web3 = _web3;
-    deploymentChecks = new DeploymentChecks({trackingFunctions, events, logger});
+    deploymentChecks = new DeploymentChecks({trackingFunctions, events, logger, contractsConfig: {}});
     deploymentChecks._web3 = _web3;
   });
   afterEach(() => {

--- a/site/source/docs/contracts_configuration.md
+++ b/site/source/docs/contracts_configuration.md
@@ -127,6 +127,26 @@ production: {
 ...
 ```
 
+## Defining interfaces
+
+There are scenarios in which certain Smart Contract sources are used for inheritance or as interfaces. While their source has to be compiled,
+we don't actually want to deploy them. To prevent such Smart Contracts from deploying, we can either take advantage of the `deploy: false`
+propery discussed above, or use the more semantic `interfaces` and `libraries` configurations.
+
+Both of them are simple lists of Smart Contract names that should be treated as interfaces and libraries respectively. The following example
+show how the `Ownable` Smart Contract is configured as interface and therefore won't be deployed:
+
+```json
+...
+development:
+  interfaces: ['Ownable'],
+  deploy: {
+    InheritsOwnable: {}
+  }
+}
+...
+```
+
 ## Deployment strategies
 
 In order to give users full control over which Smart Contracts should be deployed, Embark comes with a configuration feature called "deployment strategies". Deployment strategies tell Embark whether it should deploy all of the user's Smart Contracts (and its (3rd-party) dependencies, or just deploy individual Smart Contracts.


### PR DESCRIPTION
…iguration

This commit adds two new configuration settings for Smart Contract configuration:

- `interfaces` - Any Smart Contract that represent an interface or is used for inheritance
- `libraries` - Any Smart Contract that is used as a library

This makes the configuration less redundant in cases where otherwise the `deploy`
property has been set to `false`, such as:

```
deploy: {
  Ownable: {
    deploy: false
  },
  ...
}
```

The above can now be done via:

```
interfaces: ['Ownable'],
deploy: {
  ...
}
```