### PR TITLE
fix(@embark/ens): fix Infura connection and testnet use of ENS

### DIFF
--- a/dapps/tests/app/test/token_spec.js
+++ b/dapps/tests/app/test/token_spec.js
@@ -8,6 +8,12 @@ const Test = require('Embark/contracts/Test');
 const SomeContract = require('Embark/contracts/SomeContract');
 
 config({
+  namesystem: {
+    enabled: true,
+    register: {
+      rootDomain: "embark.eth"
+    }
+  },
   contracts: {
     deploy: {
       ZAMyLib: {},

--- a/packages/embarkjs/ens/src/ENSFunctions.js
+++ b/packages/embarkjs/ens/src/ENSFunctions.js
@@ -1,4 +1,3 @@
-/* global require */
 const namehash = require('eth-ens-namehash');
 
 // Price of ENS registration contract functions

--- a/packages/stack/embarkjs/src/index.js
+++ b/packages/stack/embarkjs/src/index.js
@@ -117,13 +117,18 @@ class EmbarkJS {
     let code = "";
     if (stackName === 'storage') {
       code = `EmbarkJS.${moduleName}.setProviders(${JSON.stringify(config)});`;
-    } else if (stackName === 'blockchain') {
+    } else if (stackName === 'blockchain' || stackName === 'names') {
       const endpoint = await this.events.request2("proxy:endpoint:get");
       const dappConnectionConfig = {
         dappConnection: [endpoint]
       };
-      code = `EmbarkJS.${moduleName}.setProvider('${pluginName}', ${config});
+      if (stackName === 'blockchain') {
+        code = `EmbarkJS.${moduleName}.setProvider('${pluginName}', ${config});
               EmbarkJS.Blockchain.connect(${JSON.stringify(dappConnectionConfig)}, (err) => {if (err) { console.error(err); } });`;
+      } else {
+        code = `EmbarkJS.${moduleName}.setProvider('${pluginName}', ${JSON.stringify(Object.assign(config, dappConnectionConfig))});`;
+      }
+
     } else {
       code = `EmbarkJS.${moduleName}.setProvider('${pluginName}', ${JSON.stringify(config)});`;
     }


### PR DESCRIPTION
### Infura problem
Fixes the use of Infura to connect to the ENS contracts. When
connecting directly to Infura, it would throw with `rejected due to
project ID settings`, because it doesn't accept the VM as the domain
Instead, when passing from the proxy, it works. So I changed the
default when no dappConnection to ['$EMBARK']. I also added a
message when the error happens to help users fix it themselves

### Testnet problem
When in the testnet, we don,t register because we already have the
addresses, which is fine, but we also didn't populate the ensConfig
object which contains the important information about the addresses
and ABI.

### Linting
There was a lot of lint problems in a couple of files so I cleaned
that up