### PR TITLE
Nethermind plugin

### DIFF
--- a/packages/core/core/src/config.ts
+++ b/packages/core/core/src/config.ts
@@ -77,6 +77,8 @@ export class Config {
 
   version: string;
 
+  locale: string;
+
   shownNoAccountConfigMsg = false; // flag to ensure "no account config" message is only displayed once to the user
 
   corsParts: string[] = [];
@@ -95,6 +97,7 @@ export class Config {
     this.configDir = options.configDir || DEFAULT_CONFIG_PATH;
     this.chainsFile = options.chainsFile;
     this.plugins = options.plugins;
+    this.locale = options.locale || 'en';
     this.logger = options.logger;
     this.package = options.package;
     this.events = options.events;

--- a/packages/core/core/src/plugin.ts
+++ b/packages/core/core/src/plugin.ts
@@ -138,10 +138,6 @@ export class Plugin {
     this._loggerObject[type](this.name + ':', ...[].slice.call(arguments, 1));
   }
 
-  setUpLogger() {
-    this.logger = new Logger({});
-  }
-
   isContextValid() {
     if (this.currentContext.includes(constants.contexts.any) || this.acceptedContext.includes(constants.contexts.any)) {
       return true;
@@ -161,9 +157,6 @@ export class Plugin {
       return false;
     }
     this.loaded = true;
-    if (this.shouldInterceptLogs) {
-      this.setUpLogger();
-    }
     if (isEs6Module(this.pluginModule)) {
       if (this.pluginModule.default) {
         this.pluginModule = this.pluginModule.default;

--- a/packages/core/engine/src/index.ts
+++ b/packages/core/engine/src/index.ts
@@ -85,7 +85,16 @@ export class Engine {
     const options = _options || {};
     this.events = options.events || this.events || new Events();
     this.logger = this.logger || new Logger({context: this.context, logLevel: options.logLevel || this.logLevel || 'info', events: this.events, logFile: this.logFile});
-    this.config = new Config({env: this.env, logger: this.logger, events: this.events, context: this.context, webServerConfig: this.webServerConfig, version: this.version, package: this.package});
+    this.config = new Config({
+      env: this.env,
+      logger: this.logger,
+      events: this.events,
+      context: this.context,
+      webServerConfig: this.webServerConfig,
+      version: this.version,
+      package: this.package,
+      locale: this.locale
+    });
     this.config.loadConfigFiles({embarkConfig: this.embarkConfig, interceptLogs: this.interceptLogs});
     this.plugins = this.config.plugins;
     this.isDev = this.config && this.config.blockchainConfig && (this.config.blockchainConfig.isDev || this.config.blockchainConfig.default);

--- a/packages/core/utils/src/check.js
+++ b/packages/core/utils/src/check.js
@@ -1,0 +1,62 @@
+const WebSocket = require("ws");
+const http = require("http");
+const https = require("https");
+
+const LIVENESS_CHECK=`{"jsonrpc":"2.0","method":"web3_clientVersion","params":[],"id":42}`;
+
+const parseAndRespond = (data, cb) => {
+  let resp;
+  try {
+    resp = JSON.parse(data);
+    if (resp.error) {
+      return cb(resp.error);
+    }
+  } catch (e) {
+    return cb('Version data is not valid JSON');
+  }
+  if (!resp || !resp.result) {
+    return cb('No version returned');
+  }
+  const [_, version, __] = resp.result.split('/');
+  cb(null, version);
+};
+
+const testRpcWithEndpoint = (endpoint, cb) => {
+  const options = {
+    method: "POST",
+    timeout: 1000,
+    headers: {
+      "Content-Type": "application/json",
+      "Content-Length": Buffer.byteLength(LIVENESS_CHECK)
+    }
+  };
+
+  let obj = http;
+  if (endpoint.startsWith('https')) {
+    obj = https;
+  }
+
+  const req = obj.request(endpoint, options, (res) => {
+    let data = "";
+    res.on("data", chunk => { data += chunk; });
+    res.on("end", () => parseAndRespond(data, cb));
+  });
+  req.on("error", (e) => cb(e));
+  req.write(LIVENESS_CHECK);
+  req.end();
+};
+
+const testWsEndpoint = (endpoint, cb) => {
+  const conn = new WebSocket(endpoint);
+  conn.on("message", (data) => {
+    parseAndRespond(data, cb);
+    conn.close();
+  });
+  conn.on("open", () => conn.send(LIVENESS_CHECK));
+  conn.on("error", (e) => cb(e));
+};
+
+module.exports = {
+  testWsEndpoint,
+  testRpcWithEndpoint
+};

--- a/packages/core/utils/src/index.ts
+++ b/packages/core/utils/src/index.ts
@@ -6,6 +6,7 @@ const clipboardy = require('clipboardy');
 import { canonicalHost } from './host';
 export { canonicalHost, defaultCorsHost, defaultHost, dockerHostSwap, isDocker } from './host';
 export { downloadFile, findNextPort, getJson, httpGet, httpsGet, httpGetJson, httpsGetJson, pingEndpoint } from './network';
+export { testRpcWithEndpoint, testWsEndpoint } from './check';
 const logUtils = require('./log-utils');
 export const escapeHtml = logUtils.escapeHtml;
 export const normalizeInput = logUtils.normalizeInput;

--- a/packages/core/utils/src/index.ts
+++ b/packages/core/utils/src/index.ts
@@ -173,7 +173,7 @@ export function deconstructUrl(endpoint) {
   return {
     protocol: matches[1],
     host: matches[2],
-    port: matches[3],
+    port: matches[3] ? parseInt(matches[3], 10) : false,
     type: matches[1] === 'ws' || matches[1] === 'wss' ? 'ws' : 'rpc'
   };
 }

--- a/packages/embark/src/cmd/cmd_controller.js
+++ b/packages/embark/src/cmd/cmd_controller.js
@@ -58,13 +58,22 @@ class EmbarkController {
     });
 
     engine.init({}, () => {
+      Object.assign(engine.config.blockchainConfig, { isStandalone: true });
+
       engine.registerModuleGroup("coreComponents");
       engine.registerModuleGroup("blockchainStackComponents");
       engine.registerModuleGroup("blockchain");
 
+      // load custom plugins
+      engine.loadDappPlugins();
+      let pluginList = engine.plugins.listPlugins();
+      if (pluginList.length > 0) {
+        engine.logger.info(__("loaded plugins") + ": " + pluginList.join(", "));
+      }
+
       engine.startEngine(async () => {
         try {
-          const alreadyStarted = await engine.events.request2("blockchain:node:start", Object.assign(engine.config.blockchainConfig, { isStandalone: true }));
+          const alreadyStarted = await engine.events.request2("blockchain:node:start", engine.config.blockchainConfig);
           if (alreadyStarted) {
             engine.logger.warn(__('Blockchain process already started. No need to run `embark blockchain`'));
             process.exit(0);

--- a/packages/embark/src/test/config.js
+++ b/packages/embark/src/test/config.js
@@ -167,7 +167,7 @@ describe('embark.Config', function () {
         },
         "datadir": ".embark/extNetwork/datadir",
         "rpcHost": "mynetwork.com",
-        "rpcPort": undefined,
+        "rpcPort": false,
         "rpcCorsDomain": {
           "auto": true,
           "additionalCors": []

--- a/packages/plugins/ethereum-blockchain-client/src/index.js
+++ b/packages/plugins/ethereum-blockchain-client/src/index.js
@@ -64,7 +64,7 @@ class EthereumBlockchainClient {
       const code = contract.code.substring(0, 2) === '0x' ? contract.code : "0x" + contract.code;
       const contractObject = contractObj.deploy({arguments: (contract.args || []), data: code});
       if (contract.gas === 'auto' || !contract.gas) {
-        const gasValue = await contractObject.estimateGas();
+        const gasValue = await contractObject.estimateGas({value: 0, from: account});
         const increase_per = 1 + (Math.random() / 10.0);
         contract.gas = Math.floor(gasValue * increase_per);
       }

--- a/packages/plugins/geth/src/blockchain.js
+++ b/packages/plugins/geth/src/blockchain.js
@@ -35,7 +35,7 @@ class Blockchain {
     this.config = {
       silent: this.userConfig.silent,
       client: this.userConfig.client,
-      ethereumClientBin: this.userConfig.ethereumClientBin || this.userConfig.client,
+      ethereumClientBin: this.userConfig.ethereumClientBin,
       networkType: this.userConfig.networkType || clientClass.DEFAULTS.NETWORK_TYPE,
       networkId: this.userConfig.networkId || clientClass.DEFAULTS.NETWORK_ID,
       genesisBlock: this.userConfig.genesisBlock || false,

--- a/packages/plugins/geth/src/index.js
+++ b/packages/plugins/geth/src/index.js
@@ -12,6 +12,7 @@ class Geth {
     this.embarkConfig = embark.config.embarkConfig;
     this.blockchainConfig = embark.config.blockchainConfig;
     this.communicationConfig = embark.config.communicationConfig;
+    // TODO get options from config instead of options
     this.locale = options.locale;
     this.logger = embark.logger;
     this.client = options.client;

--- a/packages/plugins/nethermind/.npmrc
+++ b/packages/plugins/nethermind/.npmrc
@@ -1,0 +1,4 @@
+engine-strict = true
+package-lock = false
+save-exact = true
+scripts-prepend-node-path = true

--- a/packages/plugins/nethermind/README.md
+++ b/packages/plugins/nethermind/README.md
@@ -1,0 +1,20 @@
+# `embark-nethermind`
+
+> Nethermind blockchain client plugin for Embark
+
+
+## Quick docs
+
+To configure the Netherminds client, you can use the Embark configs as always, or for more control, use the Nethermind config files.
+To change them, go in your Netherminds directory, then in `configs/`. There, you will see all the configuration files for the different networks.
+If you ever need to run a different network than dev, testnet or mainnet, you can change it in the Embark blockchain configuration by changing the `networkType` to the name of the config file, without the `.cfg`.
+Eg: For the Goerli network, just put `networkType: 'goerli`
+Note: The dev mode of Netherminds is called `ndm` and the config file is `ndm_consumer_local.cfg`. Using `miningMode: 'dev'` automatically translates to using that config file.
+
+## Websocket support
+
+Even though Nethermind supports Websocket connections, it does not support `eth_subscribe`, so you will not be able to use contract events.
+Also, please note that you will need to change the `endpoint` in the blockchain configuration to `ws://localhost:8545/ws/json-rpc` when working in local. Do change the port or the  host to whatever you need.
+
+Visit [embark.status.im](https://embark.status.im/) to get started with
+[Embark](https://github.com/embark-framework/embark).

--- a/packages/plugins/nethermind/package.json
+++ b/packages/plugins/nethermind/package.json
@@ -1,0 +1,67 @@
+{
+  "name": "embark-nethermind",
+  "version": "5.0.0-alpha.9",
+  "author": "Iuri Matias <iuri.matias@gmail.com>",
+  "contributors": [],
+  "description": "Nethermind blockchain client plugin for Embark",
+  "homepage": "https://github.com/embark-framework/embark/tree/master/packages/plugins/nethermind#readme",
+  "bugs": "https://github.com/embark-framework/embark/issues",
+  "keywords": [
+    "blockchain",
+    "dapps",
+    "ethereum",
+    "serverless",
+    "nethermind"
+  ],
+  "files": [
+    "dist"
+  ],
+  "license": "MIT",
+  "repository": {
+    "directory": "packages/plugins/nethermind",
+    "type": "git",
+    "url": "https://github.com/embark-framework/embark.git"
+  },
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "embark-collective": {
+    "build:node": true,
+    "typecheck": true
+  },
+  "scripts": {
+    "_build": "npm run solo -- build",
+    "_typecheck": "npm run solo -- typecheck",
+    "ci": "npm run qa",
+    "clean": "npm run reset",
+    "lint": "eslint src/",
+    "qa": "npm-run-all lint _typecheck _build",
+    "reset": "npx rimraf dist embark-*.tgz package",
+    "solo": "embark-solo"
+  },
+  "eslintConfig": {
+    "extends": "../../../.eslintrc.json"
+  },
+  "dependencies": {
+    "@babel/runtime-corejs3": "7.7.4",
+    "async": "2.6.1",
+    "core-js": "3.4.3",
+    "embark-core": "^5.0.0-alpha.9",
+    "embark-i18n": "^5.0.0-alpha.5",
+    "embark-utils": "^5.0.0-alpha.9",
+    "fs-extra": "8.1.0",
+    "netcat": "1.3.5",
+    "semver": "5.6.0",
+    "ws": "7.1.2"
+  },
+  "devDependencies": {
+    "embark-solo": "^5.0.0-alpha.5",
+    "eslint": "5.7.0",
+    "npm-run-all": "4.1.5",
+    "rimraf": "3.0.0"
+  },
+  "engines": {
+    "node": ">=10.17.0 <12.0.0",
+    "npm": ">=6.11.3",
+    "yarn": ">=1.19.1"
+  }
+}

--- a/packages/plugins/nethermind/src/blockchainProcess.js
+++ b/packages/plugins/nethermind/src/blockchainProcess.js
@@ -1,0 +1,57 @@
+import * as i18n from 'embark-i18n';
+import { ProcessWrapper } from 'embark-core';
+const constants = require('embark-core/constants');
+import { BlockchainClient } from './blockchain';
+
+let blockchainProcess;
+
+class BlockchainProcess extends ProcessWrapper {
+  constructor(options) {
+    super();
+    this.blockchainConfig = options.blockchainConfig;
+    this.client = options.client;
+    this.env = options.env;
+    this.isDev = options.isDev;
+    this.certOptions = options.certOptions;
+
+    i18n.setOrDetectLocale(options.locale);
+
+    this.blockchainConfig.silent = true;
+    this.blockchain = new BlockchainClient(
+      this.blockchainConfig,
+      {
+        clientName: this.client,
+        env: this.env,
+        certOptions: this.certOptions,
+        onReadyCallback: this.blockchainReady.bind(this),
+        onExitCallback: this.blockchainExit.bind(this),
+        logger: console
+      }
+    );
+
+    this.blockchain.run();
+  }
+
+  blockchainReady() {
+    blockchainProcess.send({result: constants.blockchain.blockchainReady});
+  }
+
+  blockchainExit() {
+    // tell our parent process that ethereum client has exited
+    blockchainProcess.send({result: constants.blockchain.blockchainExit});
+  }
+
+  kill() {
+    this.blockchain.kill();
+  }
+}
+
+process.on('message', (msg) => {
+  if (msg === 'exit') {
+    return blockchainProcess.kill();
+  }
+  if (msg.action === constants.blockchain.init) {
+    blockchainProcess = new BlockchainProcess(msg.options);
+    return blockchainProcess.send({result: constants.blockchain.initiated});
+  }
+});

--- a/packages/plugins/nethermind/src/blockchainProcessLauncher.js
+++ b/packages/plugins/nethermind/src/blockchainProcessLauncher.js
@@ -1,0 +1,84 @@
+import { __ } from 'embark-i18n';
+import { ProcessLauncher } from 'embark-core';
+import { joinPath } from 'embark-utils';
+const constants = require('embark-core/constants');
+
+export class BlockchainProcessLauncher {
+
+  constructor (options) {
+    this.events = options.events;
+    this.env = options.env;
+    this.logger = options.logger;
+    this.normalizeInput = options.normalizeInput;
+    this.blockchainConfig = options.blockchainConfig;
+    this.locale = options.locale;
+    this.isDev = options.isDev;
+    this.client = options.client;
+    this.embark = options.embark;
+  }
+
+  processEnded(code) {
+    this.logger.error(__('Blockchain process ended before the end of this process. Try running blockchain in a separate process using `$ embark blockchain`. Code: %s', code));
+  }
+
+  startBlockchainNode(readyCb) {
+    this.logger.info(__('Starting Blockchain node in another process').cyan);
+
+    this.blockchainProcess = new ProcessLauncher({
+      name: 'blockchain',
+      modulePath: joinPath(__dirname, './blockchainProcess.js'),
+      logger: this.logger,
+      events: this.events,
+      silent: this.logger.logLevel !== 'trace',
+      exitCallback: this.processEnded.bind(this),
+      embark: this.embark
+    });
+    this.blockchainProcess.send({
+      action: constants.blockchain.init, options: {
+        blockchainConfig: this.blockchainConfig,
+        client: this.client,
+        env: this.env,
+        isDev: this.isDev,
+        locale: this.locale,
+        certOptions: this.embark.config.webServerConfig.certOptions,
+        events: this.events
+      }
+    });
+
+    this.blockchainProcess.once('result', constants.blockchain.blockchainReady, () => {
+      this.logger.info(__('Blockchain node is ready').cyan);
+      readyCb();
+    });
+
+    this.blockchainProcess.once('result', constants.blockchain.blockchainExit, () => {
+      // tell everyone that our blockchain process (ie geth) died
+      this.events.emit(constants.blockchain.blockchainExit);
+
+      // then kill off the blockchain process
+      this.blockchainProcess.kill();
+    });
+
+
+    this.events.setCommandHandler('logs:ethereum:enable', () => {
+      this.blockchainProcess.setSilent(false);
+    });
+
+    this.events.setCommandHandler('logs:ethereum:disable', () => {
+      this.blockchainProcess.setSilent(true);
+    });
+
+    this.events.on('exit', () => {
+      this.blockchainProcess.send('exit');
+    });
+  }
+
+  stopBlockchainNode(cb) {
+    if (this.blockchainProcess) {
+      this.events.once(constants.blockchain.blockchainExit, cb);
+      this.blockchainProcess.exitCallback = () => {}; // don't show error message as the process was killed on purpose
+      this.blockchainProcess.send('exit');
+    }
+  }
+
+}
+

--- a/packages/plugins/nethermind/src/nethermindClient.js
+++ b/packages/plugins/nethermind/src/nethermindClient.js
@@ -1,0 +1,249 @@
+import {__} from 'embark-i18n';
+const path = require('path');
+const async = require('async');
+const semver = require('semver');
+
+const DEFAULTS = {
+  "BIN": "Nethermind.Runner",
+  "VERSIONS_SUPPORTED": ">=1.4.0",
+  "NETWORK_TYPE": "custom",
+  "NETWORK_ID": 1337,
+  "RPC_API": ['eth', 'web3', 'net', 'debug', 'personal'],
+  "WS_API": ['eth', 'web3', 'net', 'debug', 'pubsub', 'personal'],
+  "DEV_WS_API": ['eth', 'web3', 'net', 'debug', 'pubsub', 'personal'],
+  "TARGET_GAS_LIMIT": 8000000
+};
+
+const NETHERMIND_NAME = 'nethermind';
+
+class NethermindClient {
+
+  static get DEFAULTS() {
+    return DEFAULTS;
+  }
+
+  constructor(options) {
+    this.logger = options.logger;
+    this.config = options.hasOwnProperty('config') ? options.config : {};
+    this.env = options.hasOwnProperty('env') ? options.env : 'development';
+    this.isDev = options.hasOwnProperty('isDev') ? options.isDev : (this.env === 'development');
+    this.name = NETHERMIND_NAME;
+    this.prettyName = "Nethermind (https://github.com/NethermindEth/nethermind)";
+    this.bin = this.config.ethereumClientBin || DEFAULTS.BIN;
+    this.versSupported = DEFAULTS.VERSIONS_SUPPORTED;
+  }
+
+  isReady(data) {
+    return data.indexOf('Running server, url:') > -1;
+  }
+
+  commonOptions() {
+    const config = this.config;
+    const cmd = [];
+
+    cmd.push(this.determineNetworkType(config));
+
+    if (config.datadir) {
+      // There isn't a real data dir, so at least we put the keys there
+      cmd.push(`--KeyStore.KeyStoreDirectory=${config.datadir}`);
+    }
+
+    if (config.syncMode === 'light') {
+      this.logger.warn('Light sync mode does not exist in Nethermind. Switching to fast');
+      cmd.push("--Sync.FastSync=true");
+    } else if (config.syncMode === 'fast') {
+      cmd.push("--Sync.FastSync=true");
+    }
+
+    // In dev mode we store all users passwords in the devPassword file, so Parity can unlock all users from the start
+    if (this.isDev && config.account && config.account.numAccounts) {
+      cmd.push(`--Wallet.DevAccounts=${config.account.numAccounts}`);
+    } else if (config.account && config.account.password) {
+      // TODO find a way to see if we can set a password
+      // cmd.push(`--password=${config.account.password}`);
+    }
+
+    // TODO reanable this when the log level is usable
+    //  currently, you have to restart the client for the log level to apply and even then, it looks bugged
+    // if (Number.isInteger(config.verbosity) && config.verbosity >= 0 && config.verbosity <= 5) {
+    //   switch (config.verbosity) {
+    //     case 0:
+    //       cmd.push("--log=OFF");
+    //       break;
+    //     case 1:
+    //       cmd.push("--log=ERROR");
+    //       break;
+    //     case 2:
+    //       cmd.push("--log=WARN");
+    //       break;
+    //     case 3:
+    //       cmd.push("--log=INFO");
+    //       break;
+    //     case 4:
+    //       cmd.push("--log=DEBUG");
+    //       break;
+    //     case 5:
+    //       cmd.push("--log=TRACE");
+    //       break;
+    //     default:
+    //       cmd.push("--log=INFO");
+    //       break;
+    //   }
+    // }
+
+    return cmd;
+  }
+
+  getMiner() {
+    console.warn(__("Miner requested, but Nethermind does not embed a miner! Use Geth or install ethminer (https://github.com/ethereum-mining/ethminer)").yellow);
+    return;
+  }
+
+  getBinaryPath() {
+    return this.bin;
+  }
+
+  determineVersionCommand() {
+    let launcher = 'Nethermind.Launcher';
+    if (this.config.ethereumClientBin) {
+      // Replace the Runner by the Launcher in the path
+      // This is done because the Runner does not have a version command, but the Launcher has one ¯\_(ツ)_/¯
+      launcher =  this.config.ethereumClientBin.replace(path.basename(this.config.ethereumClientBin), launcher);
+    }
+    return `${launcher} --version`;
+  }
+
+  parseVersion(rawVersionOutput) {
+    let parsed;
+    const match = rawVersionOutput.match(/v([0-9.]+)/);
+    if (match) {
+      parsed = match[1].trim();
+    }
+    return parsed;
+  }
+
+  isSupportedVersion(parsedVersion) {
+    let test;
+    try {
+      let v = semver(parsedVersion);
+      v = `${v.major}.${v.minor}.${v.patch}`;
+      test = semver.Range(this.versSupported).test(semver(v));
+      if (typeof test !== 'boolean') {
+        test = undefined;
+      }
+    } finally {
+      // eslint-disable-next-line no-unsafe-finally
+      return test;
+    }
+  }
+
+  determineNetworkType(config) {
+    if (this.isDev) {
+      return "--config=ndm_consumer_local";
+    }
+    if (config.networkType === 'testnet') {
+      config.networkType = "ropsten";
+    }
+    return "--config=" + config.networkType;
+  }
+
+  determineRpcOptions(config) {
+    let cmd = [];
+    cmd.push("--Network.DiscoveryPort=" + config.port);
+    cmd.push("--JsonRpc.Port=" + config.rpcPort);
+    cmd.push("--JsonRpc.Host=" + config.rpcHost);
+    // Doesn't seem to support changing CORS
+    // if (config.rpcCorsDomain) {
+    //   if (config.rpcCorsDomain === '*') {
+    //     console.warn('==================================');
+    //     console.warn(__('rpcCorsDomain set to "all"'));
+    //     console.warn(__('make sure you know what you are doing'));
+    //     console.warn('==================================');
+    //   }
+    //   cmd.push("--jsonrpc-cors=" + (config.rpcCorsDomain === '*' ? 'all' : config.rpcCorsDomain));
+    // } else {
+    //   console.warn('==================================');
+    //   console.warn(__('warning: cors is not set'));
+    //   console.warn('==================================');
+    // }
+    return cmd;
+  }
+
+  determineWsOptions(config) {
+    let cmd = [];
+    if (config.wsRPC) {
+      cmd.push("--Init.WebSocketsEnabled=true");
+    }
+    return cmd;
+  }
+
+  mainCommand(address, done) {
+    let self = this;
+    let config = this.config;
+    let rpc_api = this.config.rpcApi;
+    let args = [];
+    async.waterfall([
+      function commonOptions(callback) {
+        let cmd = self.commonOptions();
+        args = args.concat(cmd);
+        callback();
+      },
+      function rpcOptions(callback) {
+        let cmd = self.determineRpcOptions(self.config);
+        args = args.concat(cmd);
+        callback();
+      },
+      function wsOptions(callback) {
+        let cmd = self.determineWsOptions(self.config);
+        args = args.concat(cmd);
+        callback();
+      },
+      function dontGetPeers(callback) {
+        if (config.nodiscover) {
+          args.push("--Init.DiscoveryEnabled=false");
+          return callback();
+        }
+        callback();
+      },
+      function vmDebug(callback) {
+        if (config.vmdebug) {
+          args.push("----Init.StoreTraces=true");
+          return callback();
+        }
+        callback();
+      },
+      function maxPeers(callback) {
+        args.push("--Network.ActivePeersMaxCount=" + config.maxpeers);
+        callback();
+      },
+      function bootnodes(callback) {
+        if (config.bootnodes && config.bootnodes !== "") {
+          args.push("--Discovery.Bootnodes=" + config.bootnodes);
+          return callback();
+        }
+        callback();
+      },
+      function rpcApi(callback) {
+        args.push('--JsonRpc.EnabledModules=' + rpc_api.join(','));
+        callback();
+      },
+      function customOptions(callback) {
+        if (config.customOptions) {
+          if (Array.isArray(config.customOptions)) {
+            config.customOptions = config.customOptions.join(' ');
+          }
+          args.push(config.customOptions);
+          return callback();
+        }
+        callback();
+      }
+    ], function (err) {
+      if (err) {
+        throw new Error(err.message);
+      }
+      return done(self.bin, args);
+    });
+  }
+}
+
+module.exports = NethermindClient;

--- a/packages/plugins/nethermind/tsconfig.json
+++ b/packages/plugins/nethermind/tsconfig.json
@@ -1,0 +1,23 @@
+{
+  "compilerOptions": {
+    "composite": true,
+    "declarationDir": "./dist",
+    "rootDir": "./src",
+    "tsBuildInfoFile": "./node_modules/.cache/tsc/tsconfig.embark-nethermind.tsbuildinfo"
+  },
+  "extends": "../../../tsconfig.base.json",
+  "include": [
+    "src/**/*"
+  ],
+  "references": [
+    {
+      "path": "../../core/core"
+    },
+    {
+      "path": "../../core/i18n"
+    },
+    {
+      "path": "../../core/utils"
+    }
+  ]
+}

--- a/packages/plugins/whisper-geth/src/blockchain.js
+++ b/packages/plugins/whisper-geth/src/blockchain.js
@@ -33,7 +33,7 @@ class Blockchain {
     this.config = {
       silent: this.userConfig.silent,
       client: this.userConfig.client,
-      ethereumClientBin: this.userConfig.ethereumClientBin || this.userConfig.client,
+      ethereumClientBin: this.userConfig.ethereumClientBin,
       networkType: this.userConfig.networkType || clientClass.DEFAULTS.NETWORK_TYPE,
       networkId: this.userConfig.networkId || clientClass.DEFAULTS.NETWORK_ID,
       genesisBlock: this.userConfig.genesisBlock || false,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -86,6 +86,9 @@
       "path": "packages/plugins/mocha-tests"
     },
     {
+      "path": "packages/plugins/nethermind"
+    },
+    {
       "path": "packages/plugins/parity"
     },
     {


### PR DESCRIPTION
Add Nethermind client plugin to enable using Nethermind instead of Geth.

Works completely with dev mode. Did quick tests for testnet and mainnet just to see if it starts, but didn't wait until full sync.

Works in standalone and in-process.

There is still some stuff that can be improved on it, but it can be done during the later refactor of blockchain plugins.
To create this plugin, I copied the Parity one and saw that a lot of stuff is either useless or not done correctly (same applies for Geth).

I had to fix some modules like deployer and the plugin class, because Nethermind has some small issues, but it shouldn't regress any other plugin.