### PR TITLE
build(deps): replace ethereumjs-wallet@0.6.3 with @embarklabs/ethereumjs-wallet@0.6.4

### DIFF
--- a/packages/core/utils/package.json
+++ b/packages/core/utils/package.json
@@ -47,6 +47,7 @@
   },
   "dependencies": {
     "@babel/runtime-corejs3": "7.7.4",
+    "@embarklabs/ethereumjs-wallet": "0.6.4",
     "@types/follow-redirects": "1.5.0",
     "@types/fs-extra": "7.0.0",
     "@types/node": "12.7.8",
@@ -57,7 +58,6 @@
     "core-js": "3.4.3",
     "embark-i18n": "^5.0.0",
     "embark-logger": "^5.0.0",
-    "ethereumjs-wallet": "0.6.3",
     "find-up": "2.1.0",
     "follow-redirects": "1.8.0",
     "fs-extra": "8.1.0",

--- a/packages/core/utils/src/accountParser.js
+++ b/packages/core/utils/src/accountParser.js
@@ -1,7 +1,7 @@
 import { __ } from 'embark-i18n';
 const bip39 = require("bip39");
-const hdkey = require('ethereumjs-wallet/hdkey');
-const ethereumjsWallet = require('ethereumjs-wallet');
+const hdkey = require('@embarklabs/ethereumjs-wallet/hdkey');
+const ethereumjsWallet = require('@embarklabs/ethereumjs-wallet');
 const fs = require('fs');
 import {getHexBalanceFromString, toChecksumAddress} from './web3Utils';
 const {utils} = require('web3');

--- a/packages/embark/package.json
+++ b/packages/embark/package.json
@@ -86,7 +86,6 @@
     "embark-reset": "^5.0.0",
     "embark-utils": "^5.0.0",
     "eth-ens-namehash": "2.0.8",
-    "ethereumjs-wallet": "0.6.3",
     "find-up": "2.1.0",
     "flatted": "0.2.3",
     "fs-extra": "8.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1952,6 +1952,20 @@
   resolved "https://registry.yarnpkg.com/@csstools/normalize.css/-/normalize.css-9.0.1.tgz#c27b391d8457d1e893f1eddeaf5e5412d12ffbb5"
   integrity sha512-6It2EVfGskxZCQhuykrfnALg7oVeiI6KclWSmGDqB0AiInVrTGB9Jp9i4/Ad21u9Jde/voVQz6eFX/eSg/UsPA==
 
+"@embarklabs/ethereumjs-wallet@0.6.4":
+  version "0.6.4"
+  resolved "https://registry.yarnpkg.com/@embarklabs/ethereumjs-wallet/-/ethereumjs-wallet-0.6.4.tgz#d2f121ec70a5bf995138219c524526c1bbca7e85"
+  integrity sha512-opx5prqlQUoWwP/SsJn2R8opq2j4WnBNmiJBiJ54U7s2eiplVtKc3pJ/De/X5Bb6dpJlYjuHpWgVljfgutYU7A==
+  dependencies:
+    "@web3-js/scrypt-shim" "^0.1.0"
+    aes-js "^3.1.1"
+    bs58check "^2.1.2"
+    ethereumjs-util "^6.0.0"
+    hdkey "^1.1.1"
+    randombytes "^2.0.6"
+    utf8 "^3.0.0"
+    uuid "^3.3.2"
+
 "@emotion/cache@^10.0.15":
   version "10.0.15"
   resolved "https://registry.yarnpkg.com/@emotion/cache/-/cache-10.0.15.tgz#b81767b48015aae2689c60373992145c67b8de02"
@@ -9372,21 +9386,6 @@ ethereumjs-vm@4.1.1:
     safe-buffer "^5.1.1"
     util.promisify "^1.0.0"
 
-ethereumjs-wallet@0.6.3:
-  version "0.6.3"
-  resolved "https://registry.yarnpkg.com/ethereumjs-wallet/-/ethereumjs-wallet-0.6.3.tgz#b0eae6f327637c2aeb9ccb9047b982ac542e6ab1"
-  integrity sha512-qiXPiZOsStem+Dj/CQHbn5qex+FVkuPmGH7SvSnA9F3tdRDt8dLMyvIj3+U05QzVZNPYh4HXEdnzoYI4dZkr9w==
-  dependencies:
-    aes-js "^3.1.1"
-    bs58check "^2.1.2"
-    ethereumjs-util "^6.0.0"
-    hdkey "^1.1.0"
-    randombytes "^2.0.6"
-    safe-buffer "^5.1.2"
-    scrypt.js "^0.3.0"
-    utf8 "^3.0.0"
-    uuid "^3.3.2"
-
 ethers@4.0.0-beta.3:
   version "4.0.0-beta.3"
   resolved "https://registry.yarnpkg.com/ethers/-/ethers-4.0.0-beta.3.tgz#15bef14e57e94ecbeb7f9b39dd0a4bd435bc9066"
@@ -10949,7 +10948,7 @@ hastscript@^5.0.0:
     property-information "^5.0.1"
     space-separated-tokens "^1.0.0"
 
-hdkey@^1.1.0:
+hdkey@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/hdkey/-/hdkey-1.1.1.tgz#c2b3bfd5883ff9529b72f2f08b28be0972a9f64a"
   integrity sha512-DvHZ5OuavsfWs5yfVJZestsnc3wzPvLWNk6c2nRUfo6X+OtxypGt20vDDf7Ba+MJzjL3KS1og2nw2eBbLCOUTA==
@@ -14590,7 +14589,7 @@ nan@2.13.2:
   resolved "https://registry.yarnpkg.com/nan/-/nan-2.13.2.tgz#f51dc7ae66ba7d5d55e1e6d4d8092e802c9aefe7"
   integrity sha512-TghvYc72wlMGMVMluVo9WRJc0mB8KxxF/gZ4YYFy7V2ZQX9l7rgbPg7vjS9mt6U5HXODVFVI2bOduCzwOMv/lw==
 
-nan@^2.0.8, nan@^2.12.1, nan@^2.13.2, nan@^2.14.0, nan@^2.2.1:
+nan@^2.12.1, nan@^2.13.2, nan@^2.14.0, nan@^2.2.1:
   version "2.14.0"
   resolved "https://registry.yarnpkg.com/nan/-/nan-2.14.0.tgz#7818f722027b2459a86f0295d434d1fc2336c52c"
   integrity sha512-INOFj37C7k3AfaNTtX8RhsTw7qRy7eLET14cROi9+5HAVbbHuIWUHEauBv5qT4Av2tWasiTY1Jw6puUNqRJXQg==
@@ -18793,29 +18792,6 @@ scrypt-js@2.0.4:
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/scrypt-js/-/scrypt-js-2.0.4.tgz#32f8c5149f0797672e551c07e230f834b6af5f16"
   integrity sha512-4KsaGcPnuhtCZQCxFxN3GVYIhKFPTdLd8PLC552XwbMndtD0cjRFAhDuuydXQ0h08ZfPgzqe6EKHozpuH74iDw==
-
-scrypt.js@^0.3.0:
-  version "0.3.0"
-  resolved "https://registry.yarnpkg.com/scrypt.js/-/scrypt.js-0.3.0.tgz#6c62d61728ad533c8c376a2e5e3e86d41a95c4c0"
-  integrity sha512-42LTc1nyFsyv/o0gcHtDztrn+aqpkaCNt5Qh7ATBZfhEZU7IC/0oT/qbBH+uRNoAPvs2fwiOId68FDEoSRA8/A==
-  dependencies:
-    scryptsy "^1.2.1"
-  optionalDependencies:
-    scrypt "^6.0.2"
-
-scrypt@^6.0.2:
-  version "6.0.3"
-  resolved "https://registry.yarnpkg.com/scrypt/-/scrypt-6.0.3.tgz#04e014a5682b53fa50c2d5cce167d719c06d870d"
-  integrity sha1-BOAUpWgrU/pQwtXM4WfXGcBthw0=
-  dependencies:
-    nan "^2.0.8"
-
-scryptsy@^1.2.1:
-  version "1.2.1"
-  resolved "https://registry.yarnpkg.com/scryptsy/-/scryptsy-1.2.1.tgz#a3225fa4b2524f802700761e2855bdf3b2d92163"
-  integrity sha1-oyJfpLJST4AnAHYeKFW987LZIWM=
-  dependencies:
-    pbkdf2 "^3.0.3"
 
 scryptsy@^2.1.0:
   version "2.1.0"


### PR DESCRIPTION
See: https://github.com/embark-framework/ethereumjs-wallet/releases/tag/v0.6.4
See also: https://www.npmjs.com/package/@embarklabs/ethereumjs-wallet?activeTab=versions

The primary difference is that `ethereumjs-wallet@0.6.3` is depdendent on a version of `scrypt.js` that has the [older `scrypt`][old-scrypt] package as an optional depdendency; whereas `@embarklabs/ethereumjs-wallet` depends on [`@web3-js/scrypt-shim`][web3-scrypt] (authored by @michaelsbradleyjr), which checks for the availability of [Node's built-in scrypt KDF][builtin-kdf] (Node.js `>= 10.5.0`) and uses that, or else falls back to a pure JS implementation provided by the `scryptsy` package.

[old-scrypt]: https://github.com/barrysteyn/node-scrypt
[web3-scrypt]: https://github.com/web3-js/scrypt-shim
[builtin-kdf]: https://nodejs.org/docs/latest-v10.x/api/crypto.html#crypto_crypto_scrypt_password_salt_keylen_options_callback