### PR TITLE
fix(@embark/embarkjs): support not needing embarkjs plugins defined

### DIFF
--- a/packages/embarkjs/embarkjs/src/lib/blockchain.js
+++ b/packages/embarkjs/embarkjs/src/lib/blockchain.js
@@ -78,6 +78,10 @@ Blockchain.setProvider = function(providerName, options) {
   let provider = this.Providers[providerName];
 
   if (!provider) {
+    if (providerName === 'web3') {
+      console.log("the embarkjs-web3 package might be missing from your project dependencies");
+    }
+
     throw new Error([
       'Unknown blockchain provider. Make sure to register it first using',
       'EmbarkJS.Blockchain.registerProvider(providerName, providerObject)'

--- a/packages/embarkjs/embarkjs/src/lib/messages.js
+++ b/packages/embarkjs/embarkjs/src/lib/messages.js
@@ -10,7 +10,10 @@ Messages.setProvider = function (providerName, options) {
   let provider = this.Providers[providerName];
 
   if (!provider) {
-    throw new Error('Unknown messages provider');
+    if (providerName === 'whisper') {
+      console.log("the embarkjs-whisper package might be missing from your project dependencies");
+    }
+    throw new Error('Unknown messages provider: ' + providerName);
   }
 
   this.currentProviderName = providerName;

--- a/packages/embarkjs/embarkjs/src/lib/names.js
+++ b/packages/embarkjs/embarkjs/src/lib/names.js
@@ -11,7 +11,10 @@ Names.setProvider = function(providerName, options) {
   let provider = this.Providers[providerName];
 
   if (!provider) {
-    throw new Error('Unknown name system provider');
+    if (providerName === 'ens') {
+      console.log("the embarkjs-ens package might be missing from your project dependencies");
+    }
+    throw new Error('Unknown name system provider: ' + providerName);
   }
 
   this.currentProviderName = providerName;

--- a/packages/embarkjs/embarkjs/src/lib/storage.js
+++ b/packages/embarkjs/embarkjs/src/lib/storage.js
@@ -56,7 +56,13 @@ Storage.setProvider = function (providerName, options) {
   let provider = this.Providers[providerName];
 
   if (!provider) {
-    throw new Error('Unknown storage provider');
+    if (providerName === 'ipfs') {
+      console.log("the embarkjs-ipfs package might be missing from your project dependencies");
+    }
+    if (providerName === 'swarm') {
+      console.log("the embarkjs-swarm package might be missing from your project dependencies");
+    }
+    throw new Error('Unknown storage provider: ' + providerName);
   }
 
   this.currentProviderName = providerName;

--- a/packages/stack/embarkjs/src/embarkjs-artifact.js.ejs
+++ b/packages/stack/embarkjs/src/embarkjs-artifact.js.ejs
@@ -1,23 +1,35 @@
 import EmbarkJS from 'embarkjs';
 
 <% for (let pluginName in (plugins['messages'] || [])) { %>
+try {
 const __embark<%- pluginName %> = require('<%- plugins['messages'][pluginName] %>');
 EmbarkJS.Messages.registerProvider('<%- pluginName %>', __embark<%- pluginName %>.default || __embark<%- pluginName %>);
+} catch (e) {
+}
 <% } %>
 
 <% for (let pluginName in (plugins['storage'] || [])) { %>
+try {
 const __embark<%- pluginName %> = require('<%- plugins['storage'][pluginName] %>');
 EmbarkJS.Storage.registerProvider('<%- pluginName %>', __embark<%- pluginName %>.default || __embark<%- pluginName %>);
+} catch (e) {
+}
 <% } %>
 
 <% for (let pluginName in (plugins['blockchain'] || [])) { %>
+try {
 const __embark<%- pluginName %> = require('<%- plugins['blockchain'][pluginName] %>');
 EmbarkJS.Blockchain.registerProvider('<%- pluginName %>', __embark<%- pluginName %>.default || __embark<%- pluginName %>);
+} catch (e) {
+}
 <% } %>
 
 <% for (let pluginName in (plugins['names'] || [])) { %>
+try {
 const __embark<%- pluginName %> = require('<%- plugins['names'][pluginName] %>');
 EmbarkJS.Names.registerProvider('<%- pluginName %>', __embark<%- pluginName %>.default || __embark<%- pluginName %>);
+} catch (e) {
+}
 <% } %>
 
 <% if (plugins['messages'] && Object.values(plugins['messages']).length > 0) { %>


### PR DESCRIPTION
The goal of this pr is to:
* support not specifying an embarkjs plugin if it's not being used
* warn users when attempting to do use a plugin and it's missing