### PR TITLE
refactor(transaction-logger): replace log file write by append

### DIFF
--- a/packages/embark/package.json
+++ b/packages/embark/package.json
@@ -114,7 +114,6 @@
     "simples": "0.8.8",
     "solc": "0.5.0",
     "source-map-support": "0.5.13",
-    "stream-json": "1.3.0",
     "string-replace-async": "1.2.1",
     "term.js": "0.0.7",
     "viz.js": "1.8.2",

--- a/packages/plugins/transaction-logger/src/index.js
+++ b/packages/plugins/transaction-logger/src/index.js
@@ -27,7 +27,7 @@ export default class TransactionLogger {
     this.contractsConfig = embark.config.contractsConfig;
     this.contractsDeployed = false;
     this.outputDone = false;
-    this.logFile = dappPath(".embark", "contractLogs.json");
+    this.logFile = dappPath(".embark", "contractLogs.json.txt");
     this.transactions = {};
 
     this._listenForLogRequests();
@@ -47,16 +47,14 @@ export default class TransactionLogger {
     });
 
     this.writeLogFile = async.cargo((tasks, callback) => {
-      // TODO change this to only read once then use memory, because it slows things down a lot to read on each TX
-      const data = this._readLogs();
-
+      let appendThis = '';
       tasks.forEach(task => {
-        data[new Date().getTime()] = task;
+        appendThis += `"${new Date().getTime()}":${JSON.stringify(task)},\n`;
       });
-
-      this.fs.writeJson(this.logFile, data, err => {
+      this.fs.appendFile(this.logFile, appendThis, (err) => {
         if (err) {
-          console.error(err);
+          this.logger.error('Error writing to the log file', err.message);
+          this.logger.trace(err);
         }
         callback();
       });
@@ -265,8 +263,18 @@ export default class TransactionLogger {
   _readLogs() {
     this.fs.ensureFileSync(this.logFile);
     try {
-      return JSON.parse(this.fs.readFileSync(this.logFile));
-    } catch (_error) {
+      let data = this.fs.readFileSync(this.logFile).toString();
+
+      if (!data) {
+        return {};
+      }
+
+      // remove last comma and add braces around
+      data = `{${data.substring(0, data.length - 2)}}`;
+      return JSON.parse(data);
+    } catch (error) {
+      this.logger.error('Error reading contract log file', error.message);
+      this.logger.trace(error);
       return {};
     }
   }

--- a/packages/plugins/transaction-logger/src/index.js
+++ b/packages/plugins/transaction-logger/src/index.js
@@ -245,14 +245,14 @@ export default class TransactionLogger {
     this.embark.registerAPICall(
       'get',
       apiRoute,
-      (req, res) => {
-        res.send(JSON.stringify(this._getLogs()));
+      async (req, res) => {
+        res.send(JSON.stringify(await this._getLogs()));
       }
     );
   }
 
-  _getLogs() {
-    const data = this._readLogs();
+  async _getLogs() {
+    const data = await this._readLogs();
     return Object.values(data).reverse();
   }
 
@@ -260,22 +260,29 @@ export default class TransactionLogger {
     this.writeLogFile.push(log);
   }
 
-  _readLogs() {
-    this.fs.ensureFileSync(this.logFile);
-    try {
-      let data = this.fs.readFileSync(this.logFile).toString();
+  async _readLogs() {
+    return new Promise(async resolve => {
+      try {
+        await this.fs.ensureFile(this.logFile);
+        this.fs.readFile(this.logFile, (err, data) => {
+          if (err) {
+            throw (new Error(err));
+          }
+          data = data.toString();
+          if (!data) {
+            return resolve({});
+          }
 
-      if (!data) {
-        return {};
+          // remove last comma and add braces around
+          data = `{${data.substring(0, data.length - 2)}}`;
+
+          resolve(JSON.parse(data));
+        });
+      } catch (error) {
+        this.logger.error('Error reading contract log file', error.message);
+        this.logger.trace(error);
+        resolve({});
       }
-
-      // remove last comma and add braces around
-      data = `{${data.substring(0, data.length - 2)}}`;
-      return JSON.parse(data);
-    } catch (error) {
-      this.logger.error('Error reading contract log file', error.message);
-      this.logger.trace(error);
-      return {};
-    }
+    });
   }
 }

--- a/packages/plugins/transaction-logger/src/index.js
+++ b/packages/plugins/transaction-logger/src/index.js
@@ -17,6 +17,19 @@ const LISTENED_METHODS = [
   blockchainConstants.transactionMethods.eth_sendRawTransaction
 ];
 
+const getCircularReplacer = () => {
+  const seen = new WeakSet();
+  return (key, value) => {
+    if (typeof value === "object" && value !== null) {
+      if (seen.has(value)) {
+        return;
+      }
+      seen.add(value);
+    }
+    return value;
+  };
+};
+
 export default class TransactionLogger {
   constructor(embark, _options) {
     this.embark = embark;
@@ -49,7 +62,7 @@ export default class TransactionLogger {
     this.writeLogFile = async.cargo((tasks, callback) => {
       let appendThis = '';
       tasks.forEach(task => {
-        appendThis += `"${new Date().getTime()}":${JSON.stringify(task)},\n`;
+        appendThis += `"${new Date().getTime()}":${JSON.stringify(task, getCircularReplacer())},\n`;
       });
       this.fs.appendFile(this.logFile, appendThis, (err) => {
         if (err) {
@@ -261,28 +274,24 @@ export default class TransactionLogger {
   }
 
   async _readLogs() {
-    return new Promise(async resolve => {
-      try {
-        await this.fs.ensureFile(this.logFile);
-        this.fs.readFile(this.logFile, (err, data) => {
-          if (err) {
-            throw (new Error(err));
-          }
-          data = data.toString();
-          if (!data) {
-            return resolve({});
-          }
+    try {
+      await this.fs.ensureFile(this.logFile);
+      let data = await this.fs.readFile(this.logFile);
 
-          // remove last comma and add braces around
-          data = `{${data.substring(0, data.length - 2)}}`;
+      data = data.toString();
 
-          resolve(JSON.parse(data));
-        });
-      } catch (error) {
-        this.logger.error('Error reading contract log file', error.message);
-        this.logger.trace(error);
-        resolve({});
+      if (!data) {
+        return {};
       }
-    });
+
+      // remove last comma and add braces around
+      data = `{${data.substring(0, data.length - 2)}}`;
+
+      return JSON.parse(data);
+    } catch (error) {
+      this.logger.error('Error reading contract log file', error.message);
+      this.logger.trace(error.trace);
+      return {};
+    }
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -19860,11 +19860,6 @@ stream-browserify@^2.0.1:
     inherits "~2.0.1"
     readable-stream "^2.0.2"
 
-stream-chain@^2.1.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/stream-chain/-/stream-chain-2.1.0.tgz#a058a7104d7261a71bf7eb4c5f496f13dc665320"
-  integrity sha512-PAUXdRGm0G8P0+/+JEd3O9kfmB9kwmr2nKIc5zhcsHn0KdBByD5PJ2po21iDzc+TZsOSEbU8j4JbAevJsZkLyQ==
-
 stream-each@^1.1.0:
   version "1.2.3"
   resolved "https://registry.yarnpkg.com/stream-each/-/stream-each-1.2.3.tgz#ebe27a0c389b04fbcc233642952e10731afa9bae"
@@ -19883,13 +19878,6 @@ stream-http@^2.7.2:
     readable-stream "^2.3.6"
     to-arraybuffer "^1.0.0"
     xtend "^4.0.0"
-
-stream-json@1.3.0:
-  version "1.3.0"
-  resolved "https://registry.yarnpkg.com/stream-json/-/stream-json-1.3.0.tgz#c7c0f40a808ce91181c15018fc3dbcd09bcd6cf8"
-  integrity sha512-3qLDv/xnwmleb5kssgmKbGPqcLou2tbFIgj3CM3fy5PxKaAmeCv103Zp4LKIALdE30zMHTJn09yVwxq773btaw==
-  dependencies:
-    stream-chain "^2.1.0"
 
 stream-shift@^1.0.0:
   version "1.0.0"


### PR DESCRIPTION
## Problem
Doing read, then write each a trasaction or call exectues could get
heavy, especially with regular txs on
This was especially true in the tests, which led to deactivate the
tx logger in the tests
## Solution
Instead of reading the whole file, adding the JSON line a writing,
we instead just append some pseudo JSON to it that later gets read
and parsed correctly back to JSON